### PR TITLE
Update the HMAC Key field to be empty instead of null

### DIFF
--- a/src/cartridges/bm_adyen/cartridge/templates/default/adyenSettings/settingCards/webhookSettings.isml
+++ b/src/cartridges/bm_adyen/cartridge/templates/default/adyenSettings/settingCards/webhookSettings.isml
@@ -43,7 +43,7 @@
             <div class="input-fields">
                <input type="password" class="form-control" name="Adyen_Hmac_Key" id="hmacKey"
                   aria-describedby="hmacKeyHelp" placeholder=""
-                  value="${AdyenConfigs.getAdyenHmacKey()}">
+                  value="${AdyenConfigs.getAdyenHmacKey() || ''}">
             </div>
          </div>
       </div>

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/notify.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/notify.js
@@ -7,18 +7,18 @@ const AdyenConfigs = require('*/cartridge/scripts/util/adyenConfigs');
  * Called by Adyen to update status of payments. It should always display [accepted] when finished.
  */
 
-function handleHmacVerification(req) {
-  return checkAuth.validateHmacSignature(req);
+function handleHmacVerification(hmacKey, req) {
+  if (hmacKey) {
+    return checkAuth.validateHmacSignature(req);
+  }
+  return true;
 }
 
 function notify(req, res, next) {
   const status = checkAuth.check(req);
   const hmacKey = AdyenConfigs.getAdyenHmacKey();
-  let hmacVerification;
-  if (hmacKey) {
-    hmacVerification = handleHmacVerification(req);
-  }
-  if (!status || hmacVerification === false) {
+  const isHmacValid = handleHmacVerification(hmacKey, req);
+  if (!status || !isHmacValid) {
     res.render('/adyen/error');
     return {};
   }

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/notify.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/notify.js
@@ -7,18 +7,18 @@ const AdyenConfigs = require('*/cartridge/scripts/util/adyenConfigs');
  * Called by Adyen to update status of payments. It should always display [accepted] when finished.
  */
 
-function handleHmacVerification(hmacKey, req) {
-  if (!hmacKey) {
-    return false;
-  }
+function handleHmacVerification(req) {
   return checkAuth.validateHmacSignature(req);
 }
 
 function notify(req, res, next) {
   const status = checkAuth.check(req);
   const hmacKey = AdyenConfigs.getAdyenHmacKey();
-  const isHmacValid = handleHmacVerification(hmacKey, req);
-  if (!status || !isHmacValid) {
+  let hmacVerification;
+  if (hmacKey) {
+    hmacVerification = handleHmacVerification(req);
+  }
+  if (!status || hmacVerification === false) {
     res.render('/adyen/error');
     return {};
   }


### PR DESCRIPTION
This PR sets the HMAC Key field in BM to empty instead of null if no input is provided and updates the hmacVerification to not be false in case no hmac key is setup