### PR TITLE
currencyCode toString

### DIFF
--- a/cartridges/int_adyen_overlay/cartridge/scripts/util/AdyenHelper.ds
+++ b/cartridges/int_adyen_overlay/cartridge/scripts/util/AdyenHelper.ds
@@ -460,7 +460,7 @@ var __AdyenHelper : Object = {
 
 	getCurrencyValueForApi : function ( amount ) : String {
 		var currencyCode = dwutil.Currency.getCurrency(amount.currencyCode);
-		var digitsNumber = __AdyenHelper.getFractionDigits(currencyCode);
+		var digitsNumber = __AdyenHelper.getFractionDigits(currencyCode.toString());
         return Math.round(amount.multiply(Math.pow(10, digitsNumber)).value);
 	},
 


### PR DESCRIPTION
getFractionDigits() expects a string as input, otherwise it will always return 2 by default. 
