### PR TITLE
[SFI-420] Amount per item is not populated in customer area for klarna

### DIFF
--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/adyenGetOpenInvoiceData.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/adyenGetOpenInvoiceData.js
@@ -50,10 +50,10 @@ function getLineItems({ Order: order, Basket: basket, addTaxPercentage }) {
 
       lineItemObject.amountExcludingTax = itemAmount.getValue().toFixed();
       lineItemObject.taxAmount = vatAmount.getValue().toFixed();
+      lineItemObject.amountIncludingTax = itemAmount.getValue() + vatAmount.getValue();
       lineItemObject.description = description;
       lineItemObject.id = id;
       lineItemObject.quantity = quantity;
-      lineItemObject.taxCategory = 'None';
       lineItemObject.taxPercentage = addTaxPercentage ? (
           new Number(vatPercentage) * 10000
       ).toFixed() : 0;


### PR DESCRIPTION
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
The amount per item field in customer area it always populated as 0 when using klarna as payment method.
- What existing problem does this pull request solve?
This PR passes `amountIncludingTax` in the lineItemsObject, which correctly populates the amount per item field in customer area when klarna is being used.
Also, in this PR taxCategory is removed as it is not part of checkout api v70.

**Fixed issue**: SFI-420