### PR TITLE
fix: paypal on cancel flow

### DIFF
--- a/cartridges/int_adyen_controllers/cartridge/js/pages/checkout/adyen-checkout.js
+++ b/cartridges/int_adyen_controllers/cartridge/js/pages/checkout/adyen-checkout.js
@@ -117,7 +117,9 @@ function _initializeBillingEvents() {
                 onError: function onError( /* error, component */
                 ) {
                   paypalTerminatedEarly = false;
-                  $('#dwfrm_billing').trigger('submit');
+                  paymentFromComponent({
+                    cancelTransaction: true,
+                    merchantReference: document.querySelector('#merchantReference').value});
                 },
                 onAdditionalDetails: function onAdditionalDetails(state /* , component */) {
                   paypalTerminatedEarly = false;

--- a/src/cartridges/int_adyen_controllers/cartridge/js/pages/checkout/adyen-checkout.js
+++ b/src/cartridges/int_adyen_controllers/cartridge/js/pages/checkout/adyen-checkout.js
@@ -103,7 +103,7 @@ async function initializeBillingEvents() {
           paypalTerminatedEarly = false;
           paymentFromComponent({
             cancelTransaction: true,
-            merchantReference: document.querySelector('#merchantReference').value, });
+            merchantReference: document.querySelector('#merchantReference').value});
         },
         onAdditionalDetails: (state /* , component */) => {
           paypalTerminatedEarly = false;

--- a/src/cartridges/int_adyen_controllers/cartridge/js/pages/checkout/adyen-checkout.js
+++ b/src/cartridges/int_adyen_controllers/cartridge/js/pages/checkout/adyen-checkout.js
@@ -101,7 +101,9 @@ async function initializeBillingEvents() {
         },
         onError: (/* error, component */) => {
           paypalTerminatedEarly = false;
-          $('#dwfrm_billing').trigger('submit');
+          paymentFromComponent({
+            cancelTransaction: true,
+            merchantReference: document.querySelector('#merchantReference').value, });
         },
         onAdditionalDetails: (state /* , component */) => {
           paypalTerminatedEarly = false;


### PR DESCRIPTION
when paypal is canceled user return back to checkout page and is able to select paypal or other payment method.