### PR TITLE
PW-3540

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyenCheckout.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyenCheckout.js
@@ -461,9 +461,11 @@ $('button[value="submit-payment"]').on('click', function () {
     return true;
   }
 
-  assignPaymentMethodValue();
-  validateComponents();
-  return showValidation();
+  if (document.querySelector('#selectedPaymentOption').value === 'AdyenComponent') {
+    assignPaymentMethodValue();
+    validateComponents();
+    return showValidation();
+  }
 });
 
 function assignPaymentMethodValue() {

--- a/src/cartridges/int_adyen_controllers/cartridge/js/pages/checkout/adyen-checkout.js
+++ b/src/cartridges/int_adyen_controllers/cartridge/js/pages/checkout/adyen-checkout.js
@@ -18,22 +18,26 @@ function initializeBillingEvents() {
   $('#billing-submit').on('click', function () {
     const isAdyenPOS = document.querySelector('.payment-method-options :checked').value
       === 'AdyenPOS';
+    const isAdyen = document.querySelector('.payment-method-options :checked').value === 'AdyenComponent';
+
     if (isAdyenPOS) {
       document.querySelector(
         '#dwfrm_adyPaydata_terminalId',
       ).value = document.querySelector('#terminalList').value;
       return true;
     }
-    const adyenPaymentMethod = document.querySelector(
-      '#adyenPaymentMethodName',
-    );
-    const paymentMethodLabel = document.querySelector(`#lb_${selectedMethod}`)
-      .innerHTML;
-    adyenPaymentMethod.value = paymentMethodLabel;
+    if (isAdyen) {
+      const adyenPaymentMethod = document.querySelector(
+        '#adyenPaymentMethodName',
+      );
+      const paymentMethodLabel = document.querySelector(`#lb_${selectedMethod}`)
+        .innerHTML;
+      adyenPaymentMethod.value = paymentMethodLabel;
 
-    validateComponents();
+      validateComponents();
 
-    return showValidation();
+      return showValidation();
+    }
   });
 
   if (window.getPaymentMethodsResponse) {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
check if payment processor is "adyenComponent" before validation. Otherwise our cartridge will interfere with other payment processors if the merchant was using multiple ones

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
https://github.com/SalesforceCommerceCloud/link_adyen/issues/48