### PR TITLE
fix: wrap order cancellation in transaction

### DIFF
--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/handleCustomObject.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/handleCustomObject.js
@@ -173,7 +173,9 @@ function handle(customObj) {
         if (customObj.custom.success === 'true') {
           order.setPaymentStatus(Order.PAYMENT_STATUS_NOTPAID);
           order.setExportStatus(Order.EXPORT_STATUS_NOTEXPORTED);
-          OrderMgr.cancelOrder(order);
+          Transaction.wrap(() => {
+            OrderMgr.cancelOrder(order);
+          });
         }
         Logger.getLogger('Adyen', 'adyen').info(
           'Capture Failed for order {0}',
@@ -221,7 +223,9 @@ function handle(customObj) {
           order.setPaymentStatus(Order.PAYMENT_STATUS_PAID);
           order.setExportStatus(Order.EXPORT_STATUS_READY);
           order.setConfirmationStatus(Order.CONFIRMATION_STATUS_CONFIRMED);
-          OrderMgr.undoCancelOrder(order);
+          Transaction.wrap(() => {
+            OrderMgr.undoCancelOrder(order);
+          });
           Logger.getLogger('Adyen', 'adyen').info(
             'Undo failed capture, Order {0} updated to status PAID.',
             order.orderNo,


### PR DESCRIPTION
## Summary
- On our store (lesgeorgettes.com) we have some issue while getting the event CAPTURE_FAILED. The order is not cancel.
- We need to wrap the order cancellation (undo cancellation too) to a transaction.

### Tested scenarios without this fix
- Create an order
- Simulate CAPTURE_FAILED event
- Check on BM, you should see the order is not cancel

### Tested scenarios **with** this fix
- Create an order
- Simulate CAPTURE_FAILED event
- Check on BM, you should see the order is cancel
