### PR TITLE
Specify reason for payment failure in BM

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmation.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmation.js
@@ -1,6 +1,7 @@
 const URLUtils = require('dw/web/URLUtils');
 const OrderMgr = require('dw/order/OrderMgr');
 const Order = require('dw/order/Order');
+const Transaction = require('dw/system/Transaction');
 const adyenCheckout = require('*/cartridge/scripts/adyenCheckout');
 const constants = require('*/cartridge/adyenConstants/constants');
 const payment = require('*/cartridge/controllers/middlewares/adyen/showConfirmation/payment');
@@ -57,6 +58,10 @@ function handlePaymentsDetailsResult(
       options,
     );
   }
+  Transaction.wrap(() => {
+    order.custom.Adyen_pspReference = detailsResult.pspReference;
+    order.custom.Adyen_eventCode = detailsResult.resultCode;
+  });
   return payment.handlePaymentError(order, 'placeOrder', options);
 }
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmationPaymentFromComponent/payment.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/showConfirmationPaymentFromComponent/payment.js
@@ -107,6 +107,10 @@ function handlePaymentResult(result, order, adyenPaymentInstrument, options) {
       options,
     );
   }
+  Transaction.wrap(() => {
+    order.custom.Adyen_pspReference = result.pspReference;
+    order.custom.Adyen_eventCode = result.resultCode;
+  });
   return handlePaymentError(order, adyenPaymentInstrument, options);
 }
 

--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/handleCustomObject.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/handleCustomObject.js
@@ -155,6 +155,7 @@ function handle(customObj) {
             );
             result.SubmitOrder = true;
           }
+          order.custom.Adyen_eventCode = customObj.custom.eventCode;
           order.custom.Adyen_value = amountPaid.toString();
         } else {
           AdyenLogs.info_log(
@@ -282,8 +283,6 @@ function handle(customObj) {
       ) {
         order.custom.Adyen_pspReference = customObj.custom.pspReference;
       }
-
-      order.custom.Adyen_eventCode = customObj.custom.eventCode;
 
       // Add a note with all details
       order.addNote('Adyen Payment Notification', createLogMessage(customObj));


### PR DESCRIPTION
This PR adds the eventCode and pspRef to failed order in BM under `Attributes` tab.