### PR TITLE
fixed bug in amazon pay config. moved config to separate function

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGenericComponent.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGenericComponent.js
@@ -96,6 +96,15 @@ function setCheckoutConfiguration(data) {
   };
 }
 
+function setAmazonPayConfig(adyenPaymentMethods) {
+  const amazonpay = adyenPaymentMethods.paymentMethods.find(
+      (paymentMethod) => paymentMethod.type === 'amazonpay',
+  );
+  if(amazonpay) {
+    store.checkoutConfiguration.paymentMethodsConfiguration.amazonpay.configuration = amazonpay.configuration; // eslint-disable-line max-len
+  }
+}
+
 /**
  * Calls getPaymenMethods and then renders the retrieved payment methods (including card component)
  */
@@ -107,10 +116,7 @@ module.exports.renderGenericComponent = async function renderGenericComponent() 
     store.checkoutConfiguration.paymentMethodsResponse =
       data.AdyenPaymentMethods;
     setCheckoutConfiguration(data);
-    const amazonpayConfig = data.AdyenPaymentMethods.paymentMethods.find(
-      (paymentMethod) => paymentMethod.type === 'amazonpay',
-    ).configuration;
-    store.checkoutConfiguration.paymentMethodsConfiguration.amazonpay.configuration = amazonpayConfig; // eslint-disable-line max-len
+    setAmazonPayConfig(data.AdyenPaymentMethods);
     store.checkout = new AdyenCheckout(store.checkoutConfiguration);
 
     document.querySelector('#paymentMethodsList').innerHTML = '';


### PR DESCRIPTION
## Summary
this fixes a bug that causes an error when amazon pay is not one of the retrieved payment methods

