### PR TITLE
Psp reference not passed properly to OMS in case of multiple payment instruments

### DIFF
--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
@@ -653,10 +653,7 @@ var adyenHelperObj = {
 
   // saves the payment details in the paymentInstrument's custom object
   savePaymentDetails(paymentInstrument, order, result) {
-    paymentInstrument.paymentTransaction.transactionID = session.privacy
-      .giftCardResponse
-      ? JSON.parse(session.privacy.giftCardResponse).orderPSPReference
-      : result.pspReference;
+    paymentInstrument.paymentTransaction.transactionID = result.pspReference;
     paymentInstrument.paymentTransaction.custom.Adyen_pspReference =
       result.pspReference;
 

--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/util/giftCardsHelper.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/util/giftCardsHelper.js
@@ -39,6 +39,7 @@ let giftCardsHelper = {
         paymentInstrument.paymentMethod,
       );
       paymentInstrument.paymentTransaction.paymentProcessor = paymentProcessor;
+      paymentInstrument.paymentTransaction.transactionID = parsedGiftCardObj.giftCard.pspReference;
       paymentInstrument.custom.adyenPaymentMethod = parsedGiftCardObj.giftCard.name;
       paymentInstrument.custom[`${constants.OMS_NAMESPACE}__Adyen_Payment_Method`] = parsedGiftCardObj.giftCard.name;
       paymentInstrument.custom.Adyen_Payment_Method_Variant = parsedGiftCardObj.giftCard.brand;


### PR DESCRIPTION
This PR fixes the way how the pspReference is passed to OMS, enabling each gift card to populate the `transactionId` with their corresponding pspReference.