### PR TITLE
removed obsolete setting paypal merchantID

### DIFF
--- a/metadata/site_import/meta/system-objecttype-extensions.xml
+++ b/metadata/site_import/meta/system-objecttype-extensions.xml
@@ -536,14 +536,6 @@
                 <externally-managed-flag>false</externally-managed-flag>
                 <min-length>0</min-length>
             </attribute-definition>
-            <attribute-definition attribute-id="Adyen_PaypalMerchantID">
-                <display-name xml:lang="x-default">Your PayPal MerchantID to accept live payments</display-name>
-                <description xml:lang="x-default">https://docs.adyen.com/payment-methods/paypal/web-component#show-paypal-in-your-payment-form</description>
-                <type>string</type>
-                <mandatory-flag>false</mandatory-flag>
-                <externally-managed-flag>false</externally-managed-flag>
-                <min-length>0</min-length>
-            </attribute-definition>
             <attribute-definition attribute-id="Adyen_GooglePayMerchantID">
                 <display-name xml:lang="x-default">Your Google MerchantID (required in production only)</display-name>
                 <description xml:lang="x-default">As described in https://developers.google.com/pay/api/web/guides/test-and-deploy/deploy-production-environment#obtain-your-merchantID</description>
@@ -572,7 +564,6 @@
                 <attribute attribute-id="Adyen_notification_user"/>
                 <attribute attribute-id="Adyen_notification_password"/>
 
-                <attribute attribute-id="Adyen_PaypalMerchantID"/>
                 <attribute attribute-id="AdyenPayPalIntent"/>
 
                 <attribute attribute-id="Adyen_GooglePayMerchantID"/>

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyenCheckout.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyenCheckout.js
@@ -50,10 +50,6 @@ if (
     id
   ] = window.googleMerchantID;
 }
-if (window.paypalMerchantID !== 'null') {
-  store.checkoutConfiguration.paymentMethodsConfiguration.paypal.merchantId =
-    window.paypalMerchantID;
-}
 
 // Submit the payment
 $('button[value="submit-payment"]').on('click', () => {

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout/__tests__/__snapshots__/begin.test.js.snap
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout/__tests__/__snapshots__/begin.test.js.snap
@@ -16,7 +16,6 @@ Array [
         "installments": true,
         "merchantAccount": "mocked_merchant_account",
         "paypalIntent": "mocked_intent",
-        "paypalMerchantID": "mocked_paypal_merchant_id",
       },
     },
   ],

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout/begin.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout/begin.js
@@ -11,7 +11,6 @@ function begin(req, res, next) {
   const clientKey = AdyenHelper.getAdyenClientKey();
   const environment = AdyenHelper.getAdyenEnvironment().toLowerCase();
   const installments = AdyenHelper.getCreditCardInstallments();
-  const paypalMerchantID = AdyenHelper.getPaypalMerchantID();
   const amazonMerchantID = AdyenHelper.getAmazonMerchantID();
   const amazonStoreID = AdyenHelper.getAmazonStoreID();
   const adyenClientKey = AdyenHelper.getAdyenClientKey();
@@ -26,7 +25,6 @@ function begin(req, res, next) {
     clientKey,
     environment,
     installments,
-    paypalMerchantID,
     amazonMerchantID,
     amazonStoreID,
     amazonPublicKeyID,

--- a/src/cartridges/int_adyen_SFRA/cartridge/templates/default/checkout/billing/adyenComponentForm.isml
+++ b/src/cartridges/int_adyen_SFRA/cartridge/templates/default/checkout/billing/adyenComponentForm.isml
@@ -56,7 +56,6 @@
 <iselse>
     <script>
          window.installments = '${pdict.adyen.installments}';
-         window.paypalMerchantID = '${pdict.adyen.paypalMerchantID}';
          window.googleMerchantID = '${pdict.adyen.googleMerchantID}';
          window.cardholderNameBool = '${pdict.adyen.cardholderNameBool}';
          window.paypalIntent = '${pdict.adyen.paypalIntent}';

--- a/src/cartridges/int_adyen_controllers/cartridge/js/pages/checkout/adyen-checkout.js
+++ b/src/cartridges/int_adyen_controllers/cartridge/js/pages/checkout/adyen-checkout.js
@@ -237,10 +237,6 @@ function initializeBillingEvents() {
       checkoutConfiguration.paymentMethodsConfiguration.paywithgoogle.configuration.merchantIdentifier =
         window.googleMerchantID;
     }
-    if (window.paypalMerchantID !== 'null') {
-      checkoutConfiguration.paymentMethodsConfiguration.paypal.merchantId =
-        window.paypalMerchantID;
-    }
     if(window.cardholderNameBool !== 'null') {
       checkoutConfiguration.paymentMethodsConfiguration.card.hasHolderName = true;
       checkoutConfiguration.paymentMethodsConfiguration.card.holderNameRequired = true;

--- a/src/cartridges/int_adyen_controllers/cartridge/templates/default/checkout/billing/adyenComponent.isml
+++ b/src/cartridges/int_adyen_controllers/cartridge/templates/default/checkout/billing/adyenComponent.isml
@@ -55,7 +55,6 @@
 <iselse>
     <script>
          window.installments = '${pdict.adyen.installments}';
-         window.paypalMerchantID = '${pdict.adyen.paypalMerchantID}';
          window.googleMerchantID = '${pdict.adyen.googleMerchantID}';
          window.cardholderNameBool = '${pdict.adyen.cardholderNameBool}';
          window.paypalIntent = '${pdict.adyen.paypalIntent}';

--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
@@ -182,10 +182,6 @@ var adyenHelperObj = {
     return adyenHelperObj.getCustomPreference('Adyen_IntegratorName');
   },
 
-  getPaypalMerchantID() {
-    return adyenHelperObj.getCustomPreference('Adyen_PaypalMerchantID');
-  },
-
   getAmazonMerchantID() {
     return adyenHelperObj.getCustomPreference('Adyen_AmazonMerchantID');
   },


### PR DESCRIPTION
## Summary
PayPal Merchant Id has been deleted from the code and from Custom Preferences metadata.
It is no longer required to make succesful PayPal Payments.