### PR TITLE
Pw 6322/fix rounding errors

### DIFF
--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/adyenGetOpenInvoiceData.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/adyenGetOpenInvoiceData.js
@@ -55,11 +55,13 @@ function getLineItems({ Order: order, Basket: basket, addTaxPercentage }) {
       const vatAmount = LineItemHelper.getVatAmount(lineItem).divide(quantity);
       const vatPercentage = LineItemHelper.getVatPercentage(lineItem);
 
-      lineItemObject.amountExcludingTax = itemAmount.getValue().toFixed();
-      lineItemObject.taxAmount = vatAmount.getValue().toFixed();
-      lineItemObject.description = description;
+      lineItemObject.amountExcludingTax = (Math.floor(quantity * itemAmount.getValue())).toFixed();
+      lineItemObject.taxAmount = (Math.ceil(quantity * vatAmount.getValue())).toFixed();
+
+      const quantityDescription = quantity > 1 ? `${quantity}x `: '';
+      lineItemObject.description = `${quantityDescription}${description}`;
       lineItemObject.id = id;
-      lineItemObject.quantity = quantity;
+      lineItemObject.quantity = 1;
       lineItemObject.taxCategory = 'None';
       lineItemObject.taxPercentage = addTaxPercentage ? (
           new Number(vatPercentage) * 10000

--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/util/lineItemHelper.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/util/lineItemHelper.js
@@ -71,6 +71,10 @@ const __LineItemHelper = {
     return vatPercentage;
   },
 
+  getOriginalVatAmount(lineItem) {
+    return AdyenHelper.getCurrencyValueForApi(lineItem.tax);
+  },
+
   getVatAmount(lineItem) {
     if (
       lineItem instanceof dw.order.ProductLineItem ||
@@ -96,6 +100,10 @@ const __LineItemHelper = {
     }
     return new dw.value.Money(0, lineItem.getPrice().getCurrencyCode());
   },
+
+  getOriginalItemAmount(lineItem) {
+    return AdyenHelper.getCurrencyValueForApi(lineItem.netPrice);
+  }
 };
 
 module.exports = __LineItemHelper;


### PR DESCRIPTION
## Summary
This fix introduces discount lines for discounted items in order to prevent half cents from being sent to checkout API lineitems.
It also rounds price and tax up/down to again prevent the half-cent issue.

