### PR TITLE
Pw 5065/fix sfra checkout v67

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazon.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazon.js
@@ -51,7 +51,7 @@ const amazonConfig = {
       state.data,
     );
     document.querySelector('#additionalDetailsHidden').value = JSON.stringify(
-        state.data,
+      state.data,
     );
     paymentFromComponent(state.data, component);
   },

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazon.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazon.js
@@ -50,6 +50,9 @@ const amazonConfig = {
     document.querySelector('#adyenStateData').value = JSON.stringify(
       state.data,
     );
+    document.querySelector('#additionalDetailsHidden').value = JSON.stringify(
+        state.data,
+    );
     paymentFromComponent(state.data, component);
   },
 };

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/__snapshots__/showConfirmation.test.js.snap
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/__snapshots__/showConfirmation.test.js.snap
@@ -1,17 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Show Confirmation should fail if resultCode is Received with Alipay payment 1`] = `
-Array [
-  Array [
-    "Checkout-Begin",
-    "stage",
-    "payment",
-    "paymentError",
-    "mocked_error.payment.not.valid",
-  ],
-]
-`;
-
 exports[`Show Confirmation should have payload 1`] = `
 Array [
   Array [

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/redirect.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/redirect.test.js
@@ -9,7 +9,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   req = {
     querystring: {
-      signature: 'some_mocked_url/signature __ ocked_adyen_payment_data',
+      signature: 'some_mocked_url/signature __ mocked_orderNo',
       merchantReference: 'mocked_merchantReference',
     },
   };

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/showConfirmation.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/showConfirmation.test.js
@@ -56,7 +56,7 @@ describe('Show Confirmation', () => {
     const URLUtils = require('dw/web/URLUtils');
     adyenCheckout.doPaymentsDetailsCall.mockImplementation(() => ({
       resultCode: 'Received',
-      paymentMethod: ['alipay_hk'],
+      additionalData: {paymentMethod: 'alipay_hk'},
     }));
     showConfirmation(req, res, jest.fn());
     expect(URLUtils.url.mock.calls).toMatchSnapshot();

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/showConfirmation.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/showConfirmation.test.js
@@ -51,14 +51,4 @@ describe('Show Confirmation', () => {
       expect(URLUtils.url.mock.calls[0][0]).toBe('Order-Confirm');
     },
   );
-  it('should fail if resultCode is Received with Alipay payment', () => {
-    const adyenCheckout = require('*/cartridge/scripts/adyenCheckout');
-    const URLUtils = require('dw/web/URLUtils');
-    adyenCheckout.doPaymentsDetailsCall.mockImplementation(() => ({
-      resultCode: 'Received',
-      additionalData: {paymentMethod: 'alipay_hk'},
-    }));
-    showConfirmation(req, res, jest.fn());
-    expect(URLUtils.url.mock.calls).toMatchSnapshot();
-  });
 });

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/showConfirmationPaymentFromComponent.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/showConfirmationPaymentFromComponent.test.js
@@ -11,10 +11,10 @@ beforeEach(() => {
   res = { redirect: jest.fn() };
   req = {
     form: {
-      additionalDetailsHidden: {
+      additionalDetailsHidden: JSON.stringify({
         paymentData: 'mocked_paymentData',
         details: 'mocked_details',
-      },
+      }),
       result: null
     },
     locale: { id: 'nl_NL' },

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/redirect/signature.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/redirect/signature.js
@@ -28,12 +28,11 @@ function getCurrentSignature(order) {
     constants.METHOD_ADYEN_COMPONENT,
   );
   const adyenPaymentInstrument = paymentInstruments[0];
-  const paymentData = adyenPaymentInstrument.custom.adyenPaymentData;
   const redirectUrl = adyenPaymentInstrument.custom.adyenRedirectURL;
 
   return AdyenHelper.getAdyenHash(
     redirectUrl.substr(redirectUrl.length - 25),
-    paymentData.substr(1, 25),
+    order.orderNo,
   );
 }
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmation/__tests__/authorise.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmation/__tests__/authorise.test.js
@@ -14,11 +14,6 @@ beforeEach(() => {
 });
 
 describe('Authorise', () => {
-  it('should handle alipay_hk', () => {
-    const result = { resultCode: 'Received', additionalData: {paymentMethod: 'alipay_hk' }};
-    handleAuthorised({}, result, {}, {});
-    expect(payment.handleReceived).toBeCalledTimes(1);
-  });
   it('should handle error', () => {
     COHelpers.placeOrder.mockReturnValue({ error: true });
     const result = { resultCode: 'Authorised' };
@@ -29,7 +24,6 @@ describe('Authorise', () => {
     COHelpers.placeOrder.mockReturnValue({ error: false });
     const result = { resultCode: 'Authorised' };
     handleAuthorised({}, result, {}, { req });
-    expect(payment.handleReceived).toBeCalledTimes(0);
     expect(payment.handlePaymentError).toBeCalledTimes(0);
   });
 });

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmation/__tests__/authorise.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmation/__tests__/authorise.test.js
@@ -15,7 +15,7 @@ beforeEach(() => {
 
 describe('Authorise', () => {
   it('should handle alipay_hk', () => {
-    const result = { resultCode: 'Received', paymentMethod: ['alipay_hk'] };
+    const result = { resultCode: 'Received', additionalData: {paymentMethod: 'alipay_hk' }};
     handleAuthorised({}, result, {}, {});
     expect(payment.handleReceived).toBeCalledTimes(1);
   });

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmation/authorise.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmation/authorise.js
@@ -8,7 +8,7 @@ function handleAuthorised(order, result, adyenPaymentInstrument, options) {
   const { req } = options;
   if (
     result.resultCode === 'Received' &&
-    result.paymentMethod.indexOf('alipay_hk') > -1
+    result.paymentMethod?.indexOf('alipay_hk') > -1
   ) {
     return payment.handleReceived(order, result, options);
   }

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmation/authorise.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmation/authorise.js
@@ -8,7 +8,7 @@ function handleAuthorised(order, result, adyenPaymentInstrument, options) {
   const { req } = options;
   if (
     result.resultCode === 'Received' &&
-    result.paymentMethod?.indexOf('alipay_hk') > -1
+    result.additionalData?.paymentMethod?.indexOf('alipay_hk') > -1
   ) {
     return payment.handleReceived(order, result, options);
   }

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmation/authorise.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmation/authorise.js
@@ -6,12 +6,6 @@ const payment = require('./payment');
 
 function handleAuthorised(order, result, adyenPaymentInstrument, options) {
   const { req } = options;
-  if (
-    result.resultCode === 'Received' &&
-    result.additionalData?.paymentMethod ==='alipay_hk'
-  ) {
-    return payment.handleReceived(order, result, options);
-  }
 
   // custom fraudDetection
   const fraudDetectionStatus = { status: 'success' };

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmation/authorise.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmation/authorise.js
@@ -8,7 +8,7 @@ function handleAuthorised(order, result, adyenPaymentInstrument, options) {
   const { req } = options;
   if (
     result.resultCode === 'Received' &&
-    result.additionalData?.paymentMethod?.indexOf('alipay_hk') > -1
+    result.additionalData?.paymentMethod ==='alipay_hk'
   ) {
     return payment.handleReceived(order, result, options);
   }

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmation/payment.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmation/payment.js
@@ -2,7 +2,6 @@ const URLUtils = require('dw/web/URLUtils');
 const Resource = require('dw/web/Resource');
 const Transaction = require('dw/system/Transaction');
 const OrderMgr = require('dw/order/OrderMgr');
-const Logger = require('dw/system/Logger');
 
 function handleRedirect(page, { res }) {
   res.redirect(
@@ -14,25 +13,6 @@ function handleRedirect(page, { res }) {
       Resource.msg('error.payment.not.valid', 'checkout', null),
     ),
   );
-}
-
-function handleReceived(order, result, { res, next }) {
-  Transaction.wrap(() => {
-    OrderMgr.failOrder(order, true);
-  });
-  Logger.getLogger('Adyen').error(
-    `Did not complete Alipay transaction, result: ${JSON.stringify(result)}`,
-  );
-  res.redirect(
-    URLUtils.url(
-      'Checkout-Begin',
-      'stage',
-      'payment',
-      'paymentError',
-      Resource.msg('error.payment.not.valid', 'checkout', null),
-    ),
-  );
-  return next();
 }
 
 function handlePaymentError(order, page, { res, next }) {
@@ -66,7 +46,6 @@ function handlePaymentInstruments(paymentInstruments, { req }) {
 
 module.exports = {
   handleRedirect,
-  handleReceived,
   handlePaymentError,
   handlePaymentInstruments,
 };

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmationPaymentFromComponent.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmationPaymentFromComponent.js
@@ -9,7 +9,7 @@ const handlePayment = require('./showConfirmationPaymentFromComponent/payment');
 function showConfirmationPaymentFromComponent(req, res, next) {
   const options = { req, res, next };
   try {
-    const stateData = req.form.additionalDetailsHidden;
+    const stateData = JSON.parse(req.form.additionalDetailsHidden);
     const order = OrderMgr.getOrder(req.form.merchantReference);
     return handlePayment(stateData, order, options);
   } catch (e) {

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/hooks/payment/processor/middlewares/__tests__/__snapshots__/authorize.test.js.snap
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/hooks/payment/processor/middlewares/__tests__/__snapshots__/authorize.test.js.snap
@@ -59,7 +59,7 @@ Object {
   "redirectObject": Object {
     "url": "mockedURL",
   },
-  "signature": "mockedURL __ ockedpaymentData",
+  "signature": "mockedURL __ 15",
 }
 `;
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/hooks/payment/processor/middlewares/authorize/__tests__/__snapshots__/paymentResponse.test.js.snap
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/hooks/payment/processor/middlewares/authorize/__tests__/__snapshots__/paymentResponse.test.js.snap
@@ -59,6 +59,6 @@ Object {
   "redirectObject": Object {
     "url": "mocked_redirect_url",
   },
-  "signature": "ct_url __ ocked_payment_data",
+  "signature": "ct_url __ mocked_order_number",
 }
 `;

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/hooks/payment/processor/middlewares/authorize/paymentResponse.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/hooks/payment/processor/middlewares/authorize/paymentResponse.js
@@ -20,8 +20,7 @@ function getRedirectResponse(result, orderNumber, paymentInstrument) {
   const getMDSignature = () =>
     createHash(result.redirectObject.data.MD.substr(1, 25));
   // Signature for redirect methods
-  const getPaymentDataSignature = () =>
-    createHash(result.paymentData.substr(1, 25));
+  const getPaymentDataSignature = () => createHash(orderNumber);
 
   const hasMD = !!result.redirectObject?.data?.MD;
   // If the response has MD, then it is a 3DS transaction

--- a/src/cartridges/int_adyen_SFRA/cartridge/templates/default/checkout/billing/adyenComponentForm.isml
+++ b/src/cartridges/int_adyen_SFRA/cartridge/templates/default/checkout/billing/adyenComponentForm.isml
@@ -23,7 +23,7 @@
       window.paymentFromComponentURL = "${URLUtils.https('Adyen-PaymentFromComponent')}";
 </script>
 
-<isif condition="${request.getHttpQueryString().indexOf('amazonCheckoutSessionId') > -1} ">
+<isif condition="${request.getHttpQueryString() && request.getHttpQueryString().indexOf('amazonCheckoutSessionId') > -1} ">
     <link rel="stylesheet" type="text/css" href="${pdict.AdyenHelper.getCheckoutCSS()}"/>
     <isscript>
         var assets = require('*/cartridge/scripts/assets.js');

--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/adyenCheckout.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/adyenCheckout.js
@@ -167,8 +167,8 @@ function doPaymentsCall(order, paymentInstrument, paymentRequest) {
     }
 
     paymentResponse.fullResponse = responseObject;
-    paymentResponse.redirectObject = responseObject.redirect
-      ? responseObject.redirect
+    paymentResponse.redirectObject = responseObject.action
+      ? responseObject.action
       : '';
     paymentResponse.resultCode = responseObject.resultCode;
     paymentResponse.pspReference = responseObject.pspReference
@@ -196,13 +196,8 @@ function doPaymentsCall(order, paymentInstrument, paymentRequest) {
       }
       paymentResponse.decision = 'ACCEPT';
       paymentResponse.threeDS2 = true;
-      let token3ds2;
-      if (responseObject.authentication['threeds2.fingerprintToken']) {
-        token3ds2 = responseObject.authentication['threeds2.fingerprintToken'];
-      } else if (responseObject.authentication['threeds2.challengeToken']) {
-        token3ds2 = responseObject.authentication['threeds2.challengeToken'];
-      }
-      paymentResponse.token3ds2 = token3ds2;
+
+      paymentResponse.token3ds2 = responseObject.action.token;
       paymentResponse.paymentData = responseObject.paymentData;
     } else if (
       paymentResponse.resultCode === 'Authorised' ||

--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/adyenCheckout.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/adyenCheckout.js
@@ -204,7 +204,6 @@ function doPaymentsCall(order, paymentInstrument, paymentRequest) {
       paymentResponse.resultCode === 'RedirectShopper'
     ) {
       paymentResponse.decision = 'ACCEPT';
-      paymentResponse.paymentData = responseObject.paymentData;
       // if 3D Secure is used, the statuses will be updated later
       if (paymentResponse.resultCode === 'Authorised') {
         order.setPaymentStatus(Order.PAYMENT_STATUS_PAID);
@@ -218,60 +217,6 @@ function doPaymentsCall(order, paymentInstrument, paymentRequest) {
           responseObject.action,
         );
       }
-
-      if (responseObject.outputDetails) {
-        const outputDetailsData = [];
-        for (const data in responseObject.outputDetails) {
-          outputDetailsData.push({
-            key: data,
-            value: responseObject.outputDetails[data],
-          });
-        }
-        paymentInstrument.custom.adyenAdditionalPaymentData = JSON.stringify(
-          outputDetailsData,
-        );
-      }
-    } else if (paymentResponse.resultCode === 'Received') {
-      paymentResponse.decision = 'ACCEPT';
-      if (responseObject.additionalData['bankTransfer.owner']) {
-        const bankTransferData = [
-          {
-            key: 'bankTransfer.description',
-            value: 'bankTransfer.description',
-          },
-        ];
-        for (const data in responseObject.additionalData) {
-          if (data.indexOf('bankTransfer.') !== -1) {
-            bankTransferData.push({
-              key: data,
-              value: responseObject.additionalData[data],
-            });
-          }
-        }
-        paymentInstrument.custom.adyenAdditionalPaymentData = JSON.stringify(
-          bankTransferData,
-        );
-      }
-
-      if (responseObject.additionalData['comprafacil.entity']) {
-        const multiBancoData = [
-          { key: 'comprafacil.description', value: 'comprafacil.description' },
-        ];
-        for (const data in responseObject.additionalData) {
-          if (data.indexOf('comprafacil.') !== -1) {
-            multiBancoData.push({
-              key: data,
-              value: responseObject.additionalData[data],
-            });
-          }
-        }
-        paymentInstrument.custom.adyenAdditionalPaymentData = JSON.stringify(
-          multiBancoData,
-        );
-      }
-
-      order.setPaymentStatus(Order.PAYMENT_STATUS_NOTPAID);
-      order.setExportStatus(Order.EXPORT_STATUS_NOTEXPORTED);
     } else {
       paymentResponse.decision = 'REFUSED';
       order.setPaymentStatus(Order.PAYMENT_STATUS_NOTPAID);


### PR DESCRIPTION
## Summary
After update to v67, a few breaking changes were introduced

No redirect object in the /payments response
No paymentData in the /payments response, which we used to use for hash
Test several payment flows and potentially add issues in the ticket (Redirect, 3DS1, 3DS2, Voucher, Pending)

## Tested scenarios
CreditCard 3DS1+2
iDeal
PayPal
Swish
Amazon Pay

