### PR TITLE
Removes only successful custom objects

### DIFF
--- a/cartridges/int_adyen_overlay/cartridge/scripts/deleteCustomObjects.ds
+++ b/cartridges/int_adyen_overlay/cartridge/scripts/deleteCustomObjects.ds
@@ -19,19 +19,24 @@ function handle( orderID : String ) : Object {
 	}
 	while (searchQuery.hasNext()) {
 		var co : CustomObject = searchQuery.next();
-		dw.system.Logger.getLogger("Adyen", "adyen").info("Remove CO object with merchantReference {0} and pspReferenceNumber  {1}", co.custom.merchantReference, co.custom.pspReference);
-		try {
-			CustomObjectMgr.remove(co);
-		} catch (e) {
-			var ex = e;
-			dw.system.Logger.getLogger("Adyen", "adyen").error("Error occured during delete CO, ID: {0}, erorr message {1}", co.custom.orderId, e.message);
-		}
+		remove(co);
 	}
 	searchQuery.close();
    return PIPELET_NEXT;
 }
 
+function remove ( co ) {
+	dw.system.Logger.getLogger("Adyen", "adyen").info("Remove CO object with merchantReference {0} and pspReferenceNumber  {1}", co.custom.merchantReference, co.custom.pspReference);
+	try {
+		CustomObjectMgr.remove(co);
+	} catch (e) {
+		var ex = e;
+		dw.system.Logger.getLogger("Adyen", "adyen").error("Error occured during delete CO, ID: {0}, erorr message {1}", co.custom.orderId, e.message);
+	}
+}
+
 module.exports = {
 	'execute': execute,
-	'handle': handle
+	'handle': handle,
+	'remove': remove
 }

--- a/cartridges/int_adyen_overlay/cartridge/scripts/job/notifications.js
+++ b/cartridges/int_adyen_overlay/cartridge/scripts/job/notifications.js
@@ -78,12 +78,11 @@ function clearNotifications(pdict) {
 	var searchQuery = CustomObjectMgr.queryCustomObjects("adyenNotification", "custom.processedStatus = 'SUCCESS'", null);
 	logger.info("Removing Processed Custom Objects start with count {0}", searchQuery.count);
 
-	var customObj, orderID;
+	var customObj;
 	while (searchQuery.hasNext()) {
 		customObj = searchQuery.next();
-		orderID = customObj.custom.orderId.split("-", 1)[0];
 		Transaction.wrap(function () {
-			deleteCustomObjects.handle(orderID);
+			deleteCustomObjects.remove(customObj);
 		});
 		
 	}


### PR DESCRIPTION
This solves removal of unprocessed notifications for split payments. This can be caused when a new notification is received between the start of both processNotifications and clearNotifications job steps.