### PR TITLE
Incosistent data for Adyen_paymentMethod

### DIFF
--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
@@ -660,7 +660,7 @@ var adyenHelperObj = {
         result.additionalData.paymentMethod;
     } else if (result.paymentMethod) {
       paymentInstrument.paymentTransaction.custom.Adyen_paymentMethod = JSON.stringify(
-        result.paymentMethod,
+        result.paymentMethod.type,
       );
     }
 


### PR DESCRIPTION
This PR makes sure that the type of paymentMethod is saved inside `Adyen_paymentMethod`.