### PR TITLE
[SFI-421] Notifications failing for bundled products

### DIFF
--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
@@ -701,7 +701,7 @@ var adyenHelperObj = {
 
   // converts the currency value for the Adyen Checkout API
   getCurrencyValueForApi(amount) {
-    const currencyCode = dwutil.Currency.getCurrency(amount.currencyCode) || dwsystem.Site.getCurrent().getDefaultCurrency();
+    const currencyCode = dwutil.Currency.getCurrency(amount.currencyCode) || session.currency.currencyCode;
     const digitsNumber = adyenHelperObj.getFractionDigits(
       currencyCode.toString(),
     );

--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
@@ -701,8 +701,7 @@ var adyenHelperObj = {
 
   // converts the currency value for the Adyen Checkout API
   getCurrencyValueForApi(amount) {
-    const currentBasket = BasketMgr.getCurrentBasket();
-    const currencyCode = dwutil.Currency.getCurrency(amount.currencyCode) || currentBasket.currencyCode;
+    const currencyCode = dwutil.Currency.getCurrency(amount.currencyCode) || dwsystem.Site.getCurrent().getDefaultCurrency();
     const digitsNumber = adyenHelperObj.getFractionDigits(
       currencyCode.toString(),
     );


### PR DESCRIPTION
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
This PR uses the session currency to retrieve the currencyCode for initializing the session for bundled products. The previous implementation was breaking the notifications.
- What existing problem does this pull request solve?
The notifications are properly processed for every order.


**Fixed issue**: [SFI-421]