### PR TITLE
PW-3450 Error message OriginKey not found

### DIFF
--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/adyenGetOriginKey.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/adyenGetOriginKey.js
@@ -45,6 +45,7 @@ function getOriginKey(origin) {
 
     return JSON.parse(resultObject.getText());
   } catch (e) {
+    Logger.getLogger('Adyen').error(`It seems your API key is incorrect ... Please make sure API key is configured`);
     Logger.getLogger('Adyen').fatal(
       `Adyen: ${e.toString()} in ${e.fileName}:${e.lineNumber}`,
     );


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
When API key is not correctly configured, the first error will be during retrieval of OriginKeys.
A proper error message is needed there
## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
