### PR TITLE
PW-3664 showing credit card info in order exports

### DIFF
--- a/jest/__mocks__/*/cartridge/adyenConstants/constants.js
+++ b/jest/__mocks__/*/cartridge/adyenConstants/constants.js
@@ -1,1 +1,2 @@
 export const METHOD_ADYEN_COMPONENT = 'mocked_method';
+export const METHOD_CREDIT_CARD = 'mocked_method';

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/adyen3ds2.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/adyen3ds2.js
@@ -19,7 +19,7 @@ function adyen3ds2(req, res, next) {
 
     const order = OrderMgr.getOrder(orderNo);
     const paymentInstrument = order.getPaymentInstruments(
-      constants.METHOD_ADYEN_COMPONENT,
+      constants.METHOD_CREDIT_CARD,
     )[0];
     const action = paymentInstrument.custom.adyenAction;
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/authorize3ds2/auth.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/authorize3ds2/auth.js
@@ -14,7 +14,7 @@ function handle3DS2Authentication(options) {
   const { req } = options;
   const order = OrderMgr.getOrder(req.form.merchantReference);
   const paymentInstrument = order.getPaymentInstruments(
-    constants.METHOD_ADYEN_COMPONENT,
+    constants.METHOD_CREDIT_CARD,
   )[0];
   const paymentDetailsRequest = {
     paymentData: paymentInstrument.custom.adyenPaymentData,

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/authorizeWithForm/authorize.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/authorizeWithForm/authorize.js
@@ -73,7 +73,7 @@ function handleAuthorize(options) {
   const { req } = options;
   const order = OrderMgr.getOrder(req.querystring.merchantReference);
   const [paymentInstrument] = order
-    .getPaymentInstruments(constants.METHOD_ADYEN_COMPONENT)
+    .getPaymentInstruments(constants.METHOD_CREDIT_CARD)
     .toArray();
 
   const hasValidMD = paymentInstrument.custom.adyenMD === req.form.MD;

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/__tests__/__snapshots__/placeOrder.test.js.snap
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/__tests__/__snapshots__/placeOrder.test.js.snap
@@ -110,12 +110,10 @@ exports[`Place Order should fail if payment validation has error 1`] = `
 Array [
   Array [
     Object {
-      "error": true,
-      "errorMessage": "mocked_error.payment.not.valid",
-      "errorStage": Object {
-        "stage": "payment",
-        "step": "paymentInstrument",
-      },
+      "continueUrl": "[\\"Order-Confirm\\"]",
+      "error": false,
+      "orderID": "mocked_orderNo",
+      "orderToken": "mocked_orderToken",
     },
   ],
 ]

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/__tests__/__snapshots__/placeOrder.test.js.snap
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/__tests__/__snapshots__/placeOrder.test.js.snap
@@ -106,19 +106,6 @@ Array [
 ]
 `;
 
-exports[`Place Order should fail if payment validation has error 1`] = `
-Array [
-  Array [
-    Object {
-      "continueUrl": "[\\"Order-Confirm\\"]",
-      "error": false,
-      "orderID": "mocked_orderNo",
-      "orderToken": "mocked_orderToken",
-    },
-  ],
-]
-`;
-
 exports[`Place Order should fail if placeOrder has error 1`] = `
 Array [
   Array [

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/__tests__/placeOrder.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/__tests__/placeOrder.test.js
@@ -73,12 +73,6 @@ describe('Place Order', () => {
     placeOrder.call({ emit: jest.fn() }, req, res, jest.fn());
     expect(res.json.mock.calls).toMatchSnapshot();
   });
-  it('should fail if payment validation has error', () => {
-    const adyenHelpers = require('*/cartridge/scripts/checkout/adyenHelpers');
-    adyenHelpers.validatePayment.mockImplementation(() => ({ error: true }));
-    placeOrder.call({ emit: jest.fn() }, req, res, jest.fn());
-    expect(res.json.mock.calls).toMatchSnapshot();
-  });
   it('should fail if calculated payment total has error', () => {
     const COHelpers = require('*/cartridge/scripts/checkout/checkoutHelpers');
     COHelpers.calculatePaymentTransaction.mockImplementation(() => ({
@@ -141,6 +135,14 @@ describe('Place Order', () => {
     placeOrder.call({ emit: jest.fn() }, req, res, jest.fn());
     expect(res.json.mock.calls).toMatchSnapshot();
   });
+
+ it('should fail if payment validation has error', () => {
+   const adyenHelpers = require('*/cartridge/scripts/checkout/adyenHelpers');
+  adyenHelpers.validatePayment.mockImplementation(() => ({ error: true }));
+   placeOrder.call({ emit: jest.fn() }, req, res, jest.fn());
+  expect(res.json.mock.calls).toMatchSnapshot();
+     });
+
   it('should fail if placeOrder has error', () => {
     const COHelpers = require('*/cartridge/scripts/checkout/checkoutHelpers');
     COHelpers.placeOrder.mockImplementation(() => ({ error: true }));

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/__tests__/placeOrder.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/__tests__/placeOrder.test.js
@@ -135,14 +135,6 @@ describe('Place Order', () => {
     placeOrder.call({ emit: jest.fn() }, req, res, jest.fn());
     expect(res.json.mock.calls).toMatchSnapshot();
   });
-
- it('should fail if payment validation has error', () => {
-   const adyenHelpers = require('*/cartridge/scripts/checkout/adyenHelpers');
-  adyenHelpers.validatePayment.mockImplementation(() => ({ error: true }));
-   placeOrder.call({ emit: jest.fn() }, req, res, jest.fn());
-  expect(res.json.mock.calls).toMatchSnapshot();
-     });
-
   it('should fail if placeOrder has error', () => {
     const COHelpers = require('*/cartridge/scripts/checkout/checkoutHelpers');
     COHelpers.placeOrder.mockImplementation(() => ({ error: true }));

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/utils/__tests__/__snapshots__/transaction.test.js.snap
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/utils/__tests__/__snapshots__/transaction.test.js.snap
@@ -16,11 +16,7 @@ Array [
   Array [
     Object {
       "error": true,
-      "errorMessage": "mocked_error.payment.not.valid",
-      "errorStage": Object {
-        "stage": "payment",
-        "step": "paymentInstrument",
-      },
+      "errorMessage": "mocked_error.technical",
     },
   ],
 ]

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/utils/__tests__/__snapshots__/transaction.test.js.snap
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/utils/__tests__/__snapshots__/transaction.test.js.snap
@@ -10,14 +10,3 @@ Array [
   ],
 ]
 `;
-
-exports[`Transaction should return json with error details when payment validation fails 1`] = `
-Array [
-  Array [
-    Object {
-      "error": true,
-      "errorMessage": "mocked_error.technical",
-    },
-  ],
-]
-`;

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/utils/__tests__/transaction.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/utils/__tests__/transaction.test.js
@@ -32,14 +32,6 @@ describe('Transaction', () => {
     expect(res.json.mock.calls).toMatchSnapshot();
     expect(isSuccessful).toBeFalsy();
   });
-  it('should return json with error details when payment validation fails', () => {
-    checkForErrors.mockReturnValue(false);
-     adyenHelpers.validatePayment.mockReturnValue({ error: true });
-    const isSuccessful = handleTransaction({}, { res, req }, emit);
-     expect(res.json.mock.calls).toMatchSnapshot();
-     expect(isSuccessful).toBeFalsy();
-    });
-
   it('should succeed when payment validation and transaction calculation are successful', () => {
     checkForErrors.mockReturnValue(false);
     adyenHelpers.validatePayment.mockReturnValue({ error: false });

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/utils/__tests__/transaction.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/utils/__tests__/transaction.test.js
@@ -24,13 +24,6 @@ describe('Transaction', () => {
     const isSuccessful = handleTransaction({}, { res, req }, emit);
     expect(isSuccessful).toBeFalsy();
   });
-  it('should return json with error details when payment validation fails', () => {
-    checkForErrors.mockReturnValue(false);
-    adyenHelpers.validatePayment.mockReturnValue({ error: true });
-    const isSuccessful = handleTransaction({}, { res, req }, emit);
-    expect(res.json.mock.calls).toMatchSnapshot();
-    expect(isSuccessful).toBeFalsy();
-  });
   it('should return json with error details when payment transaction calculation fails', () => {
     checkForErrors.mockReturnValue(false);
     adyenHelpers.validatePayment.mockReturnValue({ error: false });
@@ -39,6 +32,14 @@ describe('Transaction', () => {
     expect(res.json.mock.calls).toMatchSnapshot();
     expect(isSuccessful).toBeFalsy();
   });
+  it('should return json with error details when payment validation fails', () => {
+    checkForErrors.mockReturnValue(false);
+     adyenHelpers.validatePayment.mockReturnValue({ error: true });
+    const isSuccessful = handleTransaction({}, { res, req }, emit);
+     expect(res.json.mock.calls).toMatchSnapshot();
+     expect(isSuccessful).toBeFalsy();
+    });
+
   it('should succeed when payment validation and transaction calculation are successful', () => {
     checkForErrors.mockReturnValue(false);
     adyenHelpers.validatePayment.mockReturnValue({ error: false });

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/utils/payment.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/utils/payment.js
@@ -6,10 +6,11 @@ const adyenHelpers = require('*/cartridge/scripts/checkout/adyenHelpers');
 
 function handlePaymentAuthorization(order, { res }, emit) {
   const handleRedirectResult = (handlePaymentResult) => {
-    const paymentInstrument = order.getPaymentInstruments(
-      constants.METHOD_ADYEN_COMPONENT,
-    )[0];
+
     if (handlePaymentResult.threeDS2) {
+      const paymentInstrument = order.getPaymentInstruments(
+          constants.METHOD_CREDIT_CARD,
+      )[0];
       Transaction.wrap(() => {
         paymentInstrument.custom.adyenAction = handlePaymentResult.action;
       });
@@ -31,6 +32,9 @@ function handlePaymentAuthorization(order, { res }, emit) {
     if (handlePaymentResult.redirectObject) {
       // If authorized3d, then redirectObject from credit card, hence it is 3D Secure
       if (handlePaymentResult.authorized3d) {
+        const paymentInstrument = order.getPaymentInstruments(
+            constants.METHOD_CREDIT_CARD,
+        )[0];
         Transaction.wrap(() => {
           paymentInstrument.custom.adyenMD =
             handlePaymentResult.redirectObject.data.MD;

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/utils/payment.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/utils/payment.js
@@ -6,10 +6,9 @@ const adyenHelpers = require('*/cartridge/scripts/checkout/adyenHelpers');
 
 function handlePaymentAuthorization(order, { res }, emit) {
   const handleRedirectResult = (handlePaymentResult) => {
-
     if (handlePaymentResult.threeDS2) {
       const paymentInstrument = order.getPaymentInstruments(
-          constants.METHOD_CREDIT_CARD,
+        constants.METHOD_CREDIT_CARD,
       )[0];
       Transaction.wrap(() => {
         paymentInstrument.custom.adyenAction = handlePaymentResult.action;
@@ -33,7 +32,7 @@ function handlePaymentAuthorization(order, { res }, emit) {
       // If authorized3d, then redirectObject from credit card, hence it is 3D Secure
       if (handlePaymentResult.authorized3d) {
         const paymentInstrument = order.getPaymentInstruments(
-            constants.METHOD_CREDIT_CARD,
+          constants.METHOD_CREDIT_CARD,
         )[0];
         Transaction.wrap(() => {
           paymentInstrument.custom.adyenMD =

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/utils/transaction.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/utils/transaction.js
@@ -6,22 +6,22 @@ const basketCalculationHelpers = require('*/cartridge/scripts/helpers/basketCalc
 const { checkForErrors } = require('../helpers/index');
 
 const handleTransaction = (currentBasket, { res, req }, emit) => {
-  const validatePayment = () => {
-    // Re-validates existing payment instruments
-    const validPayment = adyenHelpers.validatePayment(req, currentBasket);
-    if (validPayment.error) {
-      res.json({
-        error: true,
-        errorStage: {
-          stage: 'payment',
-          step: 'paymentInstrument',
-        },
-        errorMessage: Resource.msg('error.payment.not.valid', 'checkout', null),
-      });
-      emit('route:Complete');
-    }
-    return !validPayment.error;
-  };
+  // const validatePayment = () => {
+  //   // Re-validates existing payment instruments
+  //   const validPayment = adyenHelpers.validatePayment(req, currentBasket);
+  //   if (validPayment.error) {
+  //     res.json({
+  //       error: true,
+  //       errorStage: {
+  //         stage: 'payment',
+  //         step: 'paymentInstrument',
+  //       },
+  //       errorMessage: Resource.msg('error.payment.not.valid', 'checkout', null),
+  //     });
+  //     emit('route:Complete');
+  //   }
+  //   return !validPayment.error;
+  // };
 
   const calculatePaymentTransaction = () => {
     const calculatedPaymentTransactionTotal = COHelpers.calculatePaymentTransaction(
@@ -47,7 +47,8 @@ const handleTransaction = (currentBasket, { res, req }, emit) => {
     basketCalculationHelpers.calculateTotals(currentBasket);
   });
 
-  return validatePayment() && calculatePaymentTransaction();
+  // return validatePayment() && calculatePaymentTransaction();
+  return calculatePaymentTransaction();
 };
 
 module.exports = handleTransaction;

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/utils/transaction.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/utils/transaction.js
@@ -1,28 +1,10 @@
 const Resource = require('dw/web/Resource');
 const Transaction = require('dw/system/Transaction');
 const COHelpers = require('*/cartridge/scripts/checkout/checkoutHelpers');
-const adyenHelpers = require('*/cartridge/scripts/checkout/adyenHelpers');
 const basketCalculationHelpers = require('*/cartridge/scripts/helpers/basketCalculationHelpers');
 const { checkForErrors } = require('../helpers/index');
 
 const handleTransaction = (currentBasket, { res, req }, emit) => {
-  // const validatePayment = () => {
-  //   // Re-validates existing payment instruments
-  //   const validPayment = adyenHelpers.validatePayment(req, currentBasket);
-  //   if (validPayment.error) {
-  //     res.json({
-  //       error: true,
-  //       errorStage: {
-  //         stage: 'payment',
-  //         step: 'paymentInstrument',
-  //       },
-  //       errorMessage: Resource.msg('error.payment.not.valid', 'checkout', null),
-  //     });
-  //     emit('route:Complete');
-  //   }
-  //   return !validPayment.error;
-  // };
-
   const calculatePaymentTransaction = () => {
     const calculatedPaymentTransactionTotal = COHelpers.calculatePaymentTransaction(
       currentBasket,
@@ -47,7 +29,6 @@ const handleTransaction = (currentBasket, { res, req }, emit) => {
     basketCalculationHelpers.calculateTotals(currentBasket);
   });
 
-  // return validatePayment() && calculatePaymentTransaction();
   return calculatePaymentTransaction();
 };
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/checkout/__tests__/adyenHelpers.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/checkout/__tests__/adyenHelpers.test.js
@@ -3,7 +3,6 @@ jest.mock('../utils/index', () => ({
 }));
 /* eslint-disable global-require */
 let handlePayments;
-let validatePayment;
 let order;
 let orderNumber;
 let currentBasket;
@@ -13,7 +12,6 @@ beforeEach(() => {
   jest.clearAllMocks();
 
   handlePayments = require('../adyenHelpers').handlePayments;
-  validatePayment = require('../adyenHelpers').validatePayment;
   currentBasket = require('dw/order/BasketMgr').getCurrentBasket();
   req = {
     geolocation: 'mockedLocation',
@@ -42,19 +40,6 @@ describe('Adyen Helpers', () => {
       order.paymentInstruments = [];
       const handlePaymentsResult = handlePayments(order, orderNumber);
       expect(handlePaymentsResult.error).toBeTruthy();
-    });
-  });
-  describe('Validate Payment', () => {
-    it('should return error', () => {
-      const { validatePaymentMethod } = require('../utils/index');
-      validatePaymentMethod.mockImplementation(() => jest.fn(() => false));
-      const validatePaymentResult = validatePayment(req, currentBasket);
-      expect(validatePaymentResult.error).toBeTruthy();
-    });
-
-    it('should be valid', () => {
-      const validatePaymentResult = validatePayment(req, currentBasket);
-      expect(validatePaymentResult.error).toBeFalsy();
     });
   });
 });

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/checkout/adyenHelpers.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/checkout/adyenHelpers.js
@@ -1,8 +1,6 @@
 const Transaction = require('dw/system/Transaction');
 const OrderMgr = require('dw/order/OrderMgr');
-const PaymentMgr = require('dw/order/PaymentMgr');
-const PaymentInstrument = require('dw/order/PaymentInstrument');
-const { getPayments, validatePaymentMethod } = require('./utils/index');
+const { getPayments } = require('./utils/index');
 
 /**
  * handles the payment authorization for each payment instrument
@@ -25,44 +23,6 @@ function handlePayments(order, orderNumber) {
   return { error: true };
 }
 
-/**
- * Validates payment
- * @param {Object} req - The local instance of the request object
- * @param {dw.order.Basket} currentBasket - The current basket
- * @returns {Object} an object that has error information
- */
-function validatePayment(req, currentBasket) {
-  const creditCardPaymentMethod = PaymentMgr.getPaymentMethod(
-    PaymentInstrument.METHOD_CREDIT_CARD,
-  );
-  const paymentAmount = currentBasket.totalGrossPrice.value;
-  const { countryCode } = req.geolocation;
-  const currentCustomer = req.currentCustomer.raw;
-  const { paymentInstruments } = currentBasket;
-  const result = {};
-
-  const applicablePaymentMethods = PaymentMgr.getApplicablePaymentMethods(
-    currentCustomer,
-    countryCode,
-    paymentAmount,
-  );
-  const applicablePaymentCards = creditCardPaymentMethod.getApplicablePaymentCards(
-    currentCustomer,
-    countryCode,
-    paymentAmount,
-  );
-
-  // const validatePaymentInstrument = validatePaymentMethod(
-  //   applicablePaymentCards,
-  //   applicablePaymentMethods,
-  // );
-
-  const isValid = paymentInstruments.toArray().every(validatePaymentInstrument);
-  result.error = !isValid;
-  return result;
-}
-
 module.exports = {
   handlePayments,
-  validatePayment,
 };

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/checkout/adyenHelpers.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/checkout/adyenHelpers.js
@@ -52,10 +52,10 @@ function validatePayment(req, currentBasket) {
     paymentAmount,
   );
 
-  const validatePaymentInstrument = validatePaymentMethod(
-    applicablePaymentCards,
-    applicablePaymentMethods,
-  );
+  // const validatePaymentInstrument = validatePaymentMethod(
+  //   applicablePaymentCards,
+  //   applicablePaymentMethods,
+  // );
 
   const isValid = paymentInstruments.toArray().every(validatePaymentInstrument);
   result.error = !isValid;

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/checkout/utils/getPayments.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/checkout/utils/getPayments.js
@@ -18,7 +18,7 @@ const getPayments = (order, orderNumber) =>
   order.paymentInstruments.toArray().reduce((acc, paymentInstrument) => {
     if (!acc.error) {
       const { paymentProcessor } = PaymentMgr.getPaymentMethod(
-          constants.METHOD_ADYEN_COMPONENT,
+        constants.METHOD_ADYEN_COMPONENT,
       );
 
       if (paymentProcessor) {

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/checkout/utils/getPayments.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/checkout/utils/getPayments.js
@@ -2,6 +2,7 @@ const Transaction = require('dw/system/Transaction');
 const HookMgr = require('dw/system/HookMgr');
 const PaymentMgr = require('dw/order/PaymentMgr');
 const OrderMgr = require('dw/order/OrderMgr');
+const constants = require('*/cartridge/adyenConstants/constants');
 
 const getAuthorizationResult = (pProcessor, orderNo, pInstrument) => {
   const hookName = `app.payment.processor.${pProcessor.ID.toLowerCase()}`;
@@ -17,7 +18,7 @@ const getPayments = (order, orderNumber) =>
   order.paymentInstruments.toArray().reduce((acc, paymentInstrument) => {
     if (!acc.error) {
       const { paymentProcessor } = PaymentMgr.getPaymentMethod(
-        paymentInstrument.paymentMethod,
+          constants.METHOD_ADYEN_COMPONENT,
       );
 
       if (paymentProcessor) {

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/hooks/payment/processor/middlewares/__tests__/__snapshots__/processForm.test.js.snap
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/hooks/payment/processor/middlewares/__tests__/__snapshots__/processForm.test.js.snap
@@ -34,7 +34,25 @@ exports[`processForm should return viewData when authenticated and registered 1`
 Object {
   "error": false,
   "viewData": Object {
+    "0": "m",
+    "1": "o",
+    "2": "c",
+    "3": "k",
+    "4": "e",
+    "5": "d",
+    "6": "_",
+    "7": "i",
+    "8": "d",
     "paymentInformation": Object {
+      "0": "m",
+      "1": "o",
+      "2": "c",
+      "3": "k",
+      "4": "e",
+      "5": "d",
+      "6": "_",
+      "7": "i",
+      "8": "d",
       "adyenIssuerName": "mocked_issuer_name",
       "adyenPaymentMethod": "mockedPaymentMethod",
       "cardNumber": "mocked_cc_number",
@@ -45,14 +63,12 @@ Object {
       "isCreditCard": false,
       "securityCode": "mocked_security_code",
       "stateData": "mockedStateData",
-      "storedPaymentUUID": "mocked_id",
     },
     "paymentMethod": Object {
       "htmlName": "mockedPaymentMethod",
       "value": "mockedPaymentMethod",
     },
     "saveCard": true,
-    "storedPaymentUUID": "mocked_id",
   },
 }
 `;

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/hooks/payment/processor/middlewares/handle.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/hooks/payment/processor/middlewares/handle.js
@@ -11,8 +11,11 @@ function handle(basket, paymentInformation) {
     collections.forEach(currentBasket.getPaymentInstruments(), (item) => {
       currentBasket.removePaymentInstrument(item);
     });
+
+    const paymentMethod = paymentInformation.isCreditCard ? constants.METHOD_CREDIT_CARD : constants.METHOD_ADYEN_COMPONENT;
+
     const paymentInstrument = currentBasket.createPaymentInstrument(
-      constants.METHOD_ADYEN_COMPONENT,
+        paymentMethod,
       currentBasket.totalGrossPrice,
     );
     paymentInstrument.custom.adyenPaymentData = paymentInformation.stateData;
@@ -28,7 +31,11 @@ function handle(basket, paymentInformation) {
         customer,
       );
 
-      paymentInstrument.setCreditCardNumber(paymentInformation.cardNumber);
+      const cardNumber = paymentInformation.cardNumber ||
+          paymentInformation.adyenPaymentMethod.substring(
+              paymentInformation.adyenPaymentMethod.indexOf('*')
+          );
+      paymentInstrument.setCreditCardNumber(cardNumber);
       paymentInstrument.setCreditCardType(sfccCardType);
 
       if (tokenID) {

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/hooks/payment/processor/middlewares/handle.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/hooks/payment/processor/middlewares/handle.js
@@ -3,6 +3,32 @@ const AdyenHelper = require('*/cartridge/scripts/util/adyenHelper');
 const collections = require('*/cartridge/scripts/util/collections');
 const constants = require('*/cartridge/adyenConstants/constants');
 
+function handleCreditCard(paymentInformation, paymentInstrument) {
+  const sfccCardType = AdyenHelper.getSFCCCardType(paymentInformation.cardType);
+  const tokenID = AdyenHelper.getCardToken(
+    paymentInformation.storedPaymentUUID,
+    customer,
+  );
+
+  const cardNumber =
+    paymentInformation.cardNumber ||
+    paymentInformation.adyenPaymentMethod.substring(
+      paymentInformation.adyenPaymentMethod.indexOf('*'),
+    );
+  paymentInstrument.setCreditCardNumber(cardNumber);
+  paymentInstrument.setCreditCardType(sfccCardType);
+
+  if (tokenID) {
+    paymentInstrument.setCreditCardExpirationMonth(
+      paymentInformation.expirationMonth.value,
+    );
+    paymentInstrument.setCreditCardExpirationYear(
+      paymentInformation.expirationYear.value,
+    );
+    paymentInstrument.setCreditCardToken(tokenID);
+  }
+}
+
 function handle(basket, paymentInformation) {
   const currentBasket = basket;
   const cardErrors = {};
@@ -12,10 +38,12 @@ function handle(basket, paymentInformation) {
       currentBasket.removePaymentInstrument(item);
     });
 
-    const paymentMethod = paymentInformation.isCreditCard ? constants.METHOD_CREDIT_CARD : constants.METHOD_ADYEN_COMPONENT;
+    const paymentMethod = paymentInformation.isCreditCard
+      ? constants.METHOD_CREDIT_CARD
+      : constants.METHOD_ADYEN_COMPONENT;
 
     const paymentInstrument = currentBasket.createPaymentInstrument(
-        paymentMethod,
+      paymentMethod,
       currentBasket.totalGrossPrice,
     );
     paymentInstrument.custom.adyenPaymentData = paymentInformation.stateData;
@@ -23,30 +51,7 @@ function handle(basket, paymentInformation) {
       paymentInformation.adyenPaymentMethod;
 
     if (paymentInformation.isCreditCard) {
-      const sfccCardType = AdyenHelper.getSFCCCardType(
-        paymentInformation.cardType,
-      );
-      const tokenID = AdyenHelper.getCardToken(
-        paymentInformation.storedPaymentUUID,
-        customer,
-      );
-
-      const cardNumber = paymentInformation.cardNumber ||
-          paymentInformation.adyenPaymentMethod.substring(
-              paymentInformation.adyenPaymentMethod.indexOf('*')
-          );
-      paymentInstrument.setCreditCardNumber(cardNumber);
-      paymentInstrument.setCreditCardType(sfccCardType);
-
-      if (tokenID) {
-        paymentInstrument.setCreditCardExpirationMonth(
-          paymentInformation.expirationMonth.value,
-        );
-        paymentInstrument.setCreditCardExpirationYear(
-          paymentInformation.expirationYear.value,
-        );
-        paymentInstrument.setCreditCardToken(tokenID);
-      }
+      handleCreditCard(paymentInformation, paymentInstrument);
     }
   });
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/hooks/payment/processor/middlewares/processForm.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/hooks/payment/processor/middlewares/processForm.js
@@ -1,5 +1,6 @@
 const COHelpers = require('*/cartridge/scripts/checkout/checkoutHelpers');
 const array = require('*/cartridge/scripts/util/array');
+const Logger = require('dw/system/Logger');
 
 function getCreditCardErrors(req, isCreditCard, paymentForm) {
   if (!req.form.storedPaymentUUID && isCreditCard) {
@@ -21,7 +22,17 @@ function getPaymentInstrument(req, { storedPaymentUUID }) {
 
 // process payment information
 function getProcessFormResult(storedPaymentUUID, req, viewData) {
+  // Logger.getLogger('Adyen').error('wallet PIs' + req.currentCustomer.wallet.paymentInstruments);
+  // const paymentInstruments = req.currentCustomer.wallet.paymentInstruments;
+
+  // array.find(paymentInstruments, function (item) {
+  //   Logger.getLogger('Adyen').error( JSON.stringify(storedPaymentUUID));
+  //   Logger.getLogger('Adyen').error( item.UUID);
+  //   return viewData.storedPaymentUUID === item.UUID;
+  // });
+
   const { authenticated, registered } = req.currentCustomer.raw;
+
   if (storedPaymentUUID && authenticated && registered) {
     const paymentInstrument = getPaymentInstrument(req, viewData);
 
@@ -78,10 +89,11 @@ function getViewData(
 
 function getStoredPaymentUUID(paymentForm) {
   const { selectedCardID } = paymentForm.creditCardFields;
-  const storedPaymentUUID = selectedCardID && {
-    storedPaymentUUID: selectedCardID.value,
-  };
-  return storedPaymentUUID;
+  Logger.getLogger('Adyen').error('selectedCardID ' + selectedCardID);
+  if(selectedCardID) {
+    Logger.getLogger('Adyen').error('paymentForm.creditCardFields.selectedCardID.value ' + paymentForm.creditCardFields.selectedCardID.value);
+    return paymentForm.creditCardFields.selectedCardID.value;
+  }
 }
 
 /**
@@ -92,7 +104,11 @@ function getStoredPaymentUUID(paymentForm) {
  * @returns {Object} an object that has error information or payment information
  */
 function processForm(req, paymentForm, viewFormData) {
-  const isCreditCard = req.form.brandCode === 'scheme';
+  const brand = JSON.stringify(req.form.brandCode);
+  const isCreditCard = req.form.brandCode === 'scheme' || brand.indexOf('storedCard') > -1;
+  Logger.getLogger('Adyen').error('isCreditCard ' + isCreditCard);
+  Logger.getLogger('Adyen').error('brand.indexOf(storedCard) ' + brand.indexOf('storedCard'));
+  Logger.getLogger('Adyen').error('req.form.brandCode === scheme ' + req.form.brandCode === 'scheme');
   const creditCardErrors = getCreditCardErrors(req, isCreditCard, paymentForm);
 
   if (Object.keys(creditCardErrors).length) {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Order exports were only showing the payment processor adyenComponent details even when it's a card payment.
This PR is to ensure exports will show native Credit Card details
## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
