### PR TITLE
Payment instrument check

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/order/__tests__/confirm.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/order/__tests__/confirm.test.js
@@ -23,14 +23,9 @@ describe('Confirm', () => {
     confirm(req, res, jest.fn());
     expect(res.setViewData).toBeCalledTimes(0);
   });
-  it('should do nothing if giving is not available', () => {
+  it('should set view data', () => {
     const AdyenHelper = require('*/cartridge/scripts/util/adyenHelper');
     AdyenHelper.getOrderMainPaymentInstrumentType.mockReturnValue('AdyenComponent');
-    AdyenHelper.isAdyenGivingAvailable.mockImplementation(() => false);
-    confirm(req, res, jest.fn());
-    expect(res.setViewData).toBeCalledTimes(0);
-  });
-  it('should set view data', () => {
     confirm(req, res, jest.fn());
     expect(res.setViewData).toMatchSnapshot();
   });

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/order/confirm.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/order/confirm.js
@@ -52,13 +52,7 @@ function confirm(req, res, next) {
   const orderToken = getOrderToken(req);
   if (orderId && orderToken) {
     const order = OrderMgr.getOrder(orderId, orderToken);
-    const paymentInstrument = order.getPaymentInstruments(
-      AdyenHelper.getOrderMainPaymentInstrumentType(order),
-    )[0];
-    if (
-      AdyenHelper.getAdyenGivingConfig(order) &&
-      AdyenHelper.isAdyenGivingAvailable(paymentInstrument)
-    ) {
+    if (AdyenHelper.getAdyenGivingConfig(order)) {
       handleAdyenGiving(req, res);
     }
   }

--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
@@ -156,6 +156,11 @@ var adyenHelperObj = {
   },
 
   getAdyenGivingConfig(order) {
+    if (!order.getPaymentInstruments(
+      adyenHelperObj.getOrderMainPaymentInstrumentType(order),
+    ).length){
+      return null;
+    }
     const paymentInstrument = order.getPaymentInstruments(
       adyenHelperObj.getOrderMainPaymentInstrumentType(order),
     )[0];


### PR DESCRIPTION
This PR adds an additional check if the payment instruments exists before handling adyen giving component. In this way, if a merchant is using multiple payment service providers the order confirmation page will not fail rendering.