### PR TITLE
fix 3ds1 zeroauth response

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/Adyen.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/Adyen.js
@@ -68,7 +68,7 @@ server.post('PaymentsDetails', server.middleware.https, adyen.paymentsDetails);
 /**
  * Redirect to Adyen after 3DS1 Authentication When adding a card to an account
  */
-server.post(
+server.get(
   'Redirect3DS1Response',
   server.middleware.https,
   adyen.redirect3ds1Response,

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/redirect3ds1Response.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/redirect3ds1Response.test.js
@@ -15,7 +15,13 @@ beforeEach(() => {
   };
 
   req = {
-    form: {},
+    httpParameterMap: {
+      get: jest.fn(() => {
+        return {
+          stringValue: 'mockedRedirectresult',
+        };
+      }),
+    }
   };
 });
 
@@ -29,9 +35,8 @@ describe('Redirect 3DS1 Response', () => {
     const adyenCheckout = require('*/cartridge/scripts/adyenCheckout');
     const URLUtils = require('dw/web/URLUtils');
 
-    req.form = {
-      MD: 'MOCK_MD',
-      PaRes: 'MOCK_PaRes'
+    req.querystring = {
+      redirectResult: 'mockedRedirectresult',
     };
 
     adyenCheckout.doPaymentsDetailsCall.mockImplementation(() => ({
@@ -49,9 +54,8 @@ describe('Redirect 3DS1 Response', () => {
     const adyenCheckout = require('*/cartridge/scripts/adyenCheckout');
     const URLUtils = require('dw/web/URLUtils');
 
-    req.form = {
-      MD: 'MOCK_MD',
-      PaRes: 'MOCK_PaRes'
+    req.querystring = {
+      redirectResult: 'mockedRedirectresult',
     };
 
     adyenCheckout.doPaymentsDetailsCall.mockImplementation(() => ({
@@ -65,11 +69,11 @@ describe('Redirect 3DS1 Response', () => {
     expect(URLUtils.url.mock.calls[0]).toEqual(['PaymentInstruments-AddPayment', 'isAuthorised', 'false']);
   });
 
-  it('should handle invalid form/missing form contents.', () => {
+  it('should handle missing querystring contents.', () => {
     const adyenCheckout = require('*/cartridge/scripts/adyenCheckout');
     const URLUtils = require('dw/web/URLUtils');
 
-    req.form = null;
+    req.querystring = null;
 
     adyenCheckout.doPaymentsDetailsCall.mockImplementation(() => ({
       resultCode:'Cancelled',

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/redirect3ds1Response.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/redirect3ds1Response.js
@@ -8,10 +8,11 @@ const constants = require('*/cartridge/adyenConstants/constants');
  */
 function redirect(req, res, next) {
   try {
+    const redirectResult = req.httpParameterMap.get('redirectResult')
+      .stringValue;
     const jsonRequest = {
       details: {
-        MD: req.form?.MD,
-        PaRes: req.form?.PaRes,
+        redirectResult,
       },
     };
     const result = adyenCheckout.doPaymentsDetailsCall(jsonRequest);


### PR DESCRIPTION
## Summary
This issue is caused by the callback from the 3DS1 authentication before and is likely caused by the updated version of the Component.
Previously, we expected a POST call containing a form with an MD and PaRes field.

