### PR TITLE
[SFI-516] Different live prefixes can be used accross sites

### DIFF
--- a/metadata/site_import/meta/system-objecttype-extensions.xml
+++ b/metadata/site_import/meta/system-objecttype-extensions.xml
@@ -620,6 +620,14 @@
                 <externally-managed-flag>false</externally-managed-flag>
                 <min-length>0</min-length>
             </attribute-definition>
+            <attribute-definition attribute-id="Adyen_LivePrefix">
+                <display-name xml:lang="x-default">Your Adyen Live Prefix. Required to accept live payments</display-name>
+                <description xml:lang="x-default">Retrieve this value from Customer Area</description>
+                <type>string</type>
+                <mandatory-flag>false</mandatory-flag>
+                <externally-managed-flag>false</externally-managed-flag>
+                <min-length>0</min-length>
+            </attribute-definition>
             <attribute-definition attribute-id="Adyen_GooglePayMerchantID">
                 <display-name xml:lang="x-default">Your Google MerchantID (required in production only)</display-name>
                 <description xml:lang="x-default">As described in https://developers.google.com/pay/api/web/guides/test-and-deploy/deploy-production-environment#obtain-your-merchantID</description>

--- a/src/cartridges/bm_adyen/cartridge/static/default/js/adyenSettings.js
+++ b/src/cartridges/bm_adyen/cartridge/static/default/js/adyenSettings.js
@@ -473,7 +473,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   testRadio.addEventListener('click', () => {
-    livePrefix.disabled = testRadio.value === 'TEST';
+    livePrefix.disabled = true;
   });
 
   adyenGivingBackground.addEventListener('click', saveAndHideAlerts);

--- a/src/cartridges/bm_adyen/cartridge/static/default/js/adyenSettings.js
+++ b/src/cartridges/bm_adyen/cartridge/static/default/js/adyenSettings.js
@@ -469,7 +469,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   productionRadio.addEventListener('click', () => {
-    livePrefix.disabled = productionRadio.value === 'TEST';
+    livePrefix.disabled = false;
   });
 
   testRadio.addEventListener('click', () => {

--- a/src/cartridges/bm_adyen/cartridge/static/default/js/adyenSettings.js
+++ b/src/cartridges/bm_adyen/cartridge/static/default/js/adyenSettings.js
@@ -36,6 +36,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const infoLogCheckbox = document.getElementById('infoLogs');
   const errorLogCheckbox = document.getElementById('errorLogs');
   const fatalLogCheckbox = document.getElementById('fatalLogs');
+  const testRadio = document.getElementById('testRadio');
+  const productionRadio = document.getElementById('productionRadio');
+  const livePrefix = document.getElementById('livePrefix');
   const troubleshootingCheckboxes = [
     debugLogCheckbox,
     infoLogCheckbox,
@@ -463,6 +466,14 @@ document.addEventListener('DOMContentLoaded', () => {
         JSON.stringify(Object.values(installmentsResult)),
       );
     }
+  });
+
+  productionRadio.addEventListener('click', () => {
+    livePrefix.disabled = productionRadio.value === 'TEST';
+  });
+
+  testRadio.addEventListener('click', () => {
+    livePrefix.disabled = testRadio.value === 'TEST';
   });
 
   adyenGivingBackground.addEventListener('click', saveAndHideAlerts);

--- a/src/cartridges/bm_adyen/cartridge/templates/default/adyenSettings/settingCards/requiredSettings.isml
+++ b/src/cartridges/bm_adyen/cartridge/templates/default/adyenSettings/settingCards/requiredSettings.isml
@@ -25,6 +25,16 @@
             </div>
          </div>
          <div class="form-group">
+            <label class="form-title mb-0" for="livePrefix">Adyen Live Prefix</label>
+            <small id="livePrefixHelp" class="form-text mb-1">
+               This is the LIVE prefix you can retrieve from the <a class="text-primary" href="https://ca-live.adyen.com/" target="_blank">Customer Area.</a>
+               Different sites can use different prefixes depending in the selected datacenter.
+            </small>
+            <div class="input-fields">
+               <input type="text" class="form-control" name="Adyen_LivePrefix" id="livePrefix" aria-describedby="livePrefixHelp" placeholder="" value="${AdyenConfigs.getLivePrefix() || ''}" ${AdyenConfigs.getAdyenEnvironment() === 'TEST' ? 'disabled' : ''}>
+            </div>
+         </div>
+         <div class="form-group">
             <label class="form-title mb-0" for="clienKey">Adyen Client Key</label>
             <small id="clienKeyHelp" class="form-text mb-1">
             <a class="text-primary" href="https://docs.adyen.com/development-resources/client-side-authentication#get-your-client-key" target="_blank">How to set up your client key?</a> 

--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenConfigs.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenConfigs.js
@@ -77,6 +77,10 @@ const adyenConfigsObj = {
     return getCustomPreference('Adyen_ClientKey');
   },
 
+  getLivePrefix() {
+    return getCustomPreference('Adyen_LivePrefix');
+  },
+
   getGoogleMerchantID() {
     return getCustomPreference('Adyen_GooglePayMerchantID');
   },

--- a/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
+++ b/src/cartridges/int_adyen_overlay/cartridge/scripts/util/adyenHelper.js
@@ -881,6 +881,13 @@ var adyenHelperObj = {
     if (service === null) {
       throw new Error(`Could not create ${serviceType} service object`);
     }
+
+    if (AdyenConfigs.getAdyenEnvironment() === constants.MODE.LIVE) {
+      const livePrefix = AdyenConfigs.getLivePrefix();
+      const serviceUrl = service.getURL().replace(`[YOUR_LIVE_PREFIX]`, livePrefix);
+      service.setURL(serviceUrl);
+    }
+
     const maxRetries = constants.MAX_API_RETRIES;
     const apiKey = AdyenConfigs.getAdyenApiKey();
     const uuid = UUIDUtils.createUUID();

--- a/tests/playwright/pages/PaymentMethodsPage.mjs
+++ b/tests/playwright/pages/PaymentMethodsPage.mjs
@@ -323,7 +323,7 @@ export default class PaymentMethodsPage {
   };
 
   initiateKlarnaPayment = async (klarnaVariant) => {
-    //await this.page.waitForLoadState('networkidle', { timeout: 15000 });
+    await this.page.waitForLoadState('networkidle', { timeout: 15000 });
     let klarnaSelector = this.page.locator('#rb_klarna');
     if (klarnaVariant) {
       klarnaSelector =

--- a/tests/playwright/pages/PaymentMethodsPage.mjs
+++ b/tests/playwright/pages/PaymentMethodsPage.mjs
@@ -323,7 +323,7 @@ export default class PaymentMethodsPage {
   };
 
   initiateKlarnaPayment = async (klarnaVariant) => {
-    await this.page.waitForLoadState('networkidle', { timeout: 15000 });
+    //await this.page.waitForLoadState('networkidle', { timeout: 15000 });
     let klarnaSelector = this.page.locator('#rb_klarna');
     if (klarnaVariant) {
       klarnaSelector =
@@ -441,7 +441,7 @@ export default class PaymentMethodsPage {
     this.klarnaIframe = this.page.frameLocator(
       '#klarna-apf-iframe',
     );
-    this.firstCancelButton = this.klarnaIframe.locator('#newCollectPhone__navbar__right-icon__icon-wrapper');
+    this.firstCancelButton = this.klarnaIframe.locator('#collectPhonePurchaseFlow__nav-bar__right-icon-wrapper');
     this.secondCancelButton = this.klarnaIframe.locator("button[title='Close']");
     await this.firstCancelButton.waitFor({
       state: 'visible',


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Enabling the usage of different LIVE prefixes between different sites.
- What existing problem does this pull request solve?
Possibility to use different LIVE prefixes, based on region merchant site is located.

## Tested scenarios
Description of tested scenarios:
- iDeal Payment
- Apple Pay Payment

**Fixed issue**:  SFI-516
