### PR TITLE
PW-7564/Removed contract from  requestObject

### DIFF
--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/adyenDeleteRecurringPayment.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/adyenDeleteRecurringPayment.js
@@ -49,7 +49,6 @@ function deleteRecurringPayment(args) {
       merchantAccount: AdyenConfigs.getAdyenMerchantAccount(),
       shopperReference: customerID,
       recurringDetailReference,
-      contract: 'ONECLICK',
     };
 
     AdyenHelper.executeCall(constants.SERVICE.RECURRING_DISABLE, requestObject);


### PR DESCRIPTION
This PR removes the `contract` from the requestObject that is sent for deleting saved cards. 
By doing so, the cards are successfully removed and don't show up after refreshing the page.