### PR TITLE
Converting Adyen_authResult from string to text

### DIFF
--- a/metadata/site_import/meta/system-objecttype-extensions.xml
+++ b/metadata/site_import/meta/system-objecttype-extensions.xml
@@ -296,7 +296,7 @@
             </attribute-definition>
             <attribute-definition attribute-id="Adyen_authResult">
                 <display-name xml:lang="x-default">Adyen_authResult</display-name>
-                <type>string</type>
+                <type>text</type>
                 <mandatory-flag>false</mandatory-flag>
                 <externally-managed-flag>false</externally-managed-flag>
             </attribute-definition>


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
`Adyen_authResult` can exceed the character limit of the string
- What existing problem does this pull request solve?
It uses type text to store `Adyen_authResult`, which is a safer option than string as it can accomodate a bigger amount of characters.

## Tested scenarios
Description of tested scenarios:
- 3DS2 Payment
- E2E workflow

**Fixed issue**:  SFI-609
