### PR TITLE
remove export from update payment information

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/checkout/__tests__/billing.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/checkout/__tests__/billing.test.js
@@ -1,4 +1,4 @@
-import { updatePaymentInformation } from "../billing";
+import { methods } from "../billing";
 describe("Billing", () => {
   it("should append html to payment details", () => {
     document.body.innerHTML = `
@@ -26,7 +26,7 @@ describe("Billing", () => {
         },
       },
     };
-    updatePaymentInformation(order);
+    methods.updatePaymentInformation(order);
     expect(document.querySelector(".payment-details")).toMatchSnapshot();
   });
 });

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/checkout/billing.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/checkout/billing.js
@@ -31,7 +31,7 @@ function appendPaymentMethod({ selectedAdyenPM }) {
  * Updates the payment information in checkout, based on the supplied order model
  * @param {Object} order - checkout model to use as basis of new truth
  */
-export function updatePaymentInformation(order) {
+function updatePaymentInformation(order) {
   if (order.billing.payment.selectedPaymentInstruments?.length) {
     const selectedPaymentInstrument =
       order.billing.payment.selectedPaymentInstruments[0];


### PR DESCRIPTION
Salesforce imports everything from `billing.js` and if it is a function, it is executed ¯\_(ツ)_/¯
Export was removed, so the function is not called.