### PR TITLE
Change value assigned to adyenPaymentMethod from innerHTML to textContent

### DIFF
--- a/cartridges/int_adyen_controllers/cartridge/js/pages/checkout/adyen-checkout.js
+++ b/cartridges/int_adyen_controllers/cartridge/js/pages/checkout/adyen-checkout.js
@@ -47,7 +47,7 @@ function _initializeBillingEvents() {
             }
             if (isAdyen) {
               var adyenPaymentMethod = document.querySelector('#adyenPaymentMethodName');
-              var paymentMethodLabel = document.querySelector("#lb_".concat(selectedMethod)).innerHTML;
+              var paymentMethodLabel = document.querySelector("#lb_".concat(selectedMethod)).textContent;
               adyenPaymentMethod.value = paymentMethodLabel;
               validateComponents();
               return showValidation();
@@ -270,7 +270,7 @@ function _initializeAccountEvents() {
 }
 function assignPaymentMethodValue() {
   var adyenPaymentMethod = document.querySelector('#adyenPaymentMethodName');
-  adyenPaymentMethod.value = document.querySelector("#lb_".concat(selectedMethod)).innerHTML;
+  adyenPaymentMethod.value = document.querySelector("#lb_".concat(selectedMethod)).textContent;
 }
 
 /**

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/helpers.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/helpers.js
@@ -7,7 +7,7 @@ function assignPaymentMethodValue() {
   if (adyenPaymentMethod) {
     adyenPaymentMethod.value = store.brand
       ? store.brand
-      : document.querySelector(paymentMethodlabelId)?.innerHTML;
+      : document.querySelector(paymentMethodlabelId)?.textContent;
   }
 }
 

--- a/src/cartridges/int_adyen_controllers/cartridge/js/pages/checkout/adyen-checkout.js
+++ b/src/cartridges/int_adyen_controllers/cartridge/js/pages/checkout/adyen-checkout.js
@@ -251,7 +251,7 @@ function assignPaymentMethodValue() {
   var adyenPaymentMethod = document.querySelector('#adyenPaymentMethodName');
   adyenPaymentMethod.value = document.querySelector(
       `#lb_${selectedMethod}`,
-  ).innerHTML;
+  ).textContent;
 }
 
 /**


### PR DESCRIPTION
since innerHTML also takes the HTML and saves it in the order information. Issue found if you translate your frontend page with the browser in use which adds extra HTML tags like font and spans.
Changing the code form innerHTML to textContent it takes only the text inside the provided id tag in the JS. If you keep innerHTML some customers translate their front which adds extra HTML tags in, for example, Chrome adds 2 font HTML tags, even for text which can't be translated example Paypal.

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

**Fixed issue**:  <!-- #-prefixed issue number -->