### PR TITLE
[SFI-556] Level 2/3 data only on scheme requests

### DIFF
--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/adyenCheckout.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/adyenCheckout.js
@@ -49,6 +49,7 @@ function createPaymentRequest(args) {
     );
 
     paymentRequest = AdyenHelper.add3DS2Data(paymentRequest);
+    const paymentMethodType = paymentRequest.paymentMethod.type;
 
     // Add Risk data
     if (AdyenConfigs.getAdyenBasketFieldsEnabled()) {
@@ -58,7 +59,7 @@ function createPaymentRequest(args) {
     }
 
     // L2/3 Data
-    if (AdyenConfigs.getAdyenLevel23DataEnabled()) {
+    if (AdyenConfigs.getAdyenLevel23DataEnabled() && paymentMethodType.indexOf('scheme') > -1) {
       paymentRequest.additionalData = {
         ...paymentRequest.additionalData,
         ...adyenLevelTwoThreeData.getLineItems(args),
@@ -95,7 +96,6 @@ function createPaymentRequest(args) {
       };
     }
 
-    const paymentMethodType = paymentRequest.paymentMethod.type;
     // Create billing and delivery address objects for new orders,
     // no address fields for credit cards through My Account
     paymentRequest = AdyenHelper.createAddressObjects(


### PR DESCRIPTION
## Summary
- What is the motivation for this change?
Level 2/3 data is being included in all payment requests in case it is enabled.
- What existing problem does this pull request solve?
This PR includes the level 2/3 data only in case `scheme` payment methods are being used.


## Tested scenarios
Description of tested scenarios: 
- Scheme payment with level 2/3 data enabled
- Alternative payment method with level 2/3 data enabled
- Scheme payment with level 2/3 data disabled

**Fixed issue**:  SFI-556
