### PR TITLE
Replaced /sessions with /paymentMethods from end of checkout

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/__tests__/__snapshots__/renderGenericComponent.test.js.snap
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/__tests__/__snapshots__/renderGenericComponent.test.js.snap
@@ -2,7 +2,10 @@
 
 exports[`Render Generic Component should hide giftcard container 1`] = `
 {
-  "amount": "mocked_amount",
+  "amount": {
+    "currency": "mocked_currency",
+    "value": "mocked_amount",
+  },
   "countryCode": "mocked_countrycode",
   "paymentMethodsConfiguration": {
     "amazonpay": {
@@ -18,18 +21,18 @@ exports[`Render Generic Component should hide giftcard container 1`] = `
       "configuration": undefined,
     },
   },
-  "session": {
-    "adyenDescriptions": {},
-    "id": "mock_id",
+  "paymentMethodsResponse": {
     "imagePath": "example.com",
-    "sessionData": "mock_session_data",
   },
 }
 `;
 
 exports[`Render Generic Component should render 1`] = `
 {
-  "amount": "mocked_amount",
+  "amount": {
+    "currency": "mocked_currency",
+    "value": "mocked_amount",
+  },
   "countryCode": "mocked_countrycode",
   "paymentMethodsConfiguration": {
     "amazonpay": {
@@ -45,11 +48,8 @@ exports[`Render Generic Component should render 1`] = `
       "configuration": undefined,
     },
   },
-  "session": {
-    "adyenDescriptions": {},
-    "id": "mock_id",
+  "paymentMethodsResponse": {
     "imagePath": "example.com",
-    "sessionData": "mock_session_data",
   },
 }
 `;

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/__tests__/renderGiftcardComponent.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/__tests__/renderGiftcardComponent.test.js
@@ -35,7 +35,7 @@ beforeEach(() => {
   }));
   window.Configuration = { amount: 0 };
   store.checkoutConfiguration = {
-    session: {
+    paymentMethodsResponse: {
       imagePath: 'test_image_path',
     },
   };

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
@@ -24,7 +24,7 @@ function getCardConfig() {
       store.isValid = state.isValid;
       const method = state.data.paymentMethod.storedPaymentMethodId
         ? `storedCard${state.data.paymentMethod.storedPaymentMethodId}`
-        : store.selectedMethod;
+        : constants.SCHEME;
       store.updateSelectedPayment(method, 'isValid', store.isValid);
       store.updateSelectedPayment(method, 'stateData', state.data);
     },

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGiftcardComponent.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGiftcardComponent.js
@@ -128,7 +128,7 @@ function renderGiftCardSelectForm() {
     return;
   }
 
-  const { imagePath } = store.checkoutConfiguration.session;
+  const { imagePath } = store.checkoutConfiguration.paymentMethodsResponse;
 
   giftCardBrands().forEach((giftCard) => {
     const newListItem = document.createElement('li');
@@ -277,7 +277,7 @@ function clearGiftCardsContainer() {
 
 function renderAddedGiftCard(card) {
   const giftCardData = card.giftCard;
-  const { imagePath } = store.checkoutConfiguration.session;
+  const { imagePath } = store.checkoutConfiguration.paymentMethodsResponse;
 
   const { giftCardsList, giftCardAddButton } = getGiftCardElements();
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazonPayExpressPart1.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazonPayExpressPart1.js
@@ -17,7 +17,7 @@ async function mountAmazonPayComponent() {
       locale: window.locale,
     });
 
-    const amazonPayConfig = paymentMethodsResponse.find(
+    const amazonPayConfig = paymentMethodsResponse?.paymentMethods.find(
       (pm) => pm.type === AMAZON_PAY,
     )?.configuration;
     if (!amazonPayConfig) return;

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazonPayExpressPart2.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/amazonPayExpressPart2.js
@@ -80,7 +80,7 @@ async function mountAmazonPayComponent() {
   try {
     const data = await getPaymentMethods();
     const paymentMethodsResponse = data.AdyenPaymentMethods;
-    const amazonPayConfig = paymentMethodsResponse.find(
+    const amazonPayConfig = paymentMethodsResponse?.paymentMethods.find(
       (pm) => pm.type === 'amazonpay',
     )?.configuration;
     if (!amazonPayConfig) return;

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/applePayExpress.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/applePayExpress.js
@@ -123,7 +123,7 @@ function callPaymentFromComponent(data, resolveApplePay, rejectApplePay) {
 initializeCheckout()
   .then(async () => {
     const applePayPaymentMethod =
-      paymentMethodsResponse?.AdyenPaymentMethods.find(
+      paymentMethodsResponse?.AdyenPaymentMethods?.paymentMethods.find(
         (pm) => pm.type === APPLE_PAY,
       );
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/constants.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/constants.js
@@ -8,6 +8,7 @@ module.exports = {
   NOTENOUGHBALANCE: 'NotEnoughBalance',
   SUCCESS: 'Success',
   GIFTCARD: 'giftcard',
+  SCHEME: 'scheme',
   GIROPAY: 'giropay',
   APPLE_PAY: 'applepay',
   ACTIONTYPE: {

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/getCheckoutPaymentMethods.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/getCheckoutPaymentMethods.test.js
@@ -56,7 +56,7 @@ describe('getCheckoutPaymentMethods', () => {
          new Logger.error('error'),
       );
       getCheckoutPaymentMethods(req, res, next);
-      expect(res.json).not.toHaveBeenCalledWith();
+      expect(res.json).not.toHaveBeenCalled();
       expect(Logger.fatal.mock.calls.length).toBe(1);
    });
 });

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/getCheckoutPaymentMethods.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/getCheckoutPaymentMethods.test.js
@@ -4,6 +4,7 @@ const getPaymentMethods = require('*/cartridge/scripts/adyenGetPaymentMethods');
 let req;
 let res;
 let next;
+let Logger;
 beforeEach(() => {
    req = {
       locale: {
@@ -14,6 +15,7 @@ beforeEach(() => {
       json: jest.fn(),
    };
    next = jest.fn();
+   Logger = require('dw/system/Logger');
 });
 
 afterEach(() => {
@@ -54,21 +56,7 @@ describe('getCheckoutPaymentMethods', () => {
          new Logger.error('error'),
       );
       getCheckoutPaymentMethods(req, res, next);
-      expect(res.json).toHaveBeenCalledWith({
-         AdyenPaymentMethods: [],
-         amount: {
-            currency: "EUR",
-            value: 1000,
-         },
-         adyenConnectedTerminals: {
-            "foo": "bar",
-          },
-          adyenDescriptions: {
-            "ideal": "Dutch payment method example description",
-            "paypal": "PayPal example description",
-          },
-          imagePath: "mocked_loading_contextimages/logos/medium/",
-          countryCode: "NL",
-      });
+      expect(res.json).not.toHaveBeenCalledWith();
+      expect(Logger.fatal.mock.calls.length).toBe(1);
    });
 });

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/getCheckoutPaymentMethods.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/getCheckoutPaymentMethods.test.js
@@ -24,9 +24,17 @@ describe('getCheckoutPaymentMethods', () => {
    it('returns AdyenPaymentMethods', () => {
       getCheckoutPaymentMethods(req, res, next);
       expect(res.json).toHaveBeenCalledWith({
-         AdyenPaymentMethods: [{
-            type: 'visa'
-         }, ],
+         AdyenPaymentMethods:  {
+            paymentMethods: [
+               {
+                  "type": "visa",
+               },
+            ],
+         },
+         amount: {
+            currency: "EUR",
+            value: 1000,
+         },
          adyenConnectedTerminals: {
             "foo": "bar",
           },
@@ -35,6 +43,7 @@ describe('getCheckoutPaymentMethods', () => {
             "paypal": "PayPal example description",
           },
           imagePath: "mocked_loading_contextimages/logos/medium/",
+          countryCode: "NL",
       });
       expect(next).toHaveBeenCalled();
    });
@@ -47,6 +56,10 @@ describe('getCheckoutPaymentMethods', () => {
       getCheckoutPaymentMethods(req, res, next);
       expect(res.json).toHaveBeenCalledWith({
          AdyenPaymentMethods: [],
+         amount: {
+            currency: "EUR",
+            value: 1000,
+         },
          adyenConnectedTerminals: {
             "foo": "bar",
           },
@@ -55,6 +68,7 @@ describe('getCheckoutPaymentMethods', () => {
             "paypal": "PayPal example description",
           },
           imagePath: "mocked_loading_contextimages/logos/medium/",
+          countryCode: "NL",
       });
    });
 });

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/getCheckoutPaymentMethods.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/getCheckoutPaymentMethods.js
@@ -6,6 +6,7 @@ const adyenTerminalApi = require('*/cartridge/scripts/adyenTerminalApi');
 const paymentMethodDescriptions = require('*/cartridge/adyenConstants/paymentMethodDescriptions');
 const constants = require('*/cartridge/adyenConstants/constants');
 const getPaymentMethods = require('*/cartridge/scripts/adyenGetPaymentMethods');
+const AdyenLogs = require('*/cartridge/scripts/adyenCustomLogs');
 
 function getCountryCode(currentBasket, locale) {
   const countryCode = Locale.getLocale(locale.id).country;
@@ -43,17 +44,19 @@ function getCheckoutPaymentMethods(req, res, next) {
       AdyenHelper.getCustomer(req.currentCustomer),
       countryCode,
     );
+    res.json({
+      AdyenPaymentMethods: paymentMethods,
+      imagePath: adyenURL,
+      adyenDescriptions: paymentMethodDescriptions,
+      adyenConnectedTerminals: connectedTerminals,
+      amount: { value: paymentAmount.value, currency },
+      countryCode,
+    });
   } catch (err) {
-    paymentMethods = [];
+    AdyenLogs.fatal_log(
+      `Failed to fetch payment methods ${JSON.stringify(err)}`,
+    );
   }
-  res.json({
-    AdyenPaymentMethods: paymentMethods,
-    imagePath: adyenURL,
-    adyenDescriptions: paymentMethodDescriptions,
-    adyenConnectedTerminals: connectedTerminals,
-    amount: { value: paymentAmount.value, currency },
-    countryCode,
-  });
   return next();
 }
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/templates/default/checkout/billing/adyenComponentForm.isml
+++ b/src/cartridges/int_adyen_SFRA/cartridge/templates/default/checkout/billing/adyenComponentForm.isml
@@ -22,7 +22,8 @@
       window.ShowConfirmationPaymentFromComponent = "${ShowConfirmationPaymentFromComponent}";
       window.AdyenSFRA6Enabled = '${pdict.adyen.SFRA6Enabled}';
       window.klarnaWidgetEnabled = ${adyenKlarnaWidgetEnabled};
-      window.sessionsUrl = "${URLUtils.https('Adyen-Sessions')}";
+      window.adyenRecurringPaymentsEnabled = ${adyenRecurringPaymentsEnabled};
+      window.getPaymentMethodsURL = "${URLUtils.https('Adyen-GetPaymentMethods')}";
       window.checkBalanceUrl = "${URLUtils.https('Adyen-CheckBalance')}";
       window.partialPaymentsOrderUrl = "${URLUtils.https('Adyen-PartialPaymentsOrder')}";
       window.partialPaymentUrl = "${URLUtils.https('Adyen-partialPayment')}";


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Removing the `/sessions` call from the cartridges
- What existing problem does this pull request solve?
It replaces `/sessions` with `/paymentMethods` for end of checkout flow.


## Tested scenarios
Description of tested scenarios:
- Card payments
- Redirect payments (iDeal, Klarna)
- Single gift card payments
- Multiple gift card payment + card
- Logged in user end of checkout payment
- PayPal
- UPI
- CashApp
- Bancontact

**Fixed issue**:  SFI-550
