### PR TITLE
Get checkout payment methods adjustment

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazonPayExpressPart1.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazonPayExpressPart1.js
@@ -34,8 +34,7 @@ async function mountAmazonPayComponent() {
     updateLoadedExpressMethods(AMAZON_PAY);
     checkIfExpressMethodsAreReady();
   } catch (e) {
-    updateLoadedExpressMethods(AMAZON_PAY);
-    checkIfExpressMethodsAreReady();
+    //
   }
 }
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazonPayExpressPart1.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazonPayExpressPart1.js
@@ -1,29 +1,14 @@
 const {
   checkIfExpressMethodsAreReady,
   updateLoadedExpressMethods,
+  getPaymentMethods,
 } = require('./commons');
 
 const AMAZON_PAY = 'amazonpay';
 
 async function mountAmazonPayComponent() {
-  /**
-   * Makes an ajax call to the controller function GetPaymentMethods
-   */
-  function getPaymentMethods(paymentMethods) {
-    $.ajax({
-      url: window.getPaymentMethodsURL,
-      type: 'get',
-      success(data) {
-        paymentMethods(data);
-      },
-      error() {
-        updateLoadedExpressMethods(AMAZON_PAY);
-        checkIfExpressMethodsAreReady();
-      },
-    });
-  }
-
-  getPaymentMethods(async (data) => {
+  try {
+    const data = await getPaymentMethods();
     const paymentMethodsResponse = data.AdyenPaymentMethods;
 
     const checkout = await AdyenCheckout({
@@ -48,7 +33,10 @@ async function mountAmazonPayComponent() {
     amazonPayButton.mount('#amazonpay-container');
     updateLoadedExpressMethods(AMAZON_PAY);
     checkIfExpressMethodsAreReady();
-  });
+  } catch (e) {
+    updateLoadedExpressMethods(AMAZON_PAY);
+    checkIfExpressMethodsAreReady();
+  }
 }
 
 mountAmazonPayComponent();

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazonPayExpressPart2.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazonPayExpressPart2.js
@@ -1,3 +1,5 @@
+const { getPaymentMethods } = require('./commons');
+
 function saveShopperDetails(details) {
   $.ajax({
     url: window.saveShopperDetailsURL,
@@ -18,21 +20,6 @@ function saveShopperDetails(details) {
       select.options[0].selected = true;
       select.dispatchEvent(new Event('change'));
     },
-  });
-}
-
-function getPaymentMethods() {
-  return new Promise((resolve, reject) => {
-    $.ajax({
-      url: window.getPaymentMethodsURL,
-      type: 'get',
-      success(data) {
-        resolve(data);
-      },
-      error(error) {
-        reject(error);
-      },
-    });
   });
 }
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/commons/index.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/commons/index.js
@@ -31,6 +31,16 @@ module.exports.fetchGiftCards = async function fetchGiftCards() {
   });
 };
 
+/**
+ * Makes an ajax call to the controller function GetPaymentMethods
+ */
+module.exports.getPaymentMethods = async function getPaymentMethods() {
+  return $.ajax({
+    url: window.getPaymentMethodsURL,
+    type: 'get',
+  });
+};
+
 module.exports.checkIfExpressMethodsAreReady =
   function checkIfExpressMethodsAreReady() {
     const expressMethodsConfig = {

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/getCheckoutPaymentMethods.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/getCheckoutPaymentMethods.test.js
@@ -27,6 +27,14 @@ describe('getCheckoutPaymentMethods', () => {
          AdyenPaymentMethods: [{
             type: 'visa'
          }, ],
+         adyenConnectedTerminals: {
+            "foo": "bar",
+          },
+          adyenDescriptions: {
+            "ideal": "Dutch payment method example description",
+            "paypal": "PayPal example description",
+          },
+          imagePath: "mocked_loading_contextimages/logos/medium/",
       });
       expect(next).toHaveBeenCalled();
    });
@@ -39,6 +47,14 @@ describe('getCheckoutPaymentMethods', () => {
       getCheckoutPaymentMethods(req, res, next);
       expect(res.json).toHaveBeenCalledWith({
          AdyenPaymentMethods: [],
+         adyenConnectedTerminals: {
+            "foo": "bar",
+          },
+          adyenDescriptions: {
+            "ideal": "Dutch payment method example description",
+            "paypal": "PayPal example description",
+          },
+          imagePath: "mocked_loading_contextimages/logos/medium/",
       });
    });
 });

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/getCheckoutPaymentMethods.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/getCheckoutPaymentMethods.js
@@ -1,10 +1,33 @@
 const BasketMgr = require('dw/order/BasketMgr');
 const Locale = require('dw/util/Locale');
+const PaymentMgr = require('dw/order/PaymentMgr');
+const AdyenHelper = require('*/cartridge/scripts/util/adyenHelper');
+const adyenTerminalApi = require('*/cartridge/scripts/adyenTerminalApi');
+const paymentMethodDescriptions = require('*/cartridge/adyenConstants/paymentMethodDescriptions');
+const constants = require('*/cartridge/adyenConstants/constants');
 const getPaymentMethods = require('*/cartridge/scripts/adyenGetPaymentMethods');
 
+function getCountryCode(currentBasket, locale) {
+  const countryCode = Locale.getLocale(locale.id).country;
+  const firstItem = currentBasket?.getShipments()?.[0];
+  if (firstItem?.shippingAddress) {
+    return firstItem.shippingAddress.getCountryCode().value;
+  }
+  return countryCode;
+}
+
+function getConnectedTerminals() {
+  if (PaymentMgr.getPaymentMethod(constants.METHOD_ADYEN_POS).isActive()) {
+    return adyenTerminalApi.getTerminals().response;
+  }
+  return '{}';
+}
+
 function getCheckoutPaymentMethods(req, res, next) {
-  let countryCode = Locale.getLocale(req.locale.id).country;
   const currentBasket = BasketMgr.getCurrentBasket();
+  let countryCode = getCountryCode(currentBasket, req.locale);
+  const adyenURL = `${AdyenHelper.getLoadingContext()}images/logos/medium/`;
+  const connectedTerminals = getConnectedTerminals();
   if (
     currentBasket.getShipments().length > 0 &&
     currentBasket.getShipments()[0].shippingAddress
@@ -25,6 +48,9 @@ function getCheckoutPaymentMethods(req, res, next) {
 
   res.json({
     AdyenPaymentMethods: paymentMethods,
+    imagePath: adyenURL,
+    adyenDescriptions: paymentMethodDescriptions,
+    adyenConnectedTerminals: JSON.parse(connectedTerminals),
   });
   return next();
 }


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Preparing for the removal of the sessions call.
- What existing problem does this pull request solve? 
It returns the payment methods call with the connected terminals, descriptions and imagePath, similar on how /sessions it's doing now.


## Tested scenarios
Description of tested scenarios:
- Amazon Pay Express ( which uses `/paymentMethods` call )

**Fixed issue**:  SFI-549
