### PR TITLE
avoid error logging when calling showconfirmation for processed orders

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -67,7 +67,7 @@ module.exports = {
     "complexity": [
       "error",
       {
-        "max": 4,
+        "max": 5,
       },
     ],
     "eqeqeq": "error",

--- a/jest/__mocks__/dw/system/Logger.js
+++ b/jest/__mocks__/dw/system/Logger.js
@@ -1,4 +1,6 @@
 export const error = jest.fn((message) => `${name}: ${message}`);
+export const debug = jest.fn((message) => `${name}: ${message}`);
 export const getLogger = jest.fn((name) => ({
   error,
+  debug,
 }));

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/showConfirmation.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/showConfirmation.test.js
@@ -17,7 +17,7 @@ beforeEach(() => {
 
   req = {
     querystring: {
-      merchantReference: 'mocked_merchantReference',
+      merchantReference: 0,
       signature: 'mocked_signature',
     },
     locale: { id: 'nl_NL' },
@@ -51,6 +51,13 @@ describe('Show Confirmation', () => {
       const adyenCheckout = require('*/cartridge/scripts/adyenCheckout');
       showConfirmation(req, res, jest.fn());
       expect(URLUtils.url.mock.calls[0][0]).toEqual('Error-ErrorCode');
+  })
+
+  it('should not continue processing when order is not open or failed', () => {
+    const URLUtils = require('dw/web/URLUtils');
+    req.querystring.merchantReference = 4;
+    showConfirmation(req, res, jest.fn());
+    expect(URLUtils.url.mock.calls[0][0]).toEqual('Cart-Show');
   })
 
   test.each(['Authorised', 'Pending', 'Received'])(

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmation.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmation.js
@@ -88,6 +88,15 @@ function showConfirmation(req, res, next) {
     const adyenPaymentInstrument = order.getPaymentInstruments(
       constants.METHOD_ADYEN_COMPONENT,
     )[0];
+
+    if (order.status.value === Order.ORDER_STATUS_NEW) {
+      Logger.getLogger('Adyen').debug(
+        'ShowConfirmation called for an order which has already been processed. This is likely to be caused by shoppers using the back button after order confirmation',
+      );
+      res.redirect(URLUtils.url('Cart-Show'));
+      return next();
+    }
+
     if (
       adyenPaymentInstrument.paymentTransaction.custom.Adyen_merchantSig ===
       signature

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmation.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmation.js
@@ -73,8 +73,8 @@ function setPaymentMethodField(adyenPaymentInstrument, order) {
 
 function isOrderAlreadyProcessed(order) {
   return (
-    order.status.value !==
-    (Order.ORDER_STATUS_CREATED && Order.ORDER_STATUS_FAILED)
+    order.status.value !== Order.ORDER_STATUS_CREATED &&
+    order.status.value !== Order.ORDER_STATUS_FAILED
   );
 }
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmation.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmation.js
@@ -71,6 +71,13 @@ function setPaymentMethodField(adyenPaymentInstrument, order) {
   }
 }
 
+function isOrderAlreadyProcessed(order) {
+  return (
+    order.status.value !==
+    (Order.ORDER_STATUS_CREATED && Order.ORDER_STATUS_FAILED)
+  );
+}
+
 /*
  * Makes a payment details call to Adyen and calls for the order confirmation to be shown
  * if the payment was accepted.
@@ -89,7 +96,7 @@ function showConfirmation(req, res, next) {
       constants.METHOD_ADYEN_COMPONENT,
     )[0];
 
-    if (order.status.value === Order.ORDER_STATUS_NEW) {
+    if (isOrderAlreadyProcessed(order)) {
       Logger.getLogger('Adyen').debug(
         'ShowConfirmation called for an order which has already been processed. This is likely to be caused by shoppers using the back button after order confirmation',
       );


### PR DESCRIPTION
## Summary
avoid error logging when calling showconfirmation for processed orders

## Tested scenarios
Tested by going back after Klarna, Ideal, 3ds1 cards. 3ds2 cards (does not trigger this functionality).


**Fixed issue**:  (https://github.com/SalesforceCommerceCloud/link_adyen/issues/89)
