### PR TITLE
PW-3278 temporary fix for giropay

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyenCheckout.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyenCheckout.js
@@ -376,6 +376,10 @@ function renderPaymentMethod(
     displaySelectedMethod(event.target.value);
   };
 
+  if (paymentMethodID === 'giropay') {
+    container.innerHTML = '';
+  }
+
   if (componentsObj[paymentMethodID] && !container.childNodes[0]) {
     componentsObj[paymentMethodID].isValid = true;
   }

--- a/src/cartridges/int_adyen_controllers/cartridge/js/pages/checkout/adyen-checkout.js
+++ b/src/cartridges/int_adyen_controllers/cartridge/js/pages/checkout/adyen-checkout.js
@@ -515,6 +515,10 @@ function renderPaymentMethod(paymentMethod, storedPaymentMethodBool, path) {
     displaySelectedMethod(event.target.value);
   };
 
+  if (paymentMethodID === 'giropay') {
+    container.innerHTML = '';
+  }
+
   if (componentsObj[paymentMethodID] && !container.childNodes[0]) {
     componentsObj[paymentMethodID].isValid = true;
   }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
there's a bug in giropay from Checkout, it doesn't have the property "showPayButton", meaning it doesn't pick up the configuration "showPayButton: false" that we have for components.
For that reason, the pay button in giropay is always showing and is silently failing the form validation.
This is a temporary fix to hide the pay button and to pass the validation. Once Checkout fixes this bug in a new release, we will be getting rid of this temporary fix.
