### PR TITLE
Order.custom.Adyen_value has decimal when set.

### DIFF
--- a/cartridges/int_adyen_overlay/cartridge/scripts/util/AdyenHelper.ds
+++ b/cartridges/int_adyen_overlay/cartridge/scripts/util/AdyenHelper.ds
@@ -664,7 +664,7 @@ var __AdyenHelper: Object = {
         }
 
         if ('AdyenAmount' in result && !empty(result.AdyenAmount)) {
-            order.custom.Adyen_value = result.AdyenAmount;
+            order.custom.Adyen_value = result.AdyenAmount.toFixed(0);
         }
 
         if ('AdyenCardType' in result && !empty(result.AdyenCardType)) {


### PR DESCRIPTION
Added toFixed(0) so order's field value is a whole number when parsed to string.

Looks like you have wrestled with this in the past.
Is confusing in Business Manager and can cause (downstream) notification processing errors because field will get parsed with decimal in it then amount will be wonky.