### PR TITLE
Does not transpile on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "uploadCartridgeSG": "sgmf-scripts --uploadCartridge [YOUR_WORKING_DIRECTORY]/adyen-salesforce-commerce-cloud/src/cartridges/adyen_controllers_changes/app_storefront_controllers_changes && sgmf-scripts --uploadCartridge [YOUR_WORKING_DIRECTORY]/adyen-salesforce-commerce-cloud/src/cartridges/adyen_controllers_changes/app_storefront_core_changes",
     "watch": "sgmf-scripts --watch",
     "compile:js": "sgmf-scripts --compile js",
-    "transpile": "babel ./src/cartridges  -d ./cartridges --copy-files --no-copy-ignored --extensions '.js,.test.js,.snap'",
+    "transpile": "babel ./src/cartridges  -d ./cartridges --copy-files --no-copy-ignored --extensions .js,.test.js,.snap",
     "build": "npm run transpile && npm run compile:js && npm run uploadCartridge",
     "test": "jest ./src",
     "test:watch": "jest ./src --watch",


### PR DESCRIPTION
## Summary
Noticed that `npm run transpile` silently fails on Windows 11 machine with output:
```sh
> int_adyen_SFRA@23.2.0 transpile C:\...\adyen-salesforce-commerce-cloud-23.2.0
> babel ./src/cartridges  -d ./cartridges --copy-files --no-copy-ignored --extensions '.js,.test.js,.snap'

Successfully compiled 0 files with Babel (4803ms).
```
Transpile works fine on *nix machines, only our developer on Windows was having issues during the build process.
Running with clean install of
* Windows 11 Pro 22H2
* node v14.21.3
* npm 6.14.18
* Unmodified Adyen cartridge 23.2.0

Apparently this is a known issue with babel on Windows, see : https://github.com/babel/babel/issues/9803

Removing the single quotes or switching to escaped double quotes `\"` fixes the transpile issue on Windows.

```sh
> int_adyen_SFRA@23.2.0 transpile C:\...\adyen-salesforce-commerce-cloud-23.2.0
> babel ./src/cartridges  -d ./cartridges --copy-files --no-copy-ignored --extensions .js,.test.js,.snap

[BABEL] Note: The code generator has deoptimised the styling of C:\...\adyen-salesforce-commerce-cloud-23.2.0\src\cartridges\adyen_controllers_changes\app_storefront_core_changes\cartridge\static\default\js\app.js as it exceeds the max of 500KB.
Successfully compiled 126 files with Babel (20006ms).
```



**Fixed issue**: 
Might be related to #946 since those errors are thrown by ```npm run compile:js``` if transpile fails