### PR TITLE
[SFI-464] GooglePay merchantId not being populated

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyenCheckout.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyenCheckout.js
@@ -38,7 +38,7 @@ if (window.cardholderNameBool !== 'null') {
 
 if (
   window.googleMerchantID !== 'null' &&
-  window.Configuration.environment === 'live'
+  window.Configuration.environment.includes('live')
 ) {
   const id = 'merchantId';
   store.checkoutConfiguration.paymentMethodsConfiguration.paywithgoogle.configuration[


### PR DESCRIPTION
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
This change checks if the front-end region includes live instead of being equal to live, since for different regions the second part of environment string can be different, while the first part stays `live`.
- What existing problem does this pull request solve?
This PR solves the problem of setting the google pay configuration outside the EU region, as the merchant ID was not being passed correctly.


**Fixed issue**: SFI-464