### PR TITLE
[SFI-436] Applepay billing address not being submitted

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
@@ -328,6 +328,7 @@ function getApplePayConfig() {
   return {
     showPayButton: true,
     onSubmit: (state, component) => {
+      $('#dwfrm_billing').trigger('submit');
       helpers.assignPaymentMethodValue();
       helpers.paymentFromComponent(state.data, component);
     },

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
@@ -327,6 +327,7 @@ function getAmazonpayConfig() {
 function getApplePayConfig() {
   return {
     showPayButton: true,
+    buttonColor: 'black',
     onSubmit: (state, component) => {
       $('#dwfrm_billing').trigger('submit');
       helpers.assignPaymentMethodValue();


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

Describe the changes proposed in this pull request:
- What is the motivation for this change? 
When making an ApplePay payment through end of checkout flow and filling in a different shipping and billing address, the billing address does not update since we don't submit the billing form onSubmit().
- What existing problem does this pull request solve?
This PR submits the billing form onSubmit() event of apple pay component, which will correctly update the order details.


**Fixed issue**:  <!-- #-prefixed issue number -->