### PR TITLE
PW-5307 Amazon pay didn't work on the 1st click on SFRA

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
@@ -171,18 +171,6 @@ function getAmazonpayConfig() {
     checkoutMode: 'ProcessOrder',
     locale: window.Configuration.locale,
     returnUrl: window.returnURL,
-    addressDetails: {
-      name: `${document.querySelector('#shippingFirstNamedefault').value} ${
-        document.querySelector('#shippingLastNamedefault').value
-      }`,
-      addressLine1: document.querySelector('#shippingFirstNamedefault').value,
-      city: document.querySelector('#shippingAddressCitydefault').value,
-      stateOrRegion: document.querySelector('#shippingAddressCitydefault')
-        .value,
-      postalCode: document.querySelector('#shippingZipCodedefault').value,
-      countryCode: document.querySelector('#shippingCountrydefault').value,
-      phoneNumber: document.querySelector('#shippingPhoneNumberdefault').value,
-    },
     onClick: (resolve, reject) => {
       $('#dwfrm_billing').trigger('submit');
       if (store.formErrorsExist) {

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGenericComponent.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGenericComponent.js
@@ -102,6 +102,18 @@ function setAmazonPayConfig(adyenPaymentMethods) {
   );
   if(amazonpay) {
     store.checkoutConfiguration.paymentMethodsConfiguration.amazonpay.configuration = amazonpay.configuration; // eslint-disable-line max-len
+    store.checkoutConfiguration.paymentMethodsConfiguration.amazonpay.addressDetails = {
+      name: `${document.querySelector('#shippingFirstNamedefault').value} ${
+          document.querySelector('#shippingLastNamedefault').value
+      }`,
+      addressLine1: document.querySelector('#shippingFirstNamedefault').value,
+      city: document.querySelector('#shippingAddressCitydefault').value,
+      stateOrRegion: document.querySelector('#shippingAddressCitydefault')
+          .value,
+      postalCode: document.querySelector('#shippingZipCodedefault').value,
+      countryCode: document.querySelector('#shippingCountrydefault').value,
+      phoneNumber: document.querySelector('#shippingPhoneNumberdefault').value,
+    };
   }
 }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
The component is sometimes being rendered before the billing address details are filled, so then amazon pay will fail due to empty address fields
I've moved the address setter for amazon pay
## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
