### PR TITLE
POS Terminal Empty Check

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/getPaymentMethod/payment.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/getPaymentMethod/payment.js
@@ -28,7 +28,7 @@ function handlePaymentMethod({ req, res, next }) {
     AdyenPaymentMethods: response,
     ImagePath: adyenURL,
     AdyenDescriptions: paymentMethodDescriptions,
-    AdyenConnectedTerminals: JSON.stringify(connectedTerminals) == "{}" ? '' : JSON.parse(connectedTerminals)
+    AdyenConnectedTerminals: JSON.stringify(connectedTerminals) === "{}" ? '' : JSON.parse(connectedTerminals)
   };
 
   if (AdyenHelper.getCreditCardInstallments()) {

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/getPaymentMethod/payment.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/getPaymentMethod/payment.js
@@ -28,7 +28,7 @@ function handlePaymentMethod({ req, res, next }) {
     AdyenPaymentMethods: response,
     ImagePath: adyenURL,
     AdyenDescriptions: paymentMethodDescriptions,
-    AdyenConnectedTerminals: JSON.parse(connectedTerminals),
+    AdyenConnectedTerminals: JSON.stringify(connectedTerminals) == "{}" ? '' : JSON.parse(connectedTerminals)
   };
 
   if (AdyenHelper.getCreditCardInstallments()) {


### PR DESCRIPTION
Added empty JSON check for the POS terminal variable. It was causing the page to break.

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
