### PR TITLE
PW-8000 Shipping Methods available for Amazon Express need to be up to date

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazonPayExpressPart2.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazonPayExpressPart2.js
@@ -6,6 +6,20 @@ function saveShopperDetails(data) {
       shopperDetails: JSON.stringify(data),
       paymentMethod: 'amazonpay',
     },
+    success(data) {
+      console.log('inside success');
+      console.log(JSON.stringify(data));
+      const select = document.querySelector('#shippingMethods');
+      select.innerHTML = "";
+      data.shippingMethods.forEach(shippingMethod => {
+        const option = document.createElement('option');
+        option.setAttribute('data-shipping-id', shippingMethod.ID);
+        option.innerText = `${shippingMethod.displayName} (${shippingMethod.estimatedArrivalTime})`;
+        select.appendChild(option);
+      });
+      select.options[0].selected = true;
+      select.dispatchEvent(new Event('change'));
+    },
   });
 }
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazonPayExpressPart2.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazonPayExpressPart2.js
@@ -1,17 +1,15 @@
-function saveShopperDetails(data) {
+function saveShopperDetails(details) {
   $.ajax({
     url: window.saveShopperDetailsURL,
     type: 'post',
     data: {
-      shopperDetails: JSON.stringify(data),
+      shopperDetails: JSON.stringify(details),
       paymentMethod: 'amazonpay',
     },
     success(data) {
-      console.log('inside success');
-      console.log(JSON.stringify(data));
       const select = document.querySelector('#shippingMethods');
-      select.innerHTML = "";
-      data.shippingMethods.forEach(shippingMethod => {
+      select.innerHTML = '';
+      data.shippingMethods.forEach((shippingMethod) => {
         const option = document.createElement('option');
         option.setAttribute('data-shipping-id', shippingMethod.ID);
         option.innerText = `${shippingMethod.displayName} (${shippingMethod.estimatedArrivalTime})`;

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/applePayExpress.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/applePayExpress.js
@@ -124,10 +124,9 @@ function callPaymentFromComponent(data, resolveApplePay, rejectApplePay) {
 
 if (isSafari) {
   initializeCheckout().then(() => {
-    const applePayPaymentMethod =
-      checkout.paymentMethodsResponse.paymentMethods.find(
-        (pm) => pm.type === APPLE_PAY,
-      );
+    const applePayPaymentMethod = checkout.paymentMethodsResponse.paymentMethods.find(
+      (pm) => pm.type === APPLE_PAY,
+    );
 
     if (!applePayPaymentMethod) {
       return;
@@ -241,13 +240,14 @@ if (isSafari) {
               },
             );
             if (calculationResponse.ok) {
-              const shippingMethodsStructured =
-                shippingMethodsData.shippingMethods.map((sm) => ({
+              const shippingMethodsStructured = shippingMethodsData.shippingMethods.map(
+                (sm) => ({
                   label: sm.displayName,
                   detail: sm.description,
                   identifier: sm.ID,
                   amount: `${sm.shippingCost.value}`,
-                }));
+                }),
+              );
               const newCalculation = await calculationResponse.json();
               const applePayShippingContactUpdate = {
                 newShippingMethods: shippingMethodsStructured,

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/paymentFromComponent.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/paymentFromComponent.js
@@ -189,12 +189,13 @@ function paymentFromComponent(req, res, next) {
       paymentInstrument.custom.adyenPartialPaymentsOrder =
         session.privacy.partialPaymentData;
     }
-    paymentInstrument.custom.adyenPaymentMethod =
-      AdyenHelper.getAdyenComponentType(req.form.paymentMethod);
-    paymentInstrument.custom[`${constants.OMS_NAMESPACE}_adyenPaymentMethod`] =
-      AdyenHelper.getAdyenComponentType(req.form.paymentMethod);
-    paymentInstrument.custom.Adyen_Payment_Method_Variant =
-      req.form.paymentMethod.toLowerCase();
+    paymentInstrument.custom.adyenPaymentMethod = AdyenHelper.getAdyenComponentType(
+      req.form.paymentMethod,
+    );
+    paymentInstrument.custom[
+      `${constants.OMS_NAMESPACE}_adyenPaymentMethod`
+    ] = AdyenHelper.getAdyenComponentType(req.form.paymentMethod);
+    paymentInstrument.custom.Adyen_Payment_Method_Variant = req.form.paymentMethod.toLowerCase();
     paymentInstrument.custom[
       `${constants.OMS_NAMESPACE}_Adyen_Payment_Method_Variant`
     ] = req.form.paymentMethod.toLowerCase();

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/saveExpressShopperDetails.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/saveExpressShopperDetails.js
@@ -65,7 +65,6 @@ function saveExpressShopperDetails(req, res, next) {
       );
     });
     setBillingAndShippingAddress(currentBasket);
-    //    const shippingMethods = URLUtils.https('Adyen-ShippingMethods');
     const shippingMethods = AdyenHelper.callGetShippingMethods(
       shopperDetails.shippingAddress,
     );

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/saveExpressShopperDetails.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/saveExpressShopperDetails.js
@@ -2,7 +2,6 @@ const URLUtils = require('dw/web/URLUtils');
 const Transaction = require('dw/system/Transaction');
 const BasketMgr = require('dw/order/BasketMgr');
 const AdyenLogs = require('*/cartridge/scripts/adyenCustomLogs');
-const Logger = require('dw/system/Logger');
 const AdyenHelper = require('*/cartridge/scripts/util/adyenHelper');
 
 function setBillingAndShippingAddress(currentBasket) {
@@ -66,12 +65,13 @@ function saveExpressShopperDetails(req, res, next) {
       );
     });
     setBillingAndShippingAddress(currentBasket);
-//    const shippingMethods = URLUtils.https('Adyen-ShippingMethods');
-    const shippingMethods = AdyenHelper.callGetShippingMethods(shopperDetails.shippingAddress);
-    res.json({ shippingMethods: shippingMethods });
+    //    const shippingMethods = URLUtils.https('Adyen-ShippingMethods');
+    const shippingMethods = AdyenHelper.callGetShippingMethods(
+      shopperDetails.shippingAddress,
+    );
+    res.json({ shippingMethods });
     return next();
   } catch (e) {
-    Logger.getLogger('Adyen').error('inside catch ' + JSON.stringify(e));
     AdyenLogs.error_log('Could not save amazon express shopper details');
     res.redirect(URLUtils.url('Error-ErrorCode', 'err', 'general'));
     return next();

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/saveExpressShopperDetails.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/saveExpressShopperDetails.js
@@ -2,6 +2,8 @@ const URLUtils = require('dw/web/URLUtils');
 const Transaction = require('dw/system/Transaction');
 const BasketMgr = require('dw/order/BasketMgr');
 const AdyenLogs = require('*/cartridge/scripts/adyenCustomLogs');
+const Logger = require('dw/system/Logger');
+const AdyenHelper = require('*/cartridge/scripts/util/adyenHelper');
 
 function setBillingAndShippingAddress(currentBasket) {
   let { billingAddress } = currentBasket;
@@ -64,9 +66,12 @@ function saveExpressShopperDetails(req, res, next) {
       );
     });
     setBillingAndShippingAddress(currentBasket);
-    res.json({ success: true });
+//    const shippingMethods = URLUtils.https('Adyen-ShippingMethods');
+    const shippingMethods = AdyenHelper.callGetShippingMethods(shopperDetails.shippingAddress);
+    res.json({ shippingMethods: shippingMethods });
     return next();
   } catch (e) {
+    Logger.getLogger('Adyen').error('inside catch ' + JSON.stringify(e));
     AdyenLogs.error_log('Could not save amazon express shopper details');
     res.redirect(URLUtils.url('Error-ErrorCode', 'err', 'general'));
     return next();

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/shippingMethods.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/shippingMethods.js
@@ -1,66 +1,6 @@
-const ShippingMgr = require('dw/order/ShippingMgr');
 const BasketMgr = require('dw/order/BasketMgr');
 const AdyenLogs = require('*/cartridge/scripts/adyenCustomLogs');
-const ShippingMethodModel = require('*/cartridge/models/shipping/shippingMethod');
-const collections = require('*/cartridge/scripts/util/collections');
-
-function getShippingCost(shippingMethod, shipment) {
-  const shipmentShippingModel = ShippingMgr.getShipmentShippingModel(shipment);
-  const shippingCost = shipmentShippingModel.getShippingCost(shippingMethod);
-  return {
-    value: shippingCost.amount.value,
-    currencyCode: shippingCost.amount.currencyCode,
-  };
-}
-
-function getShippingMethods(shipment, address) {
-  if (!shipment) return null;
-
-  const shipmentShippingModel = ShippingMgr.getShipmentShippingModel(shipment);
-
-  let shippingMethods;
-  if (address) {
-    shippingMethods = shipmentShippingModel.getApplicableShippingMethods(
-      address,
-    );
-  } else {
-    shippingMethods = shipmentShippingModel.getApplicableShippingMethods();
-  }
-
-  return shippingMethods;
-}
-
-function getShipmentUUID(shipment) {
-  if (!shipment) return null;
-  return shipment.UUID;
-}
-
-function getApplicableShippingMethods(shipment, address) {
-  const shippingMethods = getShippingMethods(shipment, address);
-  if (!shippingMethods) {
-    return null;
-  }
-
-  // Filter out whatever the method associated with in store pickup
-  const filteredMethods = [];
-  collections.forEach(shippingMethods, (shippingMethod) => {
-    if (!shippingMethod.custom.storePickupEnabled) {
-      const shippingMethodModel = new ShippingMethodModel(
-        shippingMethod,
-        shipment,
-      );
-      const shippingCost = getShippingCost(shippingMethod, shipment);
-      const shipmentUUID = getShipmentUUID(shipment);
-      filteredMethods.push({
-        ...shippingMethodModel,
-        shippingCost,
-        shipmentUUID,
-      });
-    }
-  });
-
-  return filteredMethods;
-}
+const AdyenHelper = require('*/cartridge/scripts/util/adyenHelper');
 
 /**
  * Make a request to Adyen to get shipping methods
@@ -76,7 +16,7 @@ function callGetShippingMethods(req, res, next) {
       };
     }
     const currentBasket = BasketMgr.getCurrentBasket();
-    const currentShippingMethodsModels = getApplicableShippingMethods(
+    const currentShippingMethodsModels = AdyenHelper.getApplicableShippingMethods(
       currentBasket.getDefaultShipment(),
       address,
     );

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/hooks/payment/processor/middlewares/handle.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/hooks/payment/processor/middlewares/handle.js
@@ -18,8 +18,9 @@ function convertToSfccCardType(paymentInformation, paymentInstrument) {
   paymentInstrument.setCreditCardType(sfccCardType);
 
   paymentInstrument.custom.adyenPaymentMethod = sfccCardType;
-  paymentInstrument.custom[`${constants.OMS_NAMESPACE}_adyenPaymentMethod`] =
-    sfccCardType;
+  paymentInstrument.custom[
+    `${constants.OMS_NAMESPACE}_adyenPaymentMethod`
+  ] = sfccCardType;
 
   if (paymentInformation.creditCardToken) {
     paymentInstrument.setCreditCardExpirationMonth(
@@ -57,10 +58,9 @@ function handle(basket, paymentInformation) {
         session.privacy.partialPaymentData;
     }
 
-    paymentInstrument.custom.Adyen_Payment_Method_Variant =
-      paymentInformation.stateData
-        ? JSON.parse(paymentInformation.stateData)?.paymentMethod?.type
-        : null;
+    paymentInstrument.custom.Adyen_Payment_Method_Variant = paymentInformation.stateData
+      ? JSON.parse(paymentInformation.stateData)?.paymentMethod?.type
+      : null;
     paymentInstrument.custom[
       `${constants.OMS_NAMESPACE}_Adyen_Payment_Method_Variant`
     ] = paymentInformation.stateData

--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
@@ -29,9 +29,13 @@ const AdyenConfigs = require('*/cartridge/scripts/util/adyenConfigs');
 const Transaction = require('dw/system/Transaction');
 const UUIDUtils = require('dw/util/UUIDUtils');
 const collections = require('*/cartridge/scripts/util/collections');
+const ShippingMgr = require('dw/order/ShippingMgr');
+const ShippingMethodModel = require('*/cartridge/models/shipping/shippingMethod');
 const PaymentInstrument = require('dw/order/PaymentInstrument');
 //script includes
 const AdyenLogs = require('*/cartridge/scripts/adyenCustomLogs');
+const Logger = require('dw/system/Logger');
+const BasketMgr = require('dw/order/BasketMgr');
 
 /* eslint no-var: off */
 var adyenHelperObj = {
@@ -72,6 +76,90 @@ var adyenHelperObj = {
       );
     }
     return null;
+  },
+
+  getShippingCost(shippingMethod, shipment) {
+    const shipmentShippingModel = ShippingMgr.getShipmentShippingModel(shipment);
+    const shippingCost = shipmentShippingModel.getShippingCost(shippingMethod);
+    return {
+      value: shippingCost.amount.value,
+      currencyCode: shippingCost.amount.currencyCode,
+    };
+  },
+
+  getShippingMethods(shipment, address) {
+    if (!shipment) return null;
+
+    const shipmentShippingModel = ShippingMgr.getShipmentShippingModel(shipment);
+
+    let shippingMethods;
+    if (address) {
+      shippingMethods = shipmentShippingModel.getApplicableShippingMethods(
+        address,
+      );
+    } else {
+      shippingMethods = shipmentShippingModel.getApplicableShippingMethods();
+    }
+
+    return shippingMethods;
+  },
+
+  getShipmentUUID(shipment) {
+    if (!shipment) return null;
+    return shipment.UUID;
+  },
+
+  getApplicableShippingMethods(shipment, address) {
+    const shippingMethods = this.getShippingMethods(shipment, address);
+    if (!shippingMethods) {
+      return null;
+    }
+
+    // Filter out whatever the method associated with in store pickup
+    const filteredMethods = [];
+    collections.forEach(shippingMethods, (shippingMethod) => {
+      if (!shippingMethod.custom.storePickupEnabled) {
+        const shippingMethodModel = new ShippingMethodModel(
+          shippingMethod,
+          shipment,
+        );
+        const shippingCost = this.getShippingCost(shippingMethod, shipment);
+        const shipmentUUID = this.getShipmentUUID(shipment);
+        filteredMethods.push({
+          ...shippingMethodModel,
+          shippingCost,
+          shipmentUUID,
+        });
+      }
+    });
+
+    return filteredMethods;
+  },
+
+  /**
+   * Make a request to Adyen to get shipping methods
+   */
+  callGetShippingMethods(shippingAddress) {
+    let address;
+    try {
+        address = {
+          city: shippingAddress.city,
+          countryCode: shippingAddress.countryCode,
+          stateCode: shippingAddress.stateOrRegion,
+        };
+      Logger.getLogger('Adyen').error('address ' + JSON.stringify(address));
+      const currentBasket = BasketMgr.getCurrentBasket();
+      const currentShippingMethodsModels = this.getApplicableShippingMethods(
+        currentBasket.getDefaultShipment(),
+        address,
+      );
+      Logger.getLogger('Adyen').error('currentShippingMethodsModels ' + JSON.stringify(currentShippingMethodsModels));
+      return currentShippingMethodsModels;
+    } catch (error) {
+      Logger.getLogger('Adyen').error('inside catch ' + JSON.stringify(error));
+      AdyenLogs.error_log('Failed to fetch shipping methods');
+      AdyenLogs.error_log(error);
+    }
   },
 
   getAdyenGivingConfig(order) {

--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
@@ -34,7 +34,6 @@ const ShippingMethodModel = require('*/cartridge/models/shipping/shippingMethod'
 const PaymentInstrument = require('dw/order/PaymentInstrument');
 //script includes
 const AdyenLogs = require('*/cartridge/scripts/adyenCustomLogs');
-const Logger = require('dw/system/Logger');
 const BasketMgr = require('dw/order/BasketMgr');
 
 /* eslint no-var: off */
@@ -147,16 +146,13 @@ var adyenHelperObj = {
           countryCode: shippingAddress.countryCode,
           stateCode: shippingAddress.stateOrRegion,
         };
-      Logger.getLogger('Adyen').error('address ' + JSON.stringify(address));
       const currentBasket = BasketMgr.getCurrentBasket();
       const currentShippingMethodsModels = this.getApplicableShippingMethods(
         currentBasket.getDefaultShipment(),
         address,
       );
-      Logger.getLogger('Adyen').error('currentShippingMethodsModels ' + JSON.stringify(currentShippingMethodsModels));
       return currentShippingMethodsModels;
     } catch (error) {
-      Logger.getLogger('Adyen').error('inside catch ' + JSON.stringify(error));
       AdyenLogs.error_log('Failed to fetch shipping methods');
       AdyenLogs.error_log(error);
     }

--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
@@ -135,9 +135,6 @@ var adyenHelperObj = {
     return filteredMethods;
   },
 
-  /**
-   * Make a request to Adyen to get shipping methods
-   */
   callGetShippingMethods(shippingAddress) {
     let address;
     try {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
- on 2nd redirect for Amazon express, empty existing shipping methods (outdated) inside the Select box and replace with updated options based on shopper details

**Fixed issue**:  <!-- #-prefixed issue number -->