### PR TITLE
point renovate to develop branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ]
+  ],
+  "baseBranches": ["develop"]
 }


### PR DESCRIPTION
Renovate haven't been creating PRs yet because by default it's pointing to "main" branch. But the renovate configuration file is in develop.