### PR TITLE
properly display gift card brand on Checkout

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
@@ -177,9 +177,9 @@ function getGiftCardConfig() {
         },
       });
     },
-    onSubmit(state) {
+    onSubmit(state, component) {
       store.selectedMethod = state.data.paymentMethod.type;
-      store.brand = state.data?.paymentMethod?.brand;
+      store.brand = component?.displayName;
       document.querySelector('input[name="brandCode"]').checked = false;
       document.querySelector('button[value="submit-payment"]').click();
     },

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
@@ -154,6 +154,9 @@ function getGiftCardConfig() {
         success: (data) => {
           if (data.resultCode === 'Success') {
             // make payments call including giftcard data and order data
+            const brandSelect = document.getElementById('giftCardSelect');
+            const selectedBrandIndex = brandSelect.selectedIndex;
+            const giftcardBrand = brandSelect.options[selectedBrandIndex].text;
             const partialPaymentRequest = {
               paymentMethod: giftCardData,
               amount: giftcardBalance,
@@ -161,7 +164,7 @@ function getGiftCardConfig() {
                 pspReference: data.pspReference,
                 orderData: data.orderData,
               },
-              giftcardBrand: store.partialPaymentsOrderObj?.giftcard?.brand,
+              giftcardBrand,
             };
             const partialPaymentResponse = helpers.makePartialPayment(
               partialPaymentRequest,


### PR DESCRIPTION
## Summary
This change will make it so that the gift card display name is shown during the order review +completion screen rather than the brand name used for API calls.

## Tested Scenarios
- Paying fully with gift card
- Paying with Gift Card + Redirect
- Paying with Gift Card + 3Ds2 credit card
- Paying with Gift Card + Paypal

## Caviats
When using a non-3ds credit card to pay for the remainder the gift card isn not shown at all in the confirmation screen.