### PR TITLE
Fixing bad references of site preferences and param map

### DIFF
--- a/cartridges/int_adyen/cartridge/scripts/checkNotificationAuth.ds
+++ b/cartridges/int_adyen/cartridge/scripts/checkNotificationAuth.ds
@@ -15,8 +15,8 @@ function execute( args : PipelineDictionary ) : Number
 }
 
 function check (request) {
-	var baUser : String = Site.getCurrent().getCustomPreferenceValue("Adyen_notification_user");
-	var baPassword : String = Site.getCurrent().getCustomPreferenceValue("Adyen_notification_password");
+	var baUser : String = Site.getCurrent().getCustomPreferenceValue("adyen_notification_user");
+	var baPassword : String = Site.getCurrent().getCustomPreferenceValue("adyen_notification_password");
 	var baHeader : String = request.httpHeaders["authorization"];
 	if(empty(baUser) || empty(baPassword) || empty(baHeader)){
 		return false;

--- a/cartridges/int_adyen_controllers/cartridge/controllers/Adyen.js
+++ b/cartridges/int_adyen_controllers/cartridge/controllers/Adyen.js
@@ -114,7 +114,7 @@ function showConfirmation() {
 	
 	if (order.status != dw.order.Order.ORDER_STATUS_CREATED) {
 		// If the same order is tried to be cancelled more than one time, show Error page to user
-		if (CurrentHttpParameterMap.authResult.value == 'CANCELLED') {
+		if (request.httpParameterMap.authResult.value == 'CANCELLED') {
 			app.getController('Error').Start();
 		} else {
 			// TODO: check is there should be errro value { PlaceOrderError: pdict.PlaceOrderError }


### PR DESCRIPTION
Fixing bad references of two things:
1. CurrentHttpParameterMap should be request.httpParametermap
2. Updating the site preference ids to match the corrent ones as coming up in the metadata xml file.