### PR TITLE
PW-1551 Only disable ONECLICK contract

### DIFF
--- a/cartridges/int_adyen_overlay/cartridge/scripts/adyenDeleteRecurringPayment.ds
+++ b/cartridges/int_adyen_overlay/cartridge/scripts/adyenDeleteRecurringPayment.ds
@@ -36,6 +36,7 @@ function deleteRecurringPayment(args) {
         requestObject['merchantAccount'] = AdyenHelper.getAdyenMerchantAccount();
         requestObject['shopperReference'] = customerID;
         requestObject['recurringDetailReference'] = recurringDetailReference;
+        requestObject['contract'] = "ONECLICK";
 
         var callResult = null,
             service = AdyenHelper.getService(AdyenHelper.SERVICE.RECURRING_DISABLE);


### PR DESCRIPTION
As shoppers are only allowed to manage their ONECLICK contracts, the disable call should only delete ONECLICK contract when deleting a stored payment method in My Account.