### PR TITLE
Paypal pop-up closed too early

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyenCheckout.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyenCheckout.js
@@ -53,12 +53,12 @@ if (window.paypalMerchantID !== 'null') {
 
 // Submit the payment
 $('button[value="submit-payment"]').on('click', () => {
-  if (window.paypalTerminatedEarly) {
+  if (store.paypalTerminatedEarly) {
     paymentFromComponent({
       cancelTransaction: true,
       merchantReference: document.querySelector('#merchantReference').value,
     });
-    window.paypalTerminatedEarly = false;
+    store.paypalTerminatedEarly = false;
   }
   if (document.querySelector('#selectedPaymentOption').value === 'AdyenPOS') {
     document.querySelector('#terminalId').value = document.querySelector(

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyenCheckout.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyenCheckout.js
@@ -8,6 +8,7 @@ const {
 const {
   assignPaymentMethodValue,
   showValidation,
+  paymentFromComponent,
 } = require('./adyen_checkout/helpers');
 const { validateComponents } = require('./adyen_checkout/validateComponents');
 
@@ -52,6 +53,13 @@ if (window.paypalMerchantID !== 'null') {
 
 // Submit the payment
 $('button[value="submit-payment"]').on('click', () => {
+  if (window.paypalTerminatedEarly) {
+    paymentFromComponent({
+      cancelTransaction: true,
+      merchantReference: document.querySelector('#merchantReference').value,
+    });
+    window.paypalTerminatedEarly = false;
+  }
   if (document.querySelector('#selectedPaymentOption').value === 'AdyenPOS') {
     document.querySelector('#terminalId').value = document.querySelector(
       '#terminalList',

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
@@ -27,6 +27,7 @@ function getCardConfig() {
 }
 
 function getPaypalConfig() {
+  window.paypalTerminatedEarly = false;
   return {
     showPayButton: true,
     environment: window.Configuration.environment,
@@ -40,6 +41,7 @@ function getPaypalConfig() {
       helpers.paymentFromComponent(state.data, component);
     },
     onCancel: (data, component) => {
+      window.paypalTerminatedEarly = false;
       helpers.paymentFromComponent(
         {
           cancelTransaction: true,
@@ -49,18 +51,26 @@ function getPaypalConfig() {
       );
     },
     onError: (error, component) => {
+      window.paypalTerminatedEarly = false;
       if (component) {
         component.setStatus('ready');
       }
       document.querySelector('#showConfirmationForm').submit();
     },
     onAdditionalDetails: (state) => {
+      window.paypalTerminatedEarly = false;
       document.querySelector('#additionalDetailsHidden').value = JSON.stringify(
         state.data,
       );
       document.querySelector('#showConfirmationForm').submit();
     },
     onClick: (data, actions) => {
+      if (window.paypalTerminatedEarly) {
+        helpers.paymentFromComponent({ cancelTransaction: true });
+        window.paypalTerminatedEarly = false;
+        return actions.resolve();
+      }
+      window.paypalTerminatedEarly = true;
       $('#dwfrm_billing').trigger('submit');
       if (store.formErrorsExist) {
         return actions.reject();

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
@@ -27,7 +27,7 @@ function getCardConfig() {
 }
 
 function getPaypalConfig() {
-  window.paypalTerminatedEarly = false;
+  store.paypalTerminatedEarly = false;
   return {
     showPayButton: true,
     environment: window.Configuration.environment,
@@ -41,7 +41,7 @@ function getPaypalConfig() {
       helpers.paymentFromComponent(state.data, component);
     },
     onCancel: (data, component) => {
-      window.paypalTerminatedEarly = false;
+      store.paypalTerminatedEarly = false;
       helpers.paymentFromComponent(
         {
           cancelTransaction: true,
@@ -51,29 +51,29 @@ function getPaypalConfig() {
       );
     },
     onError: (error, component) => {
-      window.paypalTerminatedEarly = false;
+      store.paypalTerminatedEarly = false;
       if (component) {
         component.setStatus('ready');
       }
       document.querySelector('#showConfirmationForm').submit();
     },
     onAdditionalDetails: (state) => {
-      window.paypalTerminatedEarly = false;
+      store.paypalTerminatedEarly = false;
       document.querySelector('#additionalDetailsHidden').value = JSON.stringify(
         state.data,
       );
       document.querySelector('#showConfirmationForm').submit();
     },
     onClick: (data, actions) => {
-      if (window.paypalTerminatedEarly) {
+      if (store.paypalTerminatedEarly) {
         helpers.paymentFromComponent({
           cancelTransaction: true,
           merchantReference: document.querySelector('#merchantReference').value,
         });
-        window.paypalTerminatedEarly = false;
+        store.paypalTerminatedEarly = false;
         return actions.resolve();
       }
-      window.paypalTerminatedEarly = true;
+      store.paypalTerminatedEarly = true;
       $('#dwfrm_billing').trigger('submit');
       if (store.formErrorsExist) {
         return actions.reject();

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
@@ -66,7 +66,10 @@ function getPaypalConfig() {
     },
     onClick: (data, actions) => {
       if (window.paypalTerminatedEarly) {
-        helpers.paymentFromComponent({ cancelTransaction: true });
+        helpers.paymentFromComponent({
+          cancelTransaction: true,
+          merchantReference: document.querySelector('#merchantReference').value,
+        });
         window.paypalTerminatedEarly = false;
         return actions.resolve();
       }

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderPaymentMethod.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderPaymentMethod.js
@@ -130,6 +130,12 @@ function handleInput({ paymentMethodID }) {
         cancelTransaction: true,
         merchantReference: document.querySelector('#merchantReference').value,
       });
+    } else if(window.paypalTerminatedEarly) {
+      helpers.paymentFromComponent({
+        cancelTransaction: true,
+        merchantReference: document.querySelector('#merchantReference').value,
+      });
+      window.paypalTerminatedEarly = false;
     }
 
     helpers.displaySelectedMethod(event.target.value);

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderPaymentMethod.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderPaymentMethod.js
@@ -130,12 +130,6 @@ function handleInput({ paymentMethodID }) {
         cancelTransaction: true,
         merchantReference: document.querySelector('#merchantReference').value,
       });
-    } else if(window.paypalTerminatedEarly) {
-      helpers.paymentFromComponent({
-        cancelTransaction: true,
-        merchantReference: document.querySelector('#merchantReference').value,
-      });
-      window.paypalTerminatedEarly = false;
     }
 
     helpers.displaySelectedMethod(event.target.value);

--- a/src/cartridges/int_adyen_SFRA/cartridge/store/index.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/store/index.js
@@ -17,6 +17,8 @@ class Store {
 
   @observable isValid = false;
 
+  @observable paypalTerminatedEarly = false;
+
   @observable componentState = {};
 
   @computed get maskedCardNumber() {

--- a/src/cartridges/int_adyen_controllers/cartridge/js/pages/checkout/adyen-checkout.js
+++ b/src/cartridges/int_adyen_controllers/cartridge/js/pages/checkout/adyen-checkout.js
@@ -17,13 +17,13 @@ let paypalTerminatedEarly = false;
  */
 function initializeBillingEvents() {
   $('#billing-submit').on('click', () => {
-    if(paypalTerminatedEarly) {
-      paymentFromComponent({
-        cancelTransaction: true,
-        merchantReference: document.querySelector('#merchantReference').value,
-      });
-      paypalTerminatedEarly = false;
-    }
+    // if(paypalTerminatedEarly) {
+    //   paymentFromComponent({
+    //     cancelTransaction: true,
+    //     merchantReference: document.querySelector('#merchantReference').value,
+    //   });
+    //   paypalTerminatedEarly = false;
+    // }
     const isAdyenPOS = document.querySelector(
       '.payment-method-options :checked',
     ).value;

--- a/src/cartridges/int_adyen_controllers/cartridge/js/pages/checkout/adyen-checkout.js
+++ b/src/cartridges/int_adyen_controllers/cartridge/js/pages/checkout/adyen-checkout.js
@@ -117,15 +117,14 @@ function initializeBillingEvents() {
           assignPaymentMethodValue();
           paymentFromComponent(state.data, component);
           document.querySelector('#adyenStateData').value = JSON.stringify(
-            state.data,
+              state.data,
           );
         },
         onCancel: (data, component) => {
           paypalTerminatedEarly = false;
           paymentFromComponent({
-            cancelPaypal: true,
-            merchantReference: document.querySelector('#merchantReference').value,
-          }, component);
+            cancelTransaction: true,
+            merchantReference: document.querySelector('#merchantReference').value, }, component);
         },
         onError: (/* error, component */) => {
           paypalTerminatedEarly = false;
@@ -153,6 +152,16 @@ function initializeBillingEvents() {
               state.data,
           );
         },
+        onError: (/* error, component */) => {
+          $('#dwfrm_billing').trigger('submit');
+        },
+        onAdditionalDetails: (state /* , component */) => {
+          document.querySelector('#paymentFromComponentStateData').value = JSON.stringify(
+              state.data,
+          );
+          $('#dwfrm_billing').trigger('submit');
+        },
+      },
       swish: getQRCodeConfig(),
       bcmc_mobile: getQRCodeConfig(),
       wechatpayQR: getQRCodeConfig(),
@@ -168,13 +177,13 @@ function initializeBillingEvents() {
               '#dwfrm_billing_billingAddress_addressFields_firstName',
             ).value,
             lastName: document.querySelector(
-              '#dwfrm_billing_billingAddress_addressFields_lastName',
+               '#dwfrm_billing_billingAddress_addressFields_lastName',
             ).value,
             telephoneNumber: document.querySelector(
-              '#dwfrm_billing_billingAddress_addressFields_phone',
+               '#dwfrm_billing_billingAddress_addressFields_phone',
             ).value,
             shopperEmail: document.querySelector(
-              '#dwfrm_billing_billingAddress_email_emailAddress',
+               '#dwfrm_billing_billingAddress_email_emailAddress',
             ).value,
           },
         },
@@ -188,16 +197,16 @@ function initializeBillingEvents() {
         data: {
           personalDetails: {
             firstName: document.querySelector(
-              '#dwfrm_billing_billingAddress_addressFields_firstName',
+                '#dwfrm_billing_billingAddress_addressFields_firstName',
             ).value,
             lastName: document.querySelector(
-              '#dwfrm_billing_billingAddress_addressFields_lastName',
+                '#dwfrm_billing_billingAddress_addressFields_lastName',
             ).value,
             telephoneNumber: document.querySelector(
-              '#dwfrm_billing_billingAddress_addressFields_phone',
+                '#dwfrm_billing_billingAddress_addressFields_phone',
             ).value,
             shopperEmail: document.querySelector(
-              '#dwfrm_billing_billingAddress_email_emailAddress',
+                '#dwfrm_billing_billingAddress_email_emailAddress',
             ).value,
           },
         },


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
When Paypal pop-up is closed before content loads it doesn't fire the event onCancel. Trying to checkout afterwards would result in an error
This PR handles this case where paypal is terminated early
## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
