### PR TITLE
Partial payments order is ignored when paying with Amazon Pay

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/helpers.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/helpers.js
@@ -66,6 +66,7 @@ function makePartialPayment(requestData) {
         const { giftCards, ...rest } = response;
         store.checkout.options.amount = rest.remainingAmount;
         store.partialPaymentsOrderObj = rest;
+        sessionStorage.setItem('partialPaymentsObj', JSON.stringify(rest));
         store.addedGiftCards = giftCards;
         setOrderFormData(response);
       }

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazonPayCheckout.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazonPayCheckout.js
@@ -33,14 +33,11 @@ function handleAmazonResponse(response, component) {
 }
 
 function paymentFromComponent(data, component) {
-  let partialPaymentsOrder = sessionStorage.getItem('partialPaymentsObj');
-  try {
-    partialPaymentsOrder = JSON.parse(partialPaymentsOrder);
-  } catch (e) {} // eslint-disable-line no-empty
-
+  const partialPaymentsOrder = sessionStorage.getItem('partialPaymentsObj');
   const requestData = partialPaymentsOrder
-    ? { ...data, partialPaymentsOrder }
+    ? { ...data, partialPaymentsOrder: JSON.parse(partialPaymentsOrder) }
     : data;
+
   $.ajax({
     url: window.paymentFromComponentURL,
     type: 'post',

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazonPayCheckout.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazonPayCheckout.js
@@ -33,16 +33,25 @@ function handleAmazonResponse(response, component) {
 }
 
 function paymentFromComponent(data, component) {
+  let partialPaymentsOrder = sessionStorage.getItem('partialPaymentsObj');
+  try {
+    partialPaymentsOrder = JSON.parse(partialPaymentsOrder);
+  } catch (e) {} // eslint-disable-line no-empty
+
+  const requestData = partialPaymentsOrder
+    ? { ...data, partialPaymentsOrder }
+    : data;
   $.ajax({
     url: window.paymentFromComponentURL,
     type: 'post',
     data: {
-      data: JSON.stringify(data),
+      data: JSON.stringify(requestData),
       paymentMethod: 'amazonpay',
       merchantReference: document.querySelector('#merchantReference').value,
       orderToken: document.querySelector('#orderToken').value,
     },
     success(response) {
+      sessionStorage.removeItem('partialPaymentsObj');
       helpers.setOrderFormData(response);
 
       handleAmazonResponse(response, component);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
This PR stores the partial payments order data in session storage so that they persist after the redirection back from Amazon

**Fixed issue**:  <!-- #-prefixed issue number -->