### PR TITLE
[SFI-460] Apple Pay Express postal code not being saved

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/paymentFromComponent.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/paymentFromComponent.js
@@ -39,6 +39,9 @@ function setBillingAndShippingAddress(reqDataObj, currentBasket) {
     billingAddress.setCountryCode(
       shopperDetails.billingAddressDetails.countryCode.value,
     );
+    billingAddress.setPostalCode(
+      shopperDetails.billingAddressDetails.postalCode,
+    );
     if (shopperDetails.billingAddressDetails.address2) {
       billingAddress.setAddress2(shopperDetails.billingAddressDetails.address2);
     }
@@ -58,6 +61,9 @@ function setBillingAndShippingAddress(reqDataObj, currentBasket) {
     shippingAddress.setCity(shopperDetails.addressBook.preferredAddress.city);
     shippingAddress.setCountryCode(
       shopperDetails.addressBook.preferredAddress.countryCode.value,
+    );
+    shippingAddress.setPostalCode(
+      shopperDetails.addressBook.preferredAddress.postalCode,
     );
     if (shopperDetails.addressBook.preferredAddress.address2) {
       shippingAddress.setAddress2(


### PR DESCRIPTION
- What is the motivation for this change? 
When using Apple Pay Express the postal code is not saved in the order details page in BM and also not shown in the confirmation page.
- What existing problem does this pull request solve?
This PR sets the postal code in setBillingAndShippingAddress() used for Apple Pay express, so the postal code is part of order details page in BM and also in the confirmation page.

**Fixed issue**:  SFI-460