### PR TITLE
Calculate item amount for price adjustment using netPrice

### DIFF
--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/util/LineItemHelper.ds
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/util/LineItemHelper.ds
@@ -61,7 +61,7 @@ var __LineItemHelper  = {
         if (lineItem instanceof dw.order.ProductLineItem || lineItem instanceof dw.order.ShippingLineItem) {
             return AdyenHelper.getCurrencyValueForApi(lineItem.adjustedNetPrice);
         } else if (lineItem instanceof dw.order.PriceAdjustment) {
-            return AdyenHelper.getCurrencyValueForApi(lineItem.basePrice);
+            return AdyenHelper.getCurrencyValueForApi(lineItem.netPrice);
         }
         return null;
 


### PR DESCRIPTION
While working on integration of ZipPay payments via Adyen, I noticed that the redirection to Zip doesn't work if there is a discount line item in our cart (discount coupon applied). After debugging I came to conclusion that the amounts of the line items which are "instanceof dw.order.PriceAdjustment" aren't calculated well. The "amountExcludingTax" was actually the full amount, because it was retrieved from the basePrice. After using netPrice for the "amountExcludingTax", the calculations are fine.

Note: the prices on the market are inclusive of taxes (GST Inclusive).