### PR TITLE
[SFI-525] Apple pay donations are enabled

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/applePayExpress.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/applePayExpress.js
@@ -81,6 +81,8 @@ function handleAuthorised(response, resolveApplePay) {
     paymentMethod: response.fullResponse?.paymentMethod
       ? response.fullResponse.paymentMethod
       : response.fullResponse?.additionalData?.paymentMethod,
+    donationToken: response.fullResponse?.donationToken,
+    amount: response.fullResponse?.amount,
   });
   document.querySelector('#showConfirmationForm').submit();
 }

--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/adyenGiving.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/adyenGiving.js
@@ -44,11 +44,15 @@ function donate(donationReference, donationAmount, orderToken) {
     const paymentData = JSON.parse(paymentInstrument.paymentTransaction.custom.Adyen_log);
     const paymentCurrency = paymentData.amount.currency;
     const availableDonationAmounts = AdyenHelper.getDonationAmounts();
-    paymentMethodVariant = paymentInstrument.custom.Adyen_Payment_Method_Variant;
+    paymentMethodVariant = paymentData.paymentMethod?.type || paymentData.fullResponse?.paymentMethod?.type;
 
     // for iDeal donations, the payment method variant needs to be set to sepadirectdebit
     if (paymentMethodVariant === 'ideal') {
       paymentMethodVariant = 'sepadirectdebit';
+    }
+    // for Apple Pay donations, the payment method variant needs to be the brand
+    if (paymentMethodVariant === 'applepay'){
+      paymentMethodVariant = paymentData.paymentMethod?.brand || paymentData.fullResponse?.paymentMethod?.brand;
     }
     const requestObject = {
       merchantAccount: AdyenConfigs.getAdyenMerchantAccount(),

--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/adyenGiving.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/adyenGiving.js
@@ -42,7 +42,7 @@ function donate(donationReference, donationAmount, orderToken) {
     const donationToken = paymentInstrument.paymentTransaction.custom.Adyen_donationToken;
     const originalReference = paymentInstrument.paymentTransaction.custom.Adyen_pspReference;
     const paymentData = JSON.parse(paymentInstrument.paymentTransaction.custom.Adyen_log);
-    const paymentCurrency = paymentData.amount.currency;
+    const paymentCurrency = paymentData.amount.currency || paymentData.fullResponse?.amount?.currency;
     const availableDonationAmounts = AdyenHelper.getDonationAmounts();
     paymentMethodVariant = paymentData.paymentMethod?.type || paymentData.fullResponse?.paymentMethod?.type;
 

--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
@@ -683,8 +683,8 @@ var adyenHelperObj = {
       ? result.resultCode
       : '';
     order.custom.Adyen_value = '0';
-    if (result.donationToken){
-      paymentInstrument.paymentTransaction.custom.Adyen_donationToken = result.donationToken;
+    if (result.donationToken || result.fullResponse?.donationToken){
+      paymentInstrument.paymentTransaction.custom.Adyen_donationToken = result.donationToken || result.fullResponse.donationToken;
     }
     // Save full response to transaction custom attribute
     paymentInstrument.paymentTransaction.custom.Adyen_log = JSON.stringify(

--- a/tests/playwright/fixtures/USD.spec.mjs
+++ b/tests/playwright/fixtures/USD.spec.mjs
@@ -56,7 +56,7 @@ for (const environment of environments) {
       await checkoutPage.expectRefusal();
     });
 
-    test('Card payment no 3DS with adyen giving donation success', async () => {
+    test('Card payment no 3DS with adyen giving donation success @quick', async () => {
       await cards.doCardPayment(cardData.noThreeDs);
       await checkoutPage.completeCheckout();
       await checkoutPage.makeSuccessfulDonation();


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Enabling Apple Pay donations.
- What existing problem does this pull request solve?
This PR allows donations to be done through Apple Pay end of checkout flow and express flow.

## Tested scenarios
Description of tested scenarios:
- Donations with Apple Pay Express
- Donations with Apple Pay end of checkout
- Donations with cards
- Donations with iDeal

**Fixed issue**: SFI-525
