### PR TITLE
[SFI-532] Recurring webhook not processing

### DIFF
--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/handleCustomObject.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/handleCustomObject.js
@@ -80,7 +80,7 @@ function handle(customObj) {
 
   if (order === null) {
     // check to see if this was a $0.00 auth for recurring payment. if yes, CO can safely be deleted
-    if (orderId.indexOf('recurringPayment') > -1) {
+    if (orderIdParts.indexOf('recurringPayment') > -1) {
       result.SkipOrder = true;
       setProcessedCOInfo(customObj);
     } else {


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
When doing zero auth transactions, the webhook is not being processed, throwing an error log.
- What existing problem does this pull request solve?
It satisfies the logic for skipping the webhook notification and clearing the custom objects.


**Fixed issue**:  SFI-532