### PR TITLE
Show Correct Tax Amount In Klarna Playground

### DIFF
--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/adyenGetOpenInvoiceData.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/adyenGetOpenInvoiceData.js
@@ -26,7 +26,7 @@ const LineItemHelper = require('*/cartridge/scripts/util/lineItemHelper');
 function getLineItems({ Order: order, Basket: basket, addTaxPercentage }) {
   if (!(order || basket)) return null;
   const orderOrBasket = order || basket;
-  const allLineItems = orderOrBasket.getProductLineItems();
+  const allLineItems = orderOrBasket.getAllLineItems();
 
   // Add all product and shipping line items to request
   const lineItems = [];


### PR DESCRIPTION
This PR contains the adding of the shipping cost as a line item in the klarna playground.
The price for each line item in klarna playground is calculated as (`amountExcludingTax` + `taxAmount`)