### PR TITLE
fix for new 3DS2 simulator

### DIFF
--- a/tests/e2e/pages/PaymentMethodsPage.js
+++ b/tests/e2e/pages/PaymentMethodsPage.js
@@ -91,7 +91,7 @@ export default class PaymentMethodsPage {
         await t
             .switchToIframe('.adyen-checkout__iframe')
             .typeText('.input-field', 'password')
-            .click('.button--primary')
+            .click('button[type="submit"]')
             .switchToMainWindow();
     }
 


### PR DESCRIPTION
## Summary
3DS2 simulator was updated causing the form submission to break. This selector update fixes that.