### PR TITLE
Bugfix installment options

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -161,7 +161,7 @@
                 <p>Create a new set of payment installment options</p>
                 <button type="button" class="btn btn-outline-primary" onclick="createInstallment(2)">Create</button>
             </div>
-            <div class="col-6 p-4 bd-highlight">
+            <div class="col-6 p-4 bd-highlight" style="visibility: hidden">
                 <h4>Edit</h4>
                 <p>Edit an existing set of payment installment options</p>
                 <form class="form-inline">

--- a/docs/index.html
+++ b/docs/index.html
@@ -218,7 +218,7 @@
     let rulesCount = 0;
     let result = {};
     const creditCards = [
-        {id: 1, name: "Amex"},
+        {id: 'amex', name: "Amex"},
         // {id: "argencard", name: "Argencard"},
         // {id: "bcmc", name: "Bancontact/Mister Cash"},
         // {id: "bijcard", name: "de Bijenkorf Card"},
@@ -229,16 +229,16 @@
         // {id: "dankort", name: "Dankort"},
         // {id: "diners", name: "Diners Club"},
         // {id: "discover", name: "Discover"},
-        {id: 2, name: "ELO"},
+        {id: 'elo', name: "ELO"},
         // {id: "forbrugsforeningen", name: "Forbrugsforeningen"},
-        {id: 4, name: "HiperCard"},
+        {id: 'hipercard', name: "HiperCard"},
         // {id: "hipercard", name: "HiperCard"},
         // {id: "jcb", name: "JCB"},
         // {id: "karenmillen", name: "Karen Millen GiftCard"},
         // {id: "laser", name: "Laser"},
         // {id: "maestro", name: "Maestro"},
         // {id: "maestrouk", name: "Maestro UK"},
-        {id: 8, name: "Mastercard"},
+        {id: 'mc', name: "Mastercard"},
         // {id: "mcalphabankbonus", name: "Alpha Bank Mastercard Bonus"},
         // {id: "mir", name: "MIR"},
         // {id: "naranja", name: "Naranja"},
@@ -247,7 +247,7 @@
         // {id: "solo", name: "Solo"},
         // {id: "troy", name: "Troy"},
         // {id: "uatp", name: "UATP"},
-        {id: 16, name: "Visa"},
+        {id: 'visa', name: "Visa"},
         // {id: "visaalphabankbonus", name: "Alpha Bank Visa Bonus"},
         // {id: "visadankort", name: "Visa Dankort"},
         // {id: "warehouse", name: "Warehouse GiftCard"},
@@ -332,12 +332,10 @@
         const hasId = id in sums;
         if (!hasId) { sums[id] = [] }
 
-        const parsedValue = parseInt(value)
-        const hasValue = sums[id].includes(parsedValue);
-        sums[id] = hasValue ? sums[id].filter(v => v !== parsedValue) : [...sums[id], parsedValue];
-        const sum = sums[id].reduce((acc, num) => parseInt(acc) + parseInt(num), 0);
+        const hasValue = sums[id].includes(value);
+        sums[id] = hasValue ? sums[id].filter(v => v !== value) : [...sums[id], value];
 
-        result[id][2] = parseInt(sum);
+        result[id][2] = sums[id];
         updateHash()
     }
 
@@ -363,6 +361,7 @@
         Object.entries(result).forEach(([resultId, val]) => {
             sums[resultId] = [];
             creditCards.forEach(({ id }) => {
+                console.log(id);
                 if ((parseInt(id) & val[2]) !== 0) sums[resultId] = [...sums[resultId], parseInt(id)]
             });
             addRule(resultId)

--- a/docs/index.html
+++ b/docs/index.html
@@ -329,11 +329,15 @@
     }
 
     function handleSelect(id, value) {
-        const hasId = id in sums;
-        if (!hasId) { sums[id] = [] }
+        if (id === 0 && !sums[0]) {
+          sums[0] = [];
+        }
 
-        const hasValue = sums[id].includes(value);
-        sums[id] = hasValue ? sums[id].filter(v => v !== value) : [...sums[id], value];
+        if (id > 0 && !sums[id]) {
+          sums[id] = []
+        }
+
+        sums[id] = [...sums[id], value];
 
         result[id][2] = sums[id];
         updateHash()
@@ -347,6 +351,7 @@
     function duplicateRule(id) {
         result[rulesCount] = [...result[id]];
         sums[rulesCount] = [...sums[id]];
+        sums[id + 1] = [];
         addRule()
     }
 
@@ -361,7 +366,6 @@
         Object.entries(result).forEach(([resultId, val]) => {
             sums[resultId] = [];
             creditCards.forEach(({ id }) => {
-                console.log(id);
                 if ((parseInt(id) & val[2]) !== 0) sums[resultId] = [...sums[resultId], parseInt(id)]
             });
             addRule(resultId)

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGenericComponent.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGenericComponent.js
@@ -175,18 +175,34 @@ function setInstallments(amount) {
     if (installmentLocales.indexOf(window.Configuration.locale) < 0) {
       return;
     }
-    const [minAmount, numOfInstallments] = window.installments
-      ?.replace(/\[|]/g, '')
-      .split(',');
-    if (minAmount <= amount.value) {
+    const installments = JSON.parse(
+      window.installments.replace(/&quot;/g, '"'),
+    );
+    if (installments.length) {
       store.checkoutConfiguration.paymentMethodsConfiguration.card.installmentOptions =
-        {
-          card: {},
-        }; // eslint-disable-next-line max-len
-      store.checkoutConfiguration.paymentMethodsConfiguration.card.installmentOptions.card.values =
-        helpers.getInstallmentValues(numOfInstallments);
-      store.checkoutConfiguration.paymentMethodsConfiguration.card.showInstallmentAmounts = true;
+        {};
     }
+    installments.forEach((installment) => {
+      const [minAmount, numOfInstallments, cards] = installment;
+      if (minAmount <= amount.value) {
+        cards.forEach((cardType) => {
+          const { installmentOptions } =
+            store.checkoutConfiguration.paymentMethodsConfiguration.card;
+          if (!installmentOptions[cardType]) {
+            installmentOptions[cardType] = {
+              values: [1],
+            };
+          }
+          if (
+            !installmentOptions[cardType].values.includes(numOfInstallments)
+          ) {
+            installmentOptions[cardType].values.push(numOfInstallments);
+            installmentOptions[cardType].values.sort((a, b) => a - b);
+          }
+        });
+      }
+    });
+    store.checkoutConfiguration.paymentMethodsConfiguration.card.showInstallmentAmounts = true;
   } catch (e) {} // eslint-disable-line no-empty
 }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR solves generating the installment options configuration.
The configurator page is also changed so in order to properly test the configurator should be run locally.

The new format looks like this:
`[[20,3,["mc","hipercard"]]]`

`[[0,2,["mc"]],[0,3,["mc","visa"]],[0,4,["mc","visa"]],[0,5,["visa"]]]`