### PR TITLE
Add orderToken to order retrieval for SFRA

### DIFF
--- a/jest/__mocks__/dw/order/Order.js
+++ b/jest/__mocks__/dw/order/Order.js
@@ -1,2 +1,2 @@
-export const ORDER_STATUS_FAILED = 8;
-export const ORDER_STATUS_CREATED = 0;
+export const ORDER_STATUS_FAILED = '8';
+export const ORDER_STATUS_CREATED = '0';

--- a/jest/__mocks__/dw/order/OrderMgr.js
+++ b/jest/__mocks__/dw/order/OrderMgr.js
@@ -38,7 +38,7 @@ export const getPaymentInstruments = jest.fn(() => ({
 
 
 
-export const getOrder = jest.fn((statusValue=4/* orderNo */) => ({
+export const getOrder = jest.fn((statusValue="4"/* orderNo */) => ({
   getPaymentInstruments,
   setPaymentStatus: jest.fn(),
   setExportStatus: jest.fn(),

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyenAccount.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyenAccount.js
@@ -35,7 +35,7 @@ store.checkoutConfiguration.onAdditionalDetails = (state) => {
   $.ajax({
     type: 'POST',
     url: 'Adyen-PaymentsDetails',
-    data: JSON.stringify(state.data),
+    data: JSON.stringify({ data: state.data }),
     contentType: 'application/json; charset=utf-8',
     async: false,
     success(data) {

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
@@ -4,7 +4,7 @@ const store = require('../../../../store');
 
 function getCardConfig() {
   return {
-    enableStoreDetails: showStoreDetails,
+    enableStoreDetails: window.showStoreDetails,
     onChange(state) {
       store.isValid = state.isValid;
       const method = state.data.paymentMethod.storedPaymentMethodId

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
@@ -37,6 +37,7 @@ function getPaypalConfig() {
         {
           cancelTransaction: true,
           merchantReference: document.querySelector('#merchantReference').value,
+          orderToken: document.querySelector('#orderToken').value,
         },
         component,
       );

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
@@ -113,7 +113,10 @@ function handleOnAdditionalDetails(state) {
   $.ajax({
     type: 'POST',
     url: 'Adyen-PaymentsDetails',
-    data: JSON.stringify(state.data),
+    data: JSON.stringify({
+      data: state.data,
+      orderToken: window.orderToken,
+    }),
     contentType: 'application/json; charset=utf-8',
     async: false,
     success(data) {

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/helpers.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/helpers.js
@@ -11,6 +11,15 @@ function assignPaymentMethodValue() {
   ).innerHTML;
 }
 
+function assignOrderFormValues(response) {
+  if (response.orderNo) {
+    document.querySelector('#merchantReference').value = response.orderNo;
+  }
+  if (response.orderToken) {
+    document.querySelector('#orderToken').value = response.orderToken;
+  }
+}
+
 /**
  * Makes an ajax call to the controller function PaymentFromComponent.
  * Used by certain payment methods like paypal
@@ -24,9 +33,8 @@ function paymentFromComponent(data, component) {
       paymentMethod: document.querySelector('#adyenPaymentMethodName').value,
     },
     success(response) {
-      if (response.orderNo) {
-        document.querySelector('#merchantReference').value = response.orderNo;
-      }
+      assignOrderFormValues(response);
+
       if (response.fullResponse?.action) {
         component.handleAction(response.fullResponse.action);
       }
@@ -105,6 +113,7 @@ function createShowConfirmationForm(action) {
   const form = `<form method="post" id="showConfirmationForm" name="showConfirmationForm" action="${action}">
     <input type="hidden" id="additionalDetailsHidden" name="additionalDetailsHidden" value="null"/>
     <input type="hidden" id="merchantReference" name="merchantReference"/>
+    <input type="hidden" id="orderToken" name="orderToken"/>
     <input type="hidden" id="result" name="result" value="null"/>
   </form>`;
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/helpers.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/helpers.js
@@ -122,6 +122,7 @@ function createShowConfirmationForm(action) {
 }
 
 module.exports = {
+  assignOrderFormValues,
   assignPaymentMethodValue,
   paymentFromComponent,
   resetPaymentMethod,

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/helpers.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/helpers.js
@@ -11,7 +11,7 @@ function assignPaymentMethodValue() {
   ).innerHTML;
 }
 
-function assignOrderFormValues(response) {
+function setOrderFormData(response) {
   if (response.orderNo) {
     document.querySelector('#merchantReference').value = response.orderNo;
   }
@@ -33,7 +33,7 @@ function paymentFromComponent(data, component) {
       paymentMethod: document.querySelector('#adyenPaymentMethodName').value,
     },
     success(response) {
-      assignOrderFormValues(response);
+      setOrderFormData(response);
 
       if (response.fullResponse?.action) {
         component.handleAction(response.fullResponse.action);
@@ -92,7 +92,7 @@ function doCustomValidation() {
 }
 
 function showValidation() {
-  return store.selectedPaymentIsValid
+  return store.selectedPaymentIsValid 
     ? doCustomValidation()
     : displayValidationErrors();
 }
@@ -122,7 +122,7 @@ function createShowConfirmationForm(action) {
 }
 
 module.exports = {
-  assignOrderFormValues,
+  setOrderFormData,
   assignPaymentMethodValue,
   paymentFromComponent,
   resetPaymentMethod,

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/helpers.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/helpers.js
@@ -92,7 +92,7 @@ function doCustomValidation() {
 }
 
 function showValidation() {
-  return store.selectedPaymentIsValid 
+  return store.selectedPaymentIsValid
     ? doCustomValidation()
     : displayValidationErrors();
 }

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazon.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazon.js
@@ -43,7 +43,7 @@ function paymentFromComponent(data, component) {
       orderToken: document.querySelector('#orderToken').value,
     },
     success(response) {
-      helpers.assignOrderFormValues(response);
+      helpers.setOrderFormData(response);
       handleAmazonResponse(response, component);
     },
   });

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazon.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazon.js
@@ -39,6 +39,8 @@ function paymentFromComponent(data, component) {
     data: {
       data: JSON.stringify(data),
       paymentMethod: 'amazonpay',
+      merchantReference: document.querySelector('#merchantReference').value,
+      orderToken: document.querySelector('#orderToken').value,
     },
     success(response) {
       helpers.assignOrderFormValues(response);

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazon.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazon.js
@@ -41,9 +41,7 @@ function paymentFromComponent(data, component) {
       paymentMethod: 'amazonpay',
     },
     success(response) {
-      if (response.orderNo) {
-        document.querySelector('#merchantReference').value = response.orderNo;
-      }
+      helpers.assignOrderFormValues(response);
       handleAmazonResponse(response, component);
     },
   });
@@ -76,7 +74,10 @@ async function mountAmazonPayComponent() {
       $.ajax({
         type: 'post',
         url: window.paymentsDetailsURL,
-        data: JSON.stringify(state.data),
+        data: JSON.stringify({
+          data: state.data,
+          orderToken: window.orderToken,
+        }),
         contentType: 'application/json; charset=utf-8',
         success(data) {
           if (data.isSuccessful) {

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/checkout/checkoutSFRA5.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/checkout/checkoutSFRA5.js
@@ -330,6 +330,7 @@ var adyenCheckout = require('../adyenCheckout');
                                 }
                                 // ### Custom Adyen cartridge start ###
                             } else if (data.adyenAction) {
+                                window.orderToken = data.orderToken;
                                 adyenCheckout.actionHandler(data.adyenAction);
                                 // ### Custom Adyen cartridge end ###
                             } else {

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/checkout/checkoutSFRA6.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/checkout/checkoutSFRA6.js
@@ -362,6 +362,7 @@ const adyenCheckout = require('../adyenCheckout');
                 }
                 // ### Custom Adyen cartridge start ###
               } else if (data.adyenAction) {
+                window.orderToken = data.orderToken;
                 adyenCheckout.actionHandler(data.adyenAction);
                 // ### Custom Adyen cartridge end ###
               } else {

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/__snapshots__/paymentFromComponent.test.js.snap
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/__snapshots__/paymentFromComponent.test.js.snap
@@ -15,6 +15,7 @@ Array [
   Array [
     Object {
       "orderNo": "mocked_orderNo",
+      "orderToken": "mocked_orderToken",
       "resultCode": "Authorised",
     },
   ],

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/paymentsDetails.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/paymentsDetails.test.js
@@ -50,6 +50,7 @@ describe('Confirm paymentsDetails', () => {
     const adyenCheckout = require('*/cartridge/scripts/adyenCheckout');
     const AdyenHelper = require('*/cartridge/scripts/util/adyenHelper');
 
+    adyenCheckout.doPaymentsDetailsCall.mockImplementationOnce(() => { return {}; });
     AdyenHelper.createAdyenCheckoutResponse.mockImplementationOnce(() => {throw new Error('mock_error')});
     paymentsDetails(req, res, jest.fn());
     expect(adyenCheckout.doPaymentsDetailsCall.mock.calls.length).toEqual(1);
@@ -75,7 +76,7 @@ describe('Confirm paymentsDetails', () => {
     expect(res.json.mock.calls[0][0]).toEqual({
       isFinal: true,
       isSuccessful: false,
-      redirectUrl:"[\"Adyen-ShowConfirmation\",\"merchantReference\",null,\"signature\",\"mocked_signature\"]",
+      redirectUrl: "[\"Adyen-ShowConfirmation\",\"merchantReference\",null,\"signature\",\"mocked_signature\",\"orderToken\",null]"
     });
   });
 });

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/showConfirmation.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/showConfirmation.test.js
@@ -17,7 +17,7 @@ beforeEach(() => {
 
   req = {
     querystring: {
-      merchantReference: 0,
+      merchantReference: "0",
       signature: 'mocked_signature',
     },
     locale: { id: 'nl_NL' },

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/paymentFromComponent.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/paymentFromComponent.js
@@ -19,7 +19,10 @@ function paymentFromComponent(req, res, next) {
       `Shopper cancelled paymentFromComponent transaction for order ${reqDataObj.merchantReference}`,
     );
 
-    const order = OrderMgr.getOrder(reqDataObj.merchantReference);
+    const order = OrderMgr.getOrder(
+      reqDataObj.merchantReference,
+      reqDataObj.orderToken,
+    );
     Transaction.wrap(() => {
       OrderMgr.failOrder(order, true);
     });
@@ -69,6 +72,7 @@ function paymentFromComponent(req, res, next) {
   }
 
   result.orderNo = order.orderNo;
+  result.orderToken = order.orderToken;
   res.json(result);
   return next();
 }

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmation.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmation.js
@@ -89,9 +89,10 @@ function showConfirmation(req, res, next) {
     payload,
     signature,
     merchantReference,
+    orderToken,
   } = req.querystring;
   try {
-    const order = OrderMgr.getOrder(merchantReference);
+    const order = OrderMgr.getOrder(merchantReference, orderToken);
     const adyenPaymentInstrument = order.getPaymentInstruments(
       constants.METHOD_ADYEN_COMPONENT,
     )[0];

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmationPaymentFromComponent.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmationPaymentFromComponent.js
@@ -10,7 +10,10 @@ function showConfirmationPaymentFromComponent(req, res, next) {
   const options = { req, res, next };
   try {
     const stateData = JSON.parse(req.form.additionalDetailsHidden);
-    const order = OrderMgr.getOrder(req.form.merchantReference);
+    const order = OrderMgr.getOrder(
+      req.form.merchantReference,
+      req.form.orderToken,
+    );
     return handlePayment(stateData, order, options);
   } catch (e) {
     Logger.getLogger('Adyen').error(

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout/__tests__/begin.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout/__tests__/begin.test.js
@@ -40,13 +40,13 @@ describe('Begin', () => {
 
   it('should not attempt to restore cart when cart is not empty', () => {
     req.session.privacyCache.get.mockImplementationOnce(() =>{ return '12312' });
-    OrderMgr.status = { value: 0};
+    OrderMgr.status = { value: "0"};
     begin(req, res, jest.fn());
     expect(Transaction.wrap).not.toHaveBeenCalled();
   })
 
   it('should successfully restore cart when current cart is empty and order number is in cache', () => {
-    req.session.privacyCache.get.mockImplementationOnce(() =>{ return 0 });
+    req.session.privacyCache.get.mockImplementationOnce(() =>{ return "0" });
     BasketMgr.getAllProductLineItems.mockImplementationOnce(() =>{ return []; });
     begin(req, res, jest.fn());
     expect(Transaction.wrap).toHaveBeenCalled();

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout/begin.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout/begin.js
@@ -9,7 +9,7 @@ const { updateSavedCards } = require('*/cartridge/scripts/updateSavedCards');
 
 function shouldRestoreBasket(cachedOrderNumber) {
   // restore cart if order number was cached
-  if (cachedOrderNumber !== undefined && cachedOrderNumber !== null) {
+  if (cachedOrderNumber) {
     const currentBasket = BasketMgr.getCurrentBasket();
     // check if cart is null or empty
     if (!currentBasket || currentBasket.getAllProductLineItems().length === 0) {

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout/begin.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout/begin.js
@@ -9,7 +9,7 @@ const { updateSavedCards } = require('*/cartridge/scripts/updateSavedCards');
 
 function shouldRestoreBasket(cachedOrderNumber) {
   // restore cart if order number was cached
-  if (cachedOrderNumber !== undefined) {
+  if (cachedOrderNumber !== undefined && cachedOrderNumber !== null) {
     const currentBasket = BasketMgr.getCurrentBasket();
     // check if cart is null or empty
     if (!currentBasket || currentBasket.getAllProductLineItems().length === 0) {

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout/begin.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout/begin.js
@@ -19,9 +19,9 @@ function shouldRestoreBasket(cachedOrderNumber) {
   return false;
 }
 
-function restoreBasket(cachedOrderNumber) {
+function restoreBasket(cachedOrderNumber, cachedOrderToken) {
   try {
-    const currentOrder = OrderMgr.getOrder(cachedOrderNumber);
+    const currentOrder = OrderMgr.getOrder(cachedOrderNumber, cachedOrderToken);
     // if order status is CREATED we can fail it and restore basket
     if (currentOrder.status.value === Order.ORDER_STATUS_CREATED) {
       Transaction.wrap(() => {
@@ -46,8 +46,9 @@ function begin(req, res, next) {
   }
 
   const cachedOrderNumber = req.session.privacyCache.get('currentOrderNumber');
+  const cachedOrderToken = req.session.privacyCache.get('currentOrderToken');
   if (shouldRestoreBasket(cachedOrderNumber)) {
-    if (restoreBasket(cachedOrderNumber)) {
+    if (restoreBasket(cachedOrderNumber, cachedOrderToken)) {
       const emit = (route) => this.emit(route, req, res);
       res.redirect(URLUtils.url('Checkout-Begin', 'stage', 'shipping'));
       emit('route:Complete');

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/__tests__/placeOrder.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/__tests__/placeOrder.test.js
@@ -43,5 +43,7 @@ describe('Checkout Services', () => {
     placeOrder.call({ emit: jest.fn() }, req, res, jest.fn());
     expect(req.session.privacyCache.set.mock.calls[0][0]).toBe('currentOrderNumber');
     expect(req.session.privacyCache.set.mock.calls[0][1]).toBe('mocked_orderNo');
+    expect(req.session.privacyCache.set.mock.calls[1][0]).toBe('currentOrderToken');
+    expect(req.session.privacyCache.set.mock.calls[1][1]).toBe('mocked_orderToken');
   });
 });

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/placeOrder.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/placeOrder.js
@@ -135,9 +135,10 @@ function placeOrder(req, res, next) {
     /* ### Custom Adyen cartridge start ### */
     // Cache order number in order to be able to restore cart later
     req.session.privacyCache.set('currentOrderNumber', order.orderNo);
+    req.session.privacyCache.set('currentOrderToken', order.orderToken);
 
     // Handles payment authorization
-    var handlePaymentResult = adyenHelpers.handlePayments(order, order.orderNo);
+    var handlePaymentResult = adyenHelpers.handlePayments(order);
     /* ### Custom Adyen cartridge end ### */
 
     // Handle custom processing post authorization

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/order/__tests__/confirm.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/order/__tests__/confirm.test.js
@@ -8,7 +8,7 @@ beforeEach(() => {
   confirm = order.confirm;
   jest.clearAllMocks();
   res = { setViewData: jest.fn(), getViewData: jest.fn(() => ({})) };
-  req = { querystring: { ID: 'mocked_querystring_id' } };
+  req = { querystring: { ID: 'mocked_querystring_id', token: 'mocked_token' } };
 });
 
 afterEach(() => {

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/order/confirm.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/order/confirm.js
@@ -2,10 +2,16 @@ const OrderMgr = require('dw/order/OrderMgr');
 const AdyenHelper = require('*/cartridge/scripts/util/adyenHelper');
 const AdyenConfigs = require('*/cartridge/scripts/util/adyenConfigs');
 
-// order-confirm is POST in SFRA v6.0.0. orderID is contained in form.
-// This was a GET call with a querystring containing ID in earlier versions.
+// order-confirm is POST in SFRA v6.0.0. orderID and orderToken are contained in form.
+// This was a GET call with a querystring containing ID & token in earlier versions.
 function getOrderId(req) {
   return req.form && req.form.orderID ? req.form.orderID : req.querystring.ID;
+}
+
+function getOrderToken(req) {
+  return req.form && req.form.orderToken
+    ? req.form.orderToken
+    : req.querystring.token;
 }
 
 function handleAdyenGiving(req, res, order) {
@@ -40,8 +46,9 @@ function handleAdyenGiving(req, res, order) {
 
 function confirm(req, res, next) {
   const orderId = getOrderId(req);
-  if (orderId) {
-    const order = OrderMgr.getOrder(orderId);
+  const orderToken = getOrderToken(req);
+  if (orderId && orderToken) {
+    const order = OrderMgr.getOrder(orderId, orderToken);
     const paymentMethod = order.custom.Adyen_paymentMethod;
 
     if (

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/checkout/__tests__/adyenHelpers.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/checkout/__tests__/adyenHelpers.test.js
@@ -32,13 +32,13 @@ describe('Adyen Helpers', () => {
   describe('Handle Payments', () => {
     it('should return when totalNetPrice is 0.0', () => {
       order.totalNetPrice = 0.0;
-      const handlePaymentsResult = handlePayments(order, orderNumber);
+      const handlePaymentsResult = handlePayments(order);
       expect(handlePaymentsResult).toEqual({});
     });
 
     it('should return error if there are no paymentInstruments', () => {
       order.paymentInstruments = [];
-      const handlePaymentsResult = handlePayments(order, orderNumber);
+      const handlePaymentsResult = handlePayments(order);
       expect(handlePaymentsResult.error).toBeTruthy();
     });
   });

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/checkout/adyenHelpers.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/checkout/adyenHelpers.js
@@ -8,13 +8,13 @@ const { getPayments } = require('*/cartridge/scripts/checkout/utils/index');
  * @param {string} orderNumber - The order number for the order
  * @returns {Object} an error object
  */
-function handlePayments(order, orderNumber) {
+function handlePayments(order) {
   if (order.totalNetPrice === 0.0) {
     return {};
   }
 
   if (order.paymentInstruments.length) {
-    return getPayments(order, orderNumber);
+    return getPayments(order);
   }
 
   Transaction.wrap(() => {

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/hooks/payment/processor/adyen_component.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/hooks/payment/processor/adyen_component.js
@@ -16,12 +16,8 @@ function Handle(basket, paymentInformation) {
  *      payment method
  * @return {Object} returns an error object
  */
-function Authorize(orderNumber, paymentInstrument, paymentProcessor) {
-  return middlewares.authorize(
-    orderNumber,
-    paymentInstrument,
-    paymentProcessor,
-  );
+function Authorize(order, paymentInstrument, paymentProcessor) {
+  return middlewares.authorize(order, paymentInstrument, paymentProcessor);
 }
 
 exports.Handle = Handle;

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/hooks/payment/processor/adyen_pos.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/hooks/payment/processor/adyen_pos.js
@@ -7,12 +7,8 @@ function Handle(basket) {
 /**
  * Authorize
  */
-function Authorize(orderNumber, paymentInstrument, paymentProcessor) {
-  return middlewares.posAuthorize(
-    orderNumber,
-    paymentInstrument,
-    paymentProcessor,
-  );
+function Authorize(order, paymentInstrument, paymentProcessor) {
+  return middlewares.posAuthorize(order, paymentInstrument, paymentProcessor);
 }
 
 exports.Handle = Handle;

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/hooks/payment/processor/middlewares/authorize.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/hooks/payment/processor/middlewares/authorize.js
@@ -1,7 +1,6 @@
 const Resource = require('dw/web/Resource');
 const Logger = require('dw/system/Logger');
 const Transaction = require('dw/system/Transaction');
-const OrderMgr = require('dw/order/OrderMgr');
 const AdyenHelper = require('*/cartridge/scripts/util/adyenHelper');
 const adyenCheckout = require('*/cartridge/scripts/adyenCheckout');
 
@@ -29,15 +28,13 @@ function paymentErrorHandler(result) {
 /**
  * Authorizes a payment using a credit card. Customizations may use other processors and custom
  *      logic to authorize credit card payment.
- * @param {number} orderNumber - The current order's number
+ * @param {dw.order.Order} order - The current order
  * @param {dw.order.PaymentInstrument} paymentInstrument -  The payment instrument to authorize
  * @param {dw.order.PaymentProcessor} paymentProcessor -  The payment processor of the current
  *      payment method
  * @return {Object} returns an error object
  */
-function authorize(orderNumber, paymentInstrument, paymentProcessor) {
-  const order = OrderMgr.getOrder(orderNumber);
-
+function authorize(order, paymentInstrument, paymentProcessor) {
   Transaction.wrap(() => {
     paymentInstrument.paymentTransaction.paymentProcessor = paymentProcessor;
   });

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/hooks/payment/processor/middlewares/posAuthorize.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/hooks/payment/processor/middlewares/posAuthorize.js
@@ -2,20 +2,18 @@ const server = require('server');
 const Resource = require('dw/web/Resource');
 const Transaction = require('dw/system/Transaction');
 const Logger = require('dw/system/Logger');
-const OrderMgr = require('dw/order/OrderMgr');
 const adyenTerminalApi = require('*/cartridge/scripts/adyenTerminalApi');
 
 /**
  * Authorize
  */
-function posAuthorize(orderNumber, paymentInstrument, paymentProcessor) {
+function posAuthorize(order, paymentInstrument, paymentProcessor) {
   Transaction.wrap(() => {
-    paymentInstrument.paymentTransaction.transactionID = orderNumber;
+    paymentInstrument.paymentTransaction.transactionID = order.orderNo;
     paymentInstrument.paymentTransaction.paymentProcessor = paymentProcessor;
   });
 
   const adyenPaymentForm = server.forms.getForm('billing').adyenPaymentFields;
-  const order = OrderMgr.getOrder(orderNumber);
   const terminalId = adyenPaymentForm.terminalId.value;
 
   if (!terminalId) {

--- a/src/cartridges/int_adyen_SFRA/cartridge/templates/default/checkout/billing/adyenComponentForm.isml
+++ b/src/cartridges/int_adyen_SFRA/cartridge/templates/default/checkout/billing/adyenComponentForm.isml
@@ -44,7 +44,7 @@
          window.googleMerchantID = '${pdict.adyen.googleMerchantID}';
          window.cardholderNameBool = '${pdict.adyen.cardholderNameBool}';
          window.merchantAccount = '${pdict.adyen.merchantAccount}';
-         var showStoreDetails = ${customer.authenticated && adyenRecurringPaymentsEnabled};
+         window.showStoreDetails = ${customer.authenticated && adyenRecurringPaymentsEnabled};
          window.sessionsUrl = "${URLUtils.https('Adyen-Sessions')}";
      </script>
 

--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
@@ -446,8 +446,10 @@ var adyenHelperObj = {
     const filteredJson = adyenHelperObj.validateStateData(jsonObject);
     const { stateData } = filteredJson;
     let reference = 'recurringPayment-account';
+    let orderToken = 'recurringPayment-token'
     if (order && order.getOrderNo()) {
       reference = order.getOrderNo();
+      orderToken = order.getOrderToken();
     }
 
     let signature = '';
@@ -470,7 +472,9 @@ var adyenHelperObj = {
         'merchantReference',
         reference,
         'signature',
-        signature
+        signature,
+        'orderToken',
+        orderToken,
     ).toString();
     stateData.applicationInfo = adyenHelperObj.getApplicationInfo();
 


### PR DESCRIPTION
## Summary
Update `OrderMgr.getOrder()` to always contain the orderToken when retrieving an order.
