### PR TITLE
PW-3393 QR Codes

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/__tests__/checkoutConfiguration.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/__tests__/checkoutConfiguration.test.js
@@ -3,6 +3,7 @@ const {
   getPaypalConfig,
   getGooglePayConfig,
   getMbwayConfig,
+  getQRCodeConfig,
 } = require('../checkoutConfiguration');
 const store = require('../../../../../store');
 
@@ -10,6 +11,7 @@ let card;
 let paypal;
 let paywithgoogle;
 let mbway;
+let swish;
 beforeEach(() => {
   window.Configuration = { environment: 'TEST' };
   store.checkoutConfiguration = {};
@@ -17,6 +19,7 @@ beforeEach(() => {
   paypal = getPaypalConfig();
   paywithgoogle = getGooglePayConfig();
   mbway = getMbwayConfig();
+  swish = getQRCodeConfig();
 });
 
 describe('Checkout Configuration', () => {
@@ -90,6 +93,21 @@ describe('Checkout Configuration', () => {
       store.selectedMethod = 'mbway';
       store.componentsObj = { mbway: { stateData: { foo: 'bar' } } };
       mbway.onSubmit({ data: {} });
+      expect(document.getElementById('adyenStateData').value).toBe(
+          JSON.stringify(store.selectedPayment.stateData),
+      );
+    });
+  });
+  describe('QR code (swish)', () => {
+    it('handles onSubmit', () => {
+      document.body.innerHTML = `
+        <div id="lb_swish">swish</div>
+        <div id="adyenPaymentMethodName"></div>
+        <div id="adyenStateData"></div>
+      `;
+      store.selectedMethod = 'swish';
+      store.componentsObj = { swish: { stateData: { foo: 'bar' } } };
+      swish.onSubmit({ data: {} });
       expect(document.getElementById('adyenStateData').value).toBe(
           JSON.stringify(store.selectedPayment.stateData),
       );

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
@@ -28,6 +28,7 @@ function getCardConfig() {
 
 function getPaypalConfig() {
   return {
+    showPayButton: true,
     environment: window.Configuration.environment,
     intent: 'capture',
     onSubmit: (state, component) => {
@@ -39,7 +40,13 @@ function getPaypalConfig() {
       helpers.paymentFromComponent(state.data, component);
     },
     onCancel: (data, component) => {
-      helpers.paymentFromComponent({ cancelTransaction: true }, component);
+      helpers.paymentFromComponent(
+        {
+          cancelTransaction: true,
+          merchantReference: document.querySelector('#merchantReference').value,
+        },
+        component,
+      );
     },
     onError: (error, component) => {
       if (component) {
@@ -59,6 +66,31 @@ function getPaypalConfig() {
         return actions.reject();
       }
       return null;
+    },
+  };
+}
+
+function getQRCodeConfig() {
+  return {
+    showPayButton: true,
+    onSubmit: (state, component) => {
+      $('#dwfrm_billing').trigger('submit');
+      if (store.formErrorsExist) {
+        return;
+      }
+
+      helpers.assignPaymentMethodValue();
+      document.querySelector('#adyenStateData').value = JSON.stringify(
+        store.selectedPayment.stateData,
+      );
+
+      helpers.paymentFromComponent(state.data, component);
+    },
+    onAdditionalDetails: (state /* , component */) => {
+      document.querySelector('#additionalDetailsHidden').value = JSON.stringify(
+        state.data,
+      );
+      document.querySelector('#showConfirmationForm').submit();
     },
   };
 }
@@ -139,6 +171,8 @@ function setCheckoutConfiguration() {
     paywithgoogle: getGooglePayConfig(),
     paypal: getPaypalConfig(),
     mbway: getMbwayConfig(),
+    swish: getQRCodeConfig(),
+    wechatpayQR: getQRCodeConfig(),
     afterpay_default: {
       visibility: {
         personalDetails: 'editable',
@@ -180,4 +214,5 @@ module.exports = {
   getGooglePayConfig,
   setCheckoutConfiguration,
   getMbwayConfig,
+  getQRCodeConfig,
 };

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
@@ -172,6 +172,7 @@ function setCheckoutConfiguration() {
     paypal: getPaypalConfig(),
     mbway: getMbwayConfig(),
     swish: getQRCodeConfig(),
+    bcmc_mobile: getQRCodeConfig(),
     wechatpayQR: getQRCodeConfig(),
     afterpay_default: {
       visibility: {

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/helpers.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/helpers.js
@@ -1,4 +1,5 @@
 const store = require('../../../../store');
+const { qrCodeMethods } = require('./qrCodeMethods');
 
 function assignPaymentMethodValue() {
   const adyenPaymentMethod = document.querySelector('#adyenPaymentMethodName');
@@ -25,8 +26,6 @@ function paymentFromComponent(data, component) {
       }
       if (response.fullResponse?.action) {
         component.handleAction(response.fullResponse.action);
-      } else {
-        document.querySelector('#showConfirmationForm').submit();
       }
     },
   }).fail(() => {});
@@ -52,7 +51,7 @@ function displaySelectedMethod(type) {
   store.selectedMethod = type;
   resetPaymentMethod();
   document.querySelector('button[value="submit-payment"]').disabled =
-    ['paypal', 'paywithgoogle', 'mbway'].indexOf(type) > -1;
+    ['paypal', 'paywithgoogle', 'mbway', ...qrCodeMethods].indexOf(type) > -1;
   document
     .querySelector(`#component_${type}`)
     .setAttribute('style', 'display:block');

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/qrCodeMethods.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/qrCodeMethods.js
@@ -1,0 +1,1 @@
+module.exports.qrCodeMethods = ['swish', 'wechatpayQR'];

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/qrCodeMethods.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/qrCodeMethods.js
@@ -1,1 +1,1 @@
-module.exports.qrCodeMethods = ['swish', 'wechatpayQR'];
+module.exports.qrCodeMethods = ['swish', 'wechatpayQR', 'bcmc_mobile'];

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/__snapshots__/paymentFromComponent.test.js.snap
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/__snapshots__/paymentFromComponent.test.js.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Payment from Component should cancel transaction 1`] = `
+Array [
+  Array [
+    "Checkout-Begin",
+    "stage",
+    "placeOrder",
+  ],
+]
+`;
+
 exports[`Payment from Component should return json response 1`] = `
 Array [
   Array [

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/paymentFromComponent.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/paymentFromComponent.test.js
@@ -8,7 +8,7 @@ beforeEach(() => {
   paymentFromComponent = adyen.paymentFromComponent;
   jest.clearAllMocks();
   req = { form: { data: { paymentMethod: { type: 'mocked_type' } } } };
-  res = { json: jest.fn() };
+  res = { redirect: jest.fn(), json: jest.fn() };
 });
 
 afterEach(() => {
@@ -17,10 +17,15 @@ afterEach(() => {
 
 describe('Payment from Component', () => {
   it('should cancel transaction', () => {
+    const URLUtils = require('dw/web/URLUtils');
+
     req.form.data.cancelTransaction = true;
     req.form.data = JSON.stringify(req.form.data);
-    const expected = paymentFromComponent(req, res, jest.fn());
-    expect(expected).toEqual({});
+    // const expected = paymentFromComponent(req, res, jest.fn());
+    paymentFromComponent(req, res, jest.fn());
+
+    expect(URLUtils.url.mock.calls).toMatchSnapshot();
+    // expect(expected).toEqual({});
   });
   it('should return json response', () => {
     req.form.data = JSON.stringify(req.form.data);

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/paymentFromComponent.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/paymentFromComponent.test.js
@@ -21,11 +21,9 @@ describe('Payment from Component', () => {
 
     req.form.data.cancelTransaction = true;
     req.form.data = JSON.stringify(req.form.data);
-    // const expected = paymentFromComponent(req, res, jest.fn());
     paymentFromComponent(req, res, jest.fn());
 
     expect(URLUtils.url.mock.calls).toMatchSnapshot();
-    // expect(expected).toEqual({});
   });
   it('should return json response', () => {
     req.form.data = JSON.stringify(req.form.data);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Support for QR code payment methods (swish, bcmc mobile, and weChatPayQR), and change of the cancellation flow for the function paymentFromComponent.
Once a QR code is rendered, if a different payment method was chosen then that QR code component is unmounted and a new component is created to replace it.

## Tested scenarios
<!-- Description of tested scenarios -->
- Happy flow
- shopper had QR code rendered then chose a different payment method
- QR code expired after countdown

**Fixed issue**:  <!-- #-prefixed issue number -->
