### PR TITLE
PW-1807 - Use the checkout URL for payment methods logos

### DIFF
--- a/cartridges/int_adyen_SFRA/cartridge/controllers/Adyen.js
+++ b/cartridges/int_adyen_SFRA/cartridge/controllers/Adyen.js
@@ -343,7 +343,7 @@ server.get('GetPaymentMethods', server.middleware.https, function (req, res, nex
         paymentMethods = [];
     }
 
-    var adyenURL = AdyenHelper.getAdyenUrl() + "hpp/img/pm/";
+    var adyenURL = AdyenHelper.getLoadingContext() + "images/logos/medium/";
 
     res.json({
         AdyenPaymentMethods: paymentMethods,

--- a/cartridges/int_adyen_overlay/cartridge/static/default/css/adyenCSS.css
+++ b/cartridges/int_adyen_overlay/cartridge/static/default/css/adyenCSS.css
@@ -49,6 +49,11 @@
 
 #type {
 	list-style-type: none;
+	line-height: 50px;
+}
+
+#type .form-row {
+	margin: .5rem 0 .5rem;
 }
 
 #ssnValue {

--- a/cartridges/int_adyen_overlay/cartridge/templates/default/hpp.isml
+++ b/cartridges/int_adyen_overlay/cartridge/templates/default/hpp.isml
@@ -17,7 +17,7 @@
         <isloop items="${methods}" var="method" status="loopstate">
             <li class="form-row row-${method.type}" id="li_${method.type}">
                 <input type="radio" class="input-radio" name="brandCode" value="${method.type}" id="${method.type}"/>
-                <img class="logo" src="${AdyenHelper.getAdyenUrl()}/hpp/img/pm/${method.type}.png" alt=""/>
+                <img class="logo" src="${AdyenHelper.getLoadingContext()}images/logos/medium/${method.type}.png" alt=""/>
                 <label class="payment_method_label" for="${method.type}">${method.name}</label>
                 <isscript>
                     var methodDetails = JSON.stringify(method);


### PR DESCRIPTION
The plugin now uses the payment methods logos from the Checkout Components, which look nicer :)