### PR TITLE
[SFI-469] Domain association apple pay

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/RedirectURL.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/RedirectURL.js
@@ -11,7 +11,8 @@ server.prepend('Start', (req, res, next) => {
   if (origin.match(constants.APPLE_DOMAIN_URL)) {
     const applePayDomainAssociation =
       AdyenConfigs.getApplePayDomainAssociation();
-    response.getWriter().print(applePayDomainAssociation);
+    res.setHttpHeader(dw.system.Response.CONTENT_TYPE, 'text/plain');
+    response.getWriter().println(applePayDomainAssociation);
     return null;
   }
   return next();


### PR DESCRIPTION
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
This change adds the new line at end of apple pay domain association text, which was missing before when saving the domain association to a metadata field.
Moreover, it sets the content type to text/plain.
- What existing problem does this pull request solve?
It solves the issue of Apple Pay domain association not being correctly saved in the metadata field.


**Fixed issue**:  SFI-469