### PR TITLE
fix paypal spinner bug when backend times out

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/helpers.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/helpers.js
@@ -30,7 +30,7 @@ function paymentFromComponent(data, component) {
       if (response.fullResponse?.action) {
         component.handleAction(response.fullResponse.action);
       }
-      if (response.paymentError) {
+      if (response.paymentError || response.error) {
         component.handleError();
       }
     },


### PR DESCRIPTION
## Summary
Fix bug where paypal popup spinner would spin indefinitely when Adyen times out in backend.
