### PR TITLE
Replaced /sessions with /paymentMethods for apple pay express

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/applePayExpress.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/applePayExpress.js
@@ -5,16 +5,21 @@ const { APPLE_PAY } = require('./constants');
 
 let checkout;
 let shippingMethodsData;
+let paymentMethodsResponse;
 
 async function initializeCheckout() {
-  const shippingMethods = await fetch(window.shippingMethodsUrl);
-  shippingMethodsData = await shippingMethods.json();
-
-  checkout = await AdyenCheckout({
-    environment: window.environment,
-    clientKey: window.clientKey,
-    locale: window.locale,
-  });
+  try {
+    paymentMethodsResponse = await getPaymentMethods();
+    const shippingMethods = await fetch(window.shippingMethodsUrl);
+    shippingMethodsData = await shippingMethods.json();
+    checkout = await AdyenCheckout({
+      environment: window.environment,
+      clientKey: window.clientKey,
+      locale: window.locale,
+    });
+  } catch (e) {
+    //
+  }
 }
 
 async function createApplePayButton(applePayButtonConfig) {
@@ -121,9 +126,8 @@ function callPaymentFromComponent(data, resolveApplePay, rejectApplePay) {
 
 initializeCheckout()
   .then(async () => {
-    const paymentMethodsResponse = await getPaymentMethods();
     const applePayPaymentMethod =
-      paymentMethodsResponse.AdyenPaymentMethods.find(
+      paymentMethodsResponse?.AdyenPaymentMethods.find(
         (pm) => pm.type === APPLE_PAY,
       );
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/applePayExpress.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/applePayExpress.js
@@ -8,18 +8,14 @@ let shippingMethodsData;
 let paymentMethodsResponse;
 
 async function initializeCheckout() {
-  try {
-    paymentMethodsResponse = await getPaymentMethods();
-    const shippingMethods = await fetch(window.shippingMethodsUrl);
-    shippingMethodsData = await shippingMethods.json();
-    checkout = await AdyenCheckout({
-      environment: window.environment,
-      clientKey: window.clientKey,
-      locale: window.locale,
-    });
-  } catch (e) {
-    //
-  }
+  paymentMethodsResponse = await getPaymentMethods();
+  const shippingMethods = await fetch(window.shippingMethodsUrl);
+  shippingMethodsData = await shippingMethods.json();
+  checkout = await AdyenCheckout({
+    environment: window.environment,
+    clientKey: window.clientKey,
+    locale: window.locale,
+  });
 }
 
 async function createApplePayButton(applePayButtonConfig) {

--- a/src/cartridges/int_adyen_SFRA/cartridge/templates/default/cart/checkoutButtons.isml
+++ b/src/cartridges/int_adyen_SFRA/cartridge/templates/default/cart/checkoutButtons.isml
@@ -60,6 +60,7 @@
             window.digitsNumber = "${pdict.AdyenHelper.getFractionDigits(
                 pdict.AdyenHelper.getBasketAmount().currencyCode
             )}";
+            window.basketAmount = "${pdict.AdyenHelper.getBasketAmount()}".replace(/&quot;/g, '\"');
         </script>
         <div class="mb-sm-3">
             <a


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Removal of /sessions call from the cartridge
- What existing problem does this pull request solve?
It replaces the /sessions call with /paymentMethods call for Apple Pay Express flow.


## Tested scenarios
Description of tested scenarios:
- Apple Pay Express
- Apple Pay End of Checkout

**Fixed issue**:  SFI-458
