### PR TITLE
Safari bug cleave.js

### DIFF
--- a/cartridges/int_adyen_SFRA/cartridge/templates/default/checkout/billing/creditCardForm.isml
+++ b/cartridges/int_adyen_SFRA/cartridge/templates/default/checkout/billing/creditCardForm.isml
@@ -2,13 +2,11 @@
 <link rel="stylesheet" type="text/css" href="${pdict.AdyenHelper.getCheckoutCSS()}"/>
 <input type="hidden" id="currentLocale" value="${request.locale}"/>
 <iscontent type="text/html" encoding="off"/>
-<input type="hidden" class="form-control cardNumber" id="cardNumber" ${creditFields.cardNumber.attributes}>
+<input type="text" class="form-control cardNumber" style="display:none" id="cardNumber" ${creditFields.cardNumber.attributes}>
 <input type="hidden" class="form-control saveCardAdyen" id="saveCardAdyen" ${creditFields.saveCardAdyen.attributes}>
 <input type="hidden" class="form-control" id="cardType" ${creditFields.cardType.attributes}>
-
 <input type="hidden" class="form-control selectedCardID" value="" id="selectedCardID"
        ${creditFields.selectedCardID.attributes}>
-
 <input type="hidden" class="form-control adyenEncryptedCardNumber" id="adyenEncryptedCardNumber"
        ${creditFields.adyenEncryptedCardNumber.attributes}>
 <input type="hidden" class="form-control adyenEncryptedExpiryMonth" id="adyenEncryptedExpiryMonth"


### PR DESCRIPTION
Cleave.js requires input type="text" and will give an error on Safari when input type="hidden".