### PR TITLE
update component rendering on payment stage

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/checkout/checkout.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/checkout/checkout.js
@@ -19,7 +19,7 @@ module.exports.updateCheckoutView = function updateCheckoutView() {
     const currentStage = window.location.search.substring(
       window.location.search.indexOf('=') + 1,
     );
-    if (currentStage === 'shipping') {
+    if (currentStage === 'shipping' || 'payment') {
       adyenCheckout.methods.renderGenericComponent();
     }
     billingHelpers.methods.updateBillingInformation(


### PR DESCRIPTION
## Summary
Fixes a bug where cc number would be missing from the order overview after editing the payment info.
This is done by re-rendering the payment methods every time the shopper enters the payments screen.
