### PR TITLE
Pw 7462/confirmation email Site Genesis

### DIFF
--- a/src/cartridges/int_adyen_controllers/cartridge/controllers/Adyen.js
+++ b/src/cartridges/int_adyen_controllers/cartridge/controllers/Adyen.js
@@ -386,13 +386,13 @@ function showConfirmationPaymentFromComponent() {
     paymentInformation.get('paymentFromComponentStateData').value(),
   );
 
-  let finalResult;
+  let amazonPayResult;
 
   const hasStateData = stateData && stateData.details && stateData.paymentData;
 
   if (!hasStateData) {
     if (result && JSON.stringify(result).indexOf('amazonpay') > -1) {
-      finalResult = JSON.parse(result);
+      amazonPayResult = JSON.parse(result);
     } else {
       // The billing step is fulfilled, but order will be failed
       app.getForm('billing').object.fulfilled.value = true;
@@ -423,9 +423,11 @@ function showConfirmationPaymentFromComponent() {
     adyenPaymentInstrument.paymentTransaction.paymentProcessor = paymentProcessor;
     adyenPaymentInstrument.custom.adyenPaymentData = null;
   });
+  
+  let finalResult;
 
   if (order.status.value === Order.ORDER_STATUS_CREATED) {
-    finalResult = finalResult || adyenCheckout.doPaymentsDetailsCall(requestObject);
+    finalResult = amazonPayResult || adyenCheckout.doPaymentsDetailsCall(requestObject);
   }
   if (
     [
@@ -442,7 +444,13 @@ function showConfirmationPaymentFromComponent() {
     return {};
   }
   // handles the refresh
-  else if (order.status.value === Order.ORDER_STATUS_CREATED || order.status.value === Order.ORDER_STATUS_NEW || order.status.value === Order.ORDER_STATUS_OPEN){
+  else if (
+    [
+      Order.ORDER_STATUS_CREATED, 
+      Order.ORDER_STATUS_NEW,
+      Order.ORDER_STATUS_OPEN,
+    ].indexOf(order.status.value) > -1
+  ) {
     clearForms();
     return app.getController('COSummary').ShowConfirmation(order);
   }

--- a/src/cartridges/int_adyen_controllers/cartridge/controllers/Adyen.js
+++ b/src/cartridges/int_adyen_controllers/cartridge/controllers/Adyen.js
@@ -427,7 +427,13 @@ function showConfirmationPaymentFromComponent() {
   if (order.status.value === Order.ORDER_STATUS_CREATED) {
     finalResult = finalResult || adyenCheckout.doPaymentsDetailsCall(requestObject);
   }
-  if (['Authorised', 'Pending', 'Received'].indexOf(finalResult?.resultCode) > -1) {
+  if (
+    [
+      constants.RESULTCODES.AUTHORISED,
+      constants.RESULTCODES.PENDING,
+      constants.RESULTCODES.RECEIVED,
+    ].indexOf(finalResult?.resultCode) > -1
+  ) {
     Transaction.wrap(() => {
       AdyenHelper.savePaymentDetails(adyenPaymentInstrument, order, finalResult);
     });
@@ -439,7 +445,7 @@ function showConfirmationPaymentFromComponent() {
   else if (order.status.value === Order.ORDER_STATUS_CREATED || order.status.value === Order.ORDER_STATUS_NEW || order.status.value === Order.ORDER_STATUS_OPEN){
     clearForms();
     return app.getController('COSummary').ShowConfirmation(order);
-}
+  }
   // fail order
   Transaction.wrap(() => {
     OrderMgr.failOrder(order, true);

--- a/src/cartridges/int_adyen_controllers/cartridge/controllers/Adyen.js
+++ b/src/cartridges/int_adyen_controllers/cartridge/controllers/Adyen.js
@@ -13,7 +13,6 @@ const guard = require('app_storefront_controllers/cartridge/scripts/guard');
 const AdyenHelper = require('*/cartridge/scripts/util/adyenHelper');
 const adyenSessions = require('*/cartridge/scripts/adyenSessions');
 
-const OrderModel = app.getModel('Order');
 const Logger = require('dw/system/Logger');
 const constants = require('*/cartridge/adyenConstants/constants');
 const paymentMethodDescriptions = require('*/cartridge/adyenConstants/paymentMethodDescriptions');


### PR DESCRIPTION
This PR resolves the issue of sending multiple emails when confirmation page is refreshed.
For payments completed directly from components (e.g. PayPal), it does the payment call when order is created, instead of every time the function is triggered.