### PR TITLE
[PW-7007] Use MacOS runners for E2E tests

### DIFF
--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -3,7 +3,7 @@ name: E2E
 on: [push]
 
 jobs:
-  end-to-end-testing:
+  setup-the-cartridge:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -49,6 +49,43 @@ jobs:
       - name: push cartridge code
         working-directory: adyen-salesforce-commerce-cloud
         run: npm run build
+      - name: install e2e test dependencies
+        working-directory: adyen-salesforce-commerce-cloud/tests/playwright/
+        run: npm i
+      - name: setup playwright dependencies
+        working-directory: adyen-salesforce-commerce-cloud/tests/playwright/
+        run: npx playwright install --with-deps
+      - name: run e2e tests
+        working-directory: adyen-salesforce-commerce-cloud/tests/playwright/
+        run: npm run test:ci
+        env:
+          SANDBOX_HTTP_AUTH_USERNAME: ${{ secrets.SANDBOX_HTTP_AUTH_USERNAME }}
+          SANDBOX_HTTP_AUTH_PASSWORD: ${{ secrets.SANDBOX_HTTP_AUTH_PASSWORD }}
+          PAYPAL_USERNAME: ${{ secrets.PAYPAL_USERNAME }}
+          PAYPAL_PASSWORD: ${{ secrets.PAYPAL_PASSWORD }}
+          SFRA_VERSION: ${{ matrix.sfra-version }}
+          SFCC_HOSTNAME: ${{ secrets[matrix.sfcc-hostname-secret] }}
+  end-to-end-testing:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - sfra-version: "v5.3.0"
+            sfcc-hostname-secret: "SFCC_HOSTNAME_SFRA5"
+            code-version-secret: "SFCC_CODE_VERSION_SFRA5"
+          - sfra-version: "v6.1.0"
+            sfcc-hostname-secret: "SFCC_HOSTNAME_SFRA6"
+            code-version-secret: "SFCC_CODE_VERSION_SFRA6"
+    steps:
+      - name: setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: adyen-salesforce-commerce-cloud
       - name: install e2e test dependencies
         working-directory: adyen-salesforce-commerce-cloud/tests/playwright/
         run: npm i

--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -50,6 +50,7 @@ jobs:
         working-directory: adyen-salesforce-commerce-cloud
         run: npm run build
   end-to-end-testing:
+    needs: setup-the-cartridge
     runs-on: macos-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -49,22 +49,6 @@ jobs:
       - name: push cartridge code
         working-directory: adyen-salesforce-commerce-cloud
         run: npm run build
-      - name: install e2e test dependencies
-        working-directory: adyen-salesforce-commerce-cloud/tests/playwright/
-        run: npm i
-      - name: setup playwright dependencies
-        working-directory: adyen-salesforce-commerce-cloud/tests/playwright/
-        run: npx playwright install --with-deps
-      - name: run e2e tests
-        working-directory: adyen-salesforce-commerce-cloud/tests/playwright/
-        run: npm run test:ci
-        env:
-          SANDBOX_HTTP_AUTH_USERNAME: ${{ secrets.SANDBOX_HTTP_AUTH_USERNAME }}
-          SANDBOX_HTTP_AUTH_PASSWORD: ${{ secrets.SANDBOX_HTTP_AUTH_PASSWORD }}
-          PAYPAL_USERNAME: ${{ secrets.PAYPAL_USERNAME }}
-          PAYPAL_PASSWORD: ${{ secrets.PAYPAL_PASSWORD }}
-          SFRA_VERSION: ${{ matrix.sfra-version }}
-          SFCC_HOSTNAME: ${{ secrets[matrix.sfcc-hostname-secret] }}
   end-to-end-testing:
     runs-on: macos-latest
     strategy:

--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -87,3 +87,8 @@ jobs:
           PAYPAL_PASSWORD: ${{ secrets.PAYPAL_PASSWORD }}
           SFRA_VERSION: ${{ matrix.sfra-version }}
           SFCC_HOSTNAME: ${{ secrets[matrix.sfcc-hostname-secret] }}
+      - name: Archive test result artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: html-report
+          path: adyen-salesforce-commerce-cloud/tests/playwright/test-report

--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -110,6 +110,6 @@
   },
   "scripts": {
     "test": "npx playwright test",
-    "test:ci": "npx playwright test --project=chromium --workers=2 --config=sfcc.config.js"
+    "test:ci": "npx playwright test --project=chromium --config=sfcc.config.js"
   }
 }

--- a/tests/playwright/sfcc.config.js
+++ b/tests/playwright/sfcc.config.js
@@ -27,7 +27,7 @@ const config = {
   retries: process.env.CI ? 2 : 0,
 
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 3 : 1,
+  workers: process.env.CI ? 2 : 1,
 
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',

--- a/tests/playwright/sfcc.config.js
+++ b/tests/playwright/sfcc.config.js
@@ -27,7 +27,7 @@ const config = {
   retries: process.env.CI ? 2 : 0,
 
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 2 : undefined,
+  workers: process.env.CI ? 3 : undefined,
 
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',

--- a/tests/playwright/sfcc.config.js
+++ b/tests/playwright/sfcc.config.js
@@ -27,7 +27,7 @@ const config = {
   retries: process.env.CI ? 2 : 0,
 
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 3 : undefined,
+  workers: process.env.CI ? 3 : 1,
 
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',

--- a/tests/playwright/sfcc.config.js
+++ b/tests/playwright/sfcc.config.js
@@ -27,7 +27,7 @@ const config = {
   retries: process.env.CI ? 2 : 0,
 
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 4 : 1,
+  workers: process.env.CI ? 2 : 1,
 
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',

--- a/tests/playwright/sfcc.config.js
+++ b/tests/playwright/sfcc.config.js
@@ -27,7 +27,7 @@ const config = {
   retries: process.env.CI ? 2 : 0,
 
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 2 : 1,
+  workers: process.env.CI ? 4 : 1,
 
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This change will switch GitHub actions runners from Linux to MacOS virtual machines for E2E tests.
Also seperates the job of cartridge push from testing job and makes the latter dependant on the first one's success.

## Tested scenarios
<!-- Description of tested scenarios -->
Ran the tests with different worker counts, the most stable combination as of now seems to use 2 workers, which complete SFRA5 + SG tests within 24minutes with 98 passing (5 of them retried) cases.

The SFRA6 pipeline still to be fixed with another PR.

**Fixed issue**:  <!-- #-prefixed issue number --> PW-7007
