### PR TITLE
move session request to own file and add asynchronousness. + fix edge…

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyenAccount.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyenAccount.js
@@ -1,8 +1,4 @@
-const {
-  onFieldValid,
-  onBrand,
-  createSession,
-} = require('./commons/index');
+const { onFieldValid, onBrand, createSession } = require('./commons/index');
 const store = require('../../../store');
 
 let checkout;

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyenAccount.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyenAccount.js
@@ -1,4 +1,8 @@
-const { onFieldValid, onBrand } = require('./commons/index');
+const {
+  onFieldValid,
+  onBrand,
+  createSession,
+} = require('./commons/index');
 const store = require('../../../store');
 
 let checkout;
@@ -9,6 +13,7 @@ store.checkoutConfiguration.amount = {
   value: 0,
   currency: 'EUR',
 };
+
 store.checkoutConfiguration.paymentMethodsConfiguration = {
   card: {
     enableStoreDetails: false,
@@ -51,30 +56,16 @@ store.checkoutConfiguration.onAdditionalDetails = (state) => {
   });
 };
 
-/**
- * Makes an ajax call to the controller function CreateSession
- */
-function createSession(session) {
-  $.ajax({
-    url: window.sessionsUrl,
-    type: 'get',
-    success(data) {
-      session(data);
-    },
-  });
-}
-
 async function initializeCardComponent() {
   // card and checkout component creation
-  createSession(async (session) => {
-    store.checkoutConfiguration.session = {
-      id: session.id,
-      sessionData: session.sessionData,
-    };
-    const cardNode = document.getElementById('card');
-    checkout = await AdyenCheckout(store.checkoutConfiguration);
-    card = checkout.create('card').mount(cardNode);
-  });
+  const session = await createSession();
+  store.checkoutConfiguration.session = {
+    id: session.id,
+    sessionData: session.sessionData,
+  };
+  const cardNode = document.getElementById('card');
+  checkout = await AdyenCheckout(store.checkoutConfiguration);
+  card = checkout.create('card').mount(cardNode);
 }
 
 let formErrorsExist = false;

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/commons/index.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/commons/index.js
@@ -10,3 +10,13 @@ module.exports.onFieldValid = function onFieldValid(data) {
 module.exports.onBrand = function onBrand(brandObject) {
   document.querySelector('#cardType').value = brandObject.brand;
 };
+
+/**
+ * Makes an ajax call to the controller function CreateSession
+ */
+module.exports.createSession = async function() {
+   return $.ajax({
+    url: 'Adyen-Sessions',
+    type: 'get',
+});
+}

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/commons/index.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/commons/index.js
@@ -14,9 +14,9 @@ module.exports.onBrand = function onBrand(brandObject) {
 /**
  * Makes an ajax call to the controller function CreateSession
  */
-module.exports.createSession = async function() {
-   return $.ajax({
+module.exports.createSession = async function createSession() {
+  return $.ajax({
     url: 'Adyen-Sessions',
     type: 'get',
-});
-}
+  });
+};

--- a/src/cartridges/int_adyen_SFRA/cartridge/templates/default/checkout/billing/adyenComponentForm.isml
+++ b/src/cartridges/int_adyen_SFRA/cartridge/templates/default/checkout/billing/adyenComponentForm.isml
@@ -45,7 +45,6 @@
          window.cardholderNameBool = '${pdict.adyen.cardholderNameBool}';
          window.merchantAccount = '${pdict.adyen.merchantAccount}';
          var showStoreDetails = ${customer.authenticated && adyenRecurringPaymentsEnabled};
-         window.sessionsUrl = "${URLUtils.https('Adyen-Sessions')}";
      </script>
 
      <isset name="AdyenHelper" value="${require('*/cartridge/scripts/util/adyenHelper')}" scope="pdict"/>

--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
@@ -323,7 +323,7 @@ var adyenHelperObj = {
       gender = args.paymentRequest.shopperName.gender;
     }
 
-    if (args.order.getDefaultShipment().getShippingAddress().getPhone()) {
+    if (args.order?.getDefaultShipment()?.getShippingAddress()?.getPhone()) {
       args.paymentRequest.telephoneNumber = args.order
           .getDefaultShipment()
           .getShippingAddress()
@@ -345,10 +345,10 @@ var adyenHelperObj = {
 
     const address = args.order.getBillingAddress() || args.order.getDefaultShipment().getShippingAddress();
     const shopperDetails = {
-      firstName: address.firstName,
+      firstName: address?.firstName,
       gender,
       infix: '',
-      lastName: address.lastName,
+      lastName: address?.lastName,
     };
     args.paymentRequest.shopperName = shopperDetails;
 


### PR DESCRIPTION
## Summary
- Session creation on frontend is moved to separate async function.
- AdyenHelper now takes in account baskets without address attached to it.

## Tested scenarios
Log in. fill + empty basket. Then try to add a card through `My account`. This used to break because AdyenHelper assumed there would be an address attached to the empty cart.
