### PR TITLE
added card-error classes back to account card error screens

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/templates/default/account/payment/paymentForm.isml
+++ b/src/cartridges/int_adyen_SFRA/cartridge/templates/default/account/payment/paymentForm.isml
@@ -21,7 +21,7 @@
             class="payment-form"
             method="POST"
             id="payment-form" ${pdict.paymentForm.attributes}>
-            <div id="cardError" class="alert alert-danger">
+            <div id="cardError" class="card-error alert alert-danger">
                 <span>${Resource.msg('error.card.information.error', 'creditCard', null)}</span>
             </div>
             <script type="text/javascript">

--- a/src/cartridges/int_adyen_SFRA/cartridge/templates/resources/creditCard.properties
+++ b/src/cartridges/int_adyen_SFRA/cartridge/templates/resources/creditCard.properties
@@ -1,3 +1,0 @@
-field.credit.card.holderName=Cardholder name
-load.component.error=Error while loading Secured Fields component
-myAccount.SaveCard=Please add a new payment method by completing an order through the checkout

--- a/src/cartridges/int_adyen_controllers/cartridge/templates/default/account/payment/paymentinstrumentlist.isml
+++ b/src/cartridges/int_adyen_controllers/cartridge/templates/default/account/payment/paymentinstrumentlist.isml
@@ -12,7 +12,7 @@
 			${Resource.msg('account.paymentinstrumentlist.addcard','account',null)}
 		</a>
 
-		<div id="cardError" class="alert alert-danger">
+		<div id="cardError" class="card-error alert alert-danger">
             <span>${Resource.msg('error.card.information.error', 'creditCard', null)}</span>
 		</div>
 

--- a/src/cartridges/int_adyen_overlay/cartridge/static/default/css/adyenCss.css
+++ b/src/cartridges/int_adyen_overlay/cartridge/static/default/css/adyenCss.css
@@ -128,7 +128,6 @@
 }
 
 .card-error {
-    color: red;
     display: none;
 }
 

--- a/src/cartridges/int_adyen_overlay/cartridge/templates/resources/creditCard.properties
+++ b/src/cartridges/int_adyen_overlay/cartridge/templates/resources/creditCard.properties
@@ -1,4 +1,4 @@
 field.credit.card.holderName=Cardholder name
 load.component.error=Error while loading Secured Fields component
 myAccount.SaveCard=Please add a new payment method by completing an order through the checkout
-error.card.information.error=There has been an error verifying the entered credit card information, please try again.
+error.card.information.error=There has been an error whilst verifying the entered credit card information, please try again.

--- a/src/cartridges/int_adyen_overlay/cartridge/templates/resources/creditCard.properties
+++ b/src/cartridges/int_adyen_overlay/cartridge/templates/resources/creditCard.properties
@@ -1,0 +1,4 @@
+field.credit.card.holderName=Cardholder name
+load.component.error=Error while loading Secured Fields component
+myAccount.SaveCard=Please add a new payment method by completing an order through the checkout
+error.card.information.error=There has been an error verifying the entered credit card information, please try again.


### PR DESCRIPTION
## Summary
on SFRA + SG the add card error is no longer shown when adding a new card when it is not supposed to. on SG the default error property string is always shown even when it is not supposed to. Default value for this error is introduced. The grammar of the original message was off, and it was not applied to SG
