### PR TITLE
Amazon Pay E2E tests added to pipeline

### DIFF
--- a/.github/workflows/E2E_SFRA.yml
+++ b/.github/workflows/E2E_SFRA.yml
@@ -95,6 +95,8 @@ jobs:
           SANDBOX_HTTP_AUTH_PASSWORD: ${{ secrets.SANDBOX_HTTP_AUTH_PASSWORD }}
           PAYPAL_USERNAME: ${{ secrets.PAYPAL_USERNAME }}
           PAYPAL_PASSWORD: ${{ secrets.PAYPAL_PASSWORD }}
+          AMAZONPAY_USERNAME: ${{ secrets.AMAZONPAY_USERNAME }}
+          AMAZONPAY_PASSWORD: ${{ secrets.AMAZONPAY_PASSWORD }}
           SFRA_VERSION: ${{ matrix.sfra-version }}
           SFCC_HOSTNAME: ${{ secrets[matrix.sfcc-hostname-secret] }}
       - name: run e2e tests quick coverage

--- a/.github/workflows/E2E_SFRA.yml
+++ b/.github/workflows/E2E_SFRA.yml
@@ -112,4 +112,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: html-report
-          path: adyen-salesforce-commerce-cloud/tests/playwright/test-report
+          path: adyen-salesforce-commerce-cloud/tests/playwright/playwright-report

--- a/.github/workflows/E2E_SFRA.yml
+++ b/.github/workflows/E2E_SFRA.yml
@@ -3,8 +3,8 @@ name: E2E For SFRA
 on:
   pull_request:
     paths-ignore:
-      - "int_adyen_controllers/**"
-      - "adyen_controllers_changes/**"
+      - 'int_adyen_controllers/**'
+      - 'adyen_controllers_changes/**'
 
 jobs:
   setup-the-cartridge:
@@ -14,12 +14,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - sfra-version: "v5.3.0"
-            sfcc-hostname-secret: "SFCC_HOSTNAME_SFRA5"
-            code-version-secret: "SFCC_CODE_VERSION_SFRA5"
-          - sfra-version: "v6.1.0"
-            sfcc-hostname-secret: "SFCC_HOSTNAME_SFRA6"
-            code-version-secret: "SFCC_CODE_VERSION_SFRA6"
+          - sfra-version: 'v5.3.0'
+            sfcc-hostname-secret: 'SFCC_HOSTNAME_SFRA5'
+            code-version-secret: 'SFCC_CODE_VERSION_SFRA5'
+          - sfra-version: 'v6.1.0'
+            sfcc-hostname-secret: 'SFCC_HOSTNAME_SFRA6'
+            code-version-secret: 'SFCC_CODE_VERSION_SFRA6'
     steps:
       - name: Checkout SFRA code
         uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
       - name: setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: '14'
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -65,17 +65,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - sfra-version: "v5.3.0"
-            sfcc-hostname-secret: "SFCC_STOREFRONT_URL_SFRA5"
-            code-version-secret: "SFCC_CODE_VERSION_SFRA5"
-          - sfra-version: "v6.1.0"
-            sfcc-hostname-secret: "SFCC_STOREFRONT_URL_SFRA6"
-            code-version-secret: "SFCC_CODE_VERSION_SFRA6"
+          - sfra-version: 'v5.3.0'
+            sfcc-hostname-secret: 'SFCC_STOREFRONT_URL_SFRA5'
+            code-version-secret: 'SFCC_CODE_VERSION_SFRA5'
+          - sfra-version: 'v6.1.0'
+            sfcc-hostname-secret: 'SFCC_STOREFRONT_URL_SFRA6'
+            code-version-secret: 'SFCC_CODE_VERSION_SFRA6'
     steps:
       - name: setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: '16'
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -106,6 +106,8 @@ jobs:
           SANDBOX_HTTP_AUTH_PASSWORD: ${{ secrets.SANDBOX_HTTP_AUTH_PASSWORD }}
           PAYPAL_USERNAME: ${{ secrets.PAYPAL_USERNAME }}
           PAYPAL_PASSWORD: ${{ secrets.PAYPAL_PASSWORD }}
+          AMAZONPAY_USERNAME: ${{ secrets.AMAZONPAY_USERNAME }}
+          AMAZONPAY_PASSWORD: ${{ secrets.AMAZONPAY_PASSWORD }}
           SFRA_VERSION: ${{ matrix.sfra-version }}
           SFCC_HOSTNAME: ${{ secrets[matrix.sfcc-hostname-secret] }}
       - name: Archive test result artifacts

--- a/tests/playwright/data/paymentData.mjs
+++ b/tests/playwright/data/paymentData.mjs
@@ -15,4 +15,8 @@ export class PaymentData {
     username: process.env.PAYPAL_USERNAME,
     password: process.env.PAYPAL_PASSWORD,
   };
+  AmazonPay = {
+    username : process.env.AMAZONPAY_USERNAME,
+    password: process.env.AMAZONPAY_PASSWORD,
+  }
 }

--- a/tests/playwright/fixtures/countriesEUR/FR.spec.mjs
+++ b/tests/playwright/fixtures/countriesEUR/FR.spec.mjs
@@ -50,6 +50,9 @@ test.describe.parallel(`${environment.name} EUR FR`, () => {
    test('No 3DS Amazon Pay', async ({ page }) => {
     await checkoutPage.goToCheckoutPageWithFullCart(regionsEnum.EU);
     await checkoutPage.setShopperDetails(shopperData.FR);
+    if (environment.name.indexOf('v6') === -1) {
+      await checkoutPage.setEmail();
+    }
     redirectShopper = new RedirectShopper(page);
     await redirectShopper.doAmazonPayment();
     await checkoutPage.expectSuccess();
@@ -58,6 +61,9 @@ test.describe.parallel(`${environment.name} EUR FR`, () => {
   test('3DS2 Amazon Pay', async ({ page }) => {
     await checkoutPage.goToCheckoutPageWithFullCart(regionsEnum.EU);
     await checkoutPage.setShopperDetails(shopperData.FR);
+    if (environment.name.indexOf('v6') === -1) {
+      await checkoutPage.setEmail();
+    }
     redirectShopper = new RedirectShopper(page);
     await redirectShopper.doAmazonPayment(true, true, '3ds2_card');
     await cards.do3Ds2Verification();
@@ -76,6 +82,9 @@ test.describe.parallel(`${environment.name} EUR FR`, () => {
   test('Amazon Pay Failure', async ({ page }) => {
     await checkoutPage.goToCheckoutPageWithFullCart(regionsEnum.EU);
     await checkoutPage.setShopperDetails(shopperData.FR);
+    if (environment.name.indexOf('v6') === -1) {
+      await checkoutPage.setEmail();
+    }
     redirectShopper = new RedirectShopper(page);
     await redirectShopper.doAmazonPayment(true, false);
     await checkoutPage.expectRefusal();

--- a/tests/playwright/fixtures/countriesEUR/FR.spec.mjs
+++ b/tests/playwright/fixtures/countriesEUR/FR.spec.mjs
@@ -3,21 +3,23 @@ import { regionsEnum } from '../../data/enums.mjs';
 import { environments } from '../../data/environments.mjs';
 import { RedirectShopper } from '../../paymentFlows/redirectShopper.mjs';
 import { ShopperData } from '../../data/shopperData.mjs';
+import { Cards } from '../../paymentFlows/cards.mjs';
 
 const shopperData = new ShopperData();
 
 let checkoutPage;
 let redirectShopper;
+let cards;
 
 for (const environment of environments) {
   // Skipping this one since Oney Redirection is broken on sandboxes
   test.describe.skip(`${environment.name} EUR FR`, () => {
     test.beforeEach(async ({ page }) => {
       await page.goto(`${environment.urlExtension}`);
-
       checkoutPage = new environment.CheckoutPage(page);
       await checkoutPage.goToCheckoutPageWithFullCart(regionsEnum.EU);
       await checkoutPage.setShopperDetails(shopperData.FR);
+      cards = new Cards(page);
     });
     test('Oney Success', async ({ page }) => {
       redirectShopper = new RedirectShopper(page);
@@ -37,4 +39,47 @@ for (const environment of environments) {
       await checkoutPage.expectRefusal();
     });
   });
+
+test.describe.parallel(`${environment.name} EUR FR`, () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(`${environment.urlExtension}`);
+      checkoutPage = new environment.CheckoutPage(page);
+      cards = new Cards(page);
+   });
+
+   test('No 3DS Amazon Pay', async ({ page }) => {
+    await checkoutPage.goToCheckoutPageWithFullCart(regionsEnum.EU);
+    await checkoutPage.setShopperDetails(shopperData.FR);
+    redirectShopper = new RedirectShopper(page);
+    await redirectShopper.doAmazonPayment();
+    await checkoutPage.expectSuccess();
+  });
+  
+  test('3DS2 Amazon Pay', async ({ page }) => {
+    await checkoutPage.goToCheckoutPageWithFullCart(regionsEnum.EU);
+    await checkoutPage.setShopperDetails(shopperData.FR);
+    redirectShopper = new RedirectShopper(page);
+    await redirectShopper.doAmazonPayment(true, true, '3ds2_card');
+    await cards.do3Ds2Verification();
+    await checkoutPage.expectSuccess();
+  });
+
+  test('Amazon Pay Express', async ({ page }) => {
+    redirectShopper = new RedirectShopper(page);
+    await checkoutPage.addProductToCart();
+    await checkoutPage.navigateToCart(regionsEnum.EU);
+    await redirectShopper.doAmazonPayment(false);
+    await redirectShopper.doAmazonExpressPayment();
+    await checkoutPage.expectSuccess();
+  });
+
+  test('Amazon Pay Failure', async ({ page }) => {
+    await checkoutPage.goToCheckoutPageWithFullCart(regionsEnum.EU);
+    await checkoutPage.setShopperDetails(shopperData.FR);
+    redirectShopper = new RedirectShopper(page);
+    await redirectShopper.doAmazonPayment(true, false);
+    await checkoutPage.expectRefusal();
+  });
+
+ });
 }

--- a/tests/playwright/fixtures/countriesEUR/FR.spec.mjs
+++ b/tests/playwright/fixtures/countriesEUR/FR.spec.mjs
@@ -70,7 +70,7 @@ test.describe.parallel(`${environment.name} EUR FR`, () => {
     await checkoutPage.expectSuccess();
   });
 
-  test('Amazon Pay Express', async ({ page }) => {
+  test.skip('Amazon Pay Express', async ({ page }) => {
     redirectShopper = new RedirectShopper(page);
     await checkoutPage.addProductToCart();
     await checkoutPage.navigateToCart(regionsEnum.EU);

--- a/tests/playwright/pages/CheckoutPageSFRA5.mjs
+++ b/tests/playwright/pages/CheckoutPageSFRA5.mjs
@@ -94,6 +94,10 @@ export default class CheckoutPageSFRA5 {
     await this.page.goto(this.getCheckoutUrl(locale));
   };
 
+  navigateToCart = async (locale) => {
+    await this.page.goto(this.getCartUrl(locale));
+  }
+
   goToCheckoutPageWithFullCart = async (locale, itemCount = 1) => {
     await this.addProductToCart(locale, itemCount);
     await this.successMessage.waitFor({ visible: true, timeout: 15000 });

--- a/tests/playwright/pages/CheckoutPageSFRA5.mjs
+++ b/tests/playwright/pages/CheckoutPageSFRA5.mjs
@@ -108,7 +108,11 @@ export default class CheckoutPageSFRA5 {
 
   getCheckoutUrl(locale) {
     return `/on/demandware.store/Sites-RefArch-Site/${locale}/Checkout-Login`;
-  }
+  };
+
+  getCartUrl(locale) {
+    return `/s/RefArch/cart?lang=${locale}`;
+  };
 
   addProductToCart = async (locale, itemCount = 1) => {
     await this.consentButton.click();

--- a/tests/playwright/pages/CheckoutPageSFRA6.mjs
+++ b/tests/playwright/pages/CheckoutPageSFRA6.mjs
@@ -113,6 +113,10 @@ export default class CheckoutPageSFRA {
     return `/on/demandware.store/Sites-RefArch-Site/${locale}/Checkout-Begin`;
   }
 
+  getCartUrl(locale) {
+    return `/s/RefArch/cart?lang=${locale}`;
+  };
+
   addProductToCart = async (locale, itemCount = 1) => {
     await this.consentButton.click();
     await this.page.goto(`/s/RefArch/25720033M.html?lang=${locale}`);

--- a/tests/playwright/pages/CheckoutPageSFRA6.mjs
+++ b/tests/playwright/pages/CheckoutPageSFRA6.mjs
@@ -96,6 +96,10 @@ export default class CheckoutPageSFRA {
     await this.page.goto(this.getCheckoutUrl(locale));
   };
 
+  navigateToCart = async (locale) => {
+    await this.page.goto(this.getCartUrl(locale));
+  }
+
   goToCheckoutPageWithFullCart = async (locale, itemCount = 1) => {
     await this.addProductToCart(locale, itemCount);
     await this.successMessage.waitFor({ visible: true, timeout: 15000 });

--- a/tests/playwright/pages/PaymentMethodsPage.mjs
+++ b/tests/playwright/pages/PaymentMethodsPage.mjs
@@ -1,6 +1,7 @@
 import { expect } from '@playwright/test';
 import { ShopperData } from '../data/shopperData.mjs';
 import { PaymentData } from '../data/paymentData.mjs';
+import { async } from 'regenerator-runtime';
 
 const shopperData = new ShopperData();
 const paymentData = new PaymentData();
@@ -71,6 +72,58 @@ export default class PaymentMethodsPage {
     await this.agreeAndPayNowButton.click();
   };
 
+  initiateAmazonPayment = async (
+    normalFlow = true,
+    success = true,
+    selectedCard
+  ) => {
+    if (normalFlow) {
+      await this.page.click("#rb_amazonpay");
+    }
+    await this.page.click(".adyen-checkout__amazonpay__button");
+  
+    // Amazon Sandbox selectors
+    this.emailInput = this.page.locator("#ap_email");
+    this.passwordInput = this.page.locator("#ap_password");
+    this.loginButton = this.page.locator("#signInSubmit");
+    this.changePaymentButton = this.page.locator("#change-payment-button");
+    this.confirmPaymentChangeButton = this.page.locator("#a-autoid-8");
+
+    await this.emailInput.fill(paymentData.AmazonPay.username);
+    await this.passwordInput.fill(paymentData.AmazonPay.password);
+    await this.loginButton.click();
+  
+    // Handles the saved 3DS2 Masstercard saved in Amazon Sandbox
+    if (selectedCard == "3ds2_card") {
+      await this.page.waitForLoadState("networkidle", { timeout: 15000 });
+      await this.changePaymentButton.click();
+      await this.page.click(".MASTERCARD");
+      await this.confirmPaymentChangeButton.click();
+    }
+  
+    if (!success) {
+      await this.page.waitForLoadState("networkidle", { timeout: 15000 });
+      await this.changePaymentButton.click();
+      this.rejectionCard = this.page.locator(
+        'label[for="wallet_auth_decline_processing_failure"]'
+      );
+      await this.rejectionCard.click();
+      await this.confirmPaymentChangeButton.click();
+    }
+    this.submitButton = this.page.locator(
+      'span[data-action="continue-checkout"]'
+    );
+    await this.submitButton.click();
+  };
+  
+  continueAmazonExpressFlow = async () => {
+    this.confirmExpressPaymentButton = this.page.locator(
+      ".adyen-checkout__button--pay"
+    );
+    await this.confirmExpressPaymentButton.click();
+  };
+  
+
   initiateBillDeskPayment = async (paymentMethod) => {
     await this.page.locator(`#rb_${paymentMethod}`).click();
     if (paymentMethod === 'billdesk_upi') {
@@ -80,7 +133,7 @@ export default class PaymentMethodsPage {
     const dropDown = this.page.locator(
       `#component_${paymentMethod} .adyen-checkout__dropdown__button`,
     );
-    const issuer = this.page
+    const issuer = this.page 
       .locator(`#component_${paymentMethod} .adyen-checkout__dropdown__list li`)
       .first();
     await input.click();

--- a/tests/playwright/pages/PaymentMethodsPage.mjs
+++ b/tests/playwright/pages/PaymentMethodsPage.mjs
@@ -109,6 +109,7 @@ export default class PaymentMethodsPage {
       await this.rejectionCard.click();
       await this.confirmPaymentChangeButton.click();
     }
+    await this.page.waitForLoadState("networkidle", { timeout: 15000 });
     this.submitButton = this.page.locator(
       'span[data-action="continue-checkout"]'
     );

--- a/tests/playwright/pages/PaymentMethodsPage.mjs
+++ b/tests/playwright/pages/PaymentMethodsPage.mjs
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
 import { ShopperData } from '../data/shopperData.mjs';
 import { PaymentData } from '../data/paymentData.mjs';
-import { async } from 'regenerator-runtime';
 
 const shopperData = new ShopperData();
 const paymentData = new PaymentData();
@@ -344,7 +343,6 @@ export default class PaymentMethodsPage {
 
     /* Commenting out this section since the phone number comes
     prefilled nowadays
-
     await this.klarnaPhoneInput.waitFor({
       state: "visible",
       timeout: 15000,

--- a/tests/playwright/paymentFlows/redirectShopper.mjs
+++ b/tests/playwright/paymentFlows/redirectShopper.mjs
@@ -33,6 +33,14 @@ export class RedirectShopper {
     await this.paymentMethodsPage.initiatePayPalPayment();
   };
 
+  doAmazonPayment = async (normalFlow, selectedCard, success) => {
+    await this.paymentMethodsPage.initiateAmazonPayment(normalFlow, selectedCard, success);
+  }
+
+  doAmazonExpressPayment = async () => {
+    await this.paymentMethodsPage.continueAmazonExpressFlow();
+  };
+
   completeOneyRedirect = async (shopper) => {
     await this.paymentMethodsPage.confirmOneyPayment();
   };


### PR DESCRIPTION
This PR contains E2E tests to cover the following 4 scenarios for Amazon Pay:
1. Amazon Pay No-3DS Payment
2. Amazon Pay 3DS2 Payment
3. Amazon Pay Express Checkout
4. Amazon Pay Failure