### PR TITLE
[SFI-415] setPaymentTransactionType not working for giftcards

### DIFF
--- a/jest/sfccCartridgeMocks.js
+++ b/jest/sfccCartridgeMocks.js
@@ -249,6 +249,7 @@ jest.mock('*/cartridge/scripts/util/adyenHelper', () => ({
       return request
     }),
     getAdyenComponentType : jest.fn(() => {}),
+    setPaymentTransactionType : jest.fn(() => {}),
     getOrderMainPaymentInstrumentType: jest.fn(() => {}),
     getPaymentInstrumentType: jest.fn((isCreditCard) => isCreditCard ? 'CREDIT_CARD' : 'AdyenComponent'),
   }), {virtual: true});

--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/adyenCheckout.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/adyenCheckout.js
@@ -37,18 +37,6 @@ const adyenLevelTwoThreeData = require('*/cartridge/scripts/adyenLevelTwoThreeDa
 const constants = require('*/cartridge/adyenConstants/constants');
 const AdyenLogs = require('*/cartridge/scripts/adyenCustomLogs');
 
-//SALE payment methods require payment transaction type to be Capture
-function setPaymentTransactionType(paymentInstrument, paymentMethod) {
-  const salePaymentMethods = AdyenConfigs.getAdyenSalePaymentMethods();
-  if (salePaymentMethods.indexOf(paymentMethod.type) > -1) {
-    Transaction.wrap(function () {
-      paymentInstrument
-        .getPaymentTransaction()
-        .setType(dw.order.PaymentTransaction.TYPE_CAPTURE);
-    });
-  }
-}
-
 function createPaymentRequest(args) {
   try {
     const order = args.Order;
@@ -160,8 +148,7 @@ function createPaymentRequest(args) {
         paymentRequest.storePaymentMethod = true;
         paymentRequest.recurringProcessingModel = constants.RECURRING_PROCESSING_MODEL.CARD_ON_FILE;
     }
-    setPaymentTransactionType(paymentInstrument, paymentRequest.paymentMethod);
-
+    AdyenHelper.setPaymentTransactionType(paymentInstrument, paymentRequest.paymentMethod);
     // make API call
     return doPaymentsCall(order, paymentInstrument, paymentRequest);
   } catch (e) {

--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenConfigs.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenConfigs.js
@@ -105,10 +105,6 @@ const adyenConfigsObj = {
     return getCustomPreference('AdyenTokenisationEnabled');
   },
 
-  getAdyenSalePaymentMethods: function () {
-    return getCustomPreference('AdyenSalePaymentMethods') ? getCustomPreference('AdyenSalePaymentMethods').toString().split(',') : '';
-  },
-
   getAdyenBasketFieldsEnabled() {
     return getCustomPreference('AdyenBasketFieldsEnabled');
   },
@@ -127,7 +123,7 @@ const adyenConfigsObj = {
 
   getAdyenSalePaymentMethods: function () {
     return getCustomPreference('AdyenSalePaymentMethods')
-      ? getCustomPreference('AdyenSalePaymentMethods').toString().split(',')
+      ? getCustomPreference('AdyenSalePaymentMethods').replace(/\s/g, '').toString().split(',')
       : [];
   },
 

--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
@@ -860,6 +860,23 @@ var adyenHelperObj = {
     };
   },
 
+  getPaymentMethodType(paymentMethod){
+    return paymentMethod.type === constants.ACTIONTYPES.GIFTCARD ? paymentMethod.brand : paymentMethod.type;
+  },
+
+//SALE payment methods require payment transaction type to be Capture
+  setPaymentTransactionType(paymentInstrument, paymentMethod) {
+    const salePaymentMethods = AdyenConfigs.getAdyenSalePaymentMethods();
+    const paymentMethodType = this.getPaymentMethodType(paymentMethod);
+    if (salePaymentMethods.indexOf(paymentMethodType) > -1) {
+      Transaction.wrap(function () {
+        paymentInstrument
+          .getPaymentTransaction()
+          .setType(dw.order.PaymentTransaction.TYPE_CAPTURE);
+      });
+    }
+  },
+
   executeCall(serviceType, requestObject) {
     const service = this.getService(serviceType);
     if (service === null) {

--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/util/giftCardsHelper.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/util/giftCardsHelper.js
@@ -17,6 +17,7 @@
  * See the LICENSE file for more info.
  */
 const constants = require('*/cartridge/adyenConstants/constants');
+const AdyenHelper = require('*/cartridge/scripts/util/adyenHelper');
 const Transaction = require('dw/system/Transaction');
 //script includes
 const PaymentMgr = require('dw/order/PaymentMgr');
@@ -49,6 +50,7 @@ let giftCardsHelper = {
       paymentInstrument.paymentTransaction.custom.Adyen_log = JSON.stringify(parsedGiftCardObj);
       paymentInstrument.paymentTransaction.custom.Adyen_pspReference = parsedGiftCardObj.giftCard.pspReference;
     })
+    AdyenHelper.setPaymentTransactionType(paymentInstrument, parsedGiftCardObj.giftCard);
   }
 };
 


### PR DESCRIPTION
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
This PR adjusts the setPaymentTransactionType to cover the scenarios when giftcards are being used, and gives the possibility to treat them as SALE payment methods when synchronizing with OMS. It also fixes the extra space issue when the metadata string is edited from BM config page, which before was leading to the last SALE payment method to be missed.
- What existing problem does this pull request solve?
This PR enables the giftcards to be treated as SALE payment methods and fixes the parsing issue when editing the BM fields where SALE payment methods are saved.


**Fixed issue**: SFI-415