### PR TITLE
Fix SFRA Adyen controller issue when POS disabled

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/getPaymentMethods.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/getPaymentMethods.js
@@ -48,7 +48,7 @@ function getPMs(req, res, next) {
     return next();
   }
 
-  let connectedTerminals = {};
+  let connectedTerminals = '{}';
   if (PaymentMgr.getPaymentMethod(constants.METHOD_ADYEN_POS).isActive()) {
     connectedTerminals = adyenTerminalApi.getTerminals().response;
   }


### PR DESCRIPTION
When Adyen_POS is disabled, the initialized value of {} throws an error in JSON.parse.

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
