### PR TITLE
Remove sessions call from My Account

### DIFF
--- a/jest/globals.js
+++ b/jest/globals.js
@@ -23,6 +23,9 @@ global.AdyenCheckout = () => {
   return Promise.resolve({
     create: () => {
       return { mount: jest.fn() };
-    }
+    },
+    createFromAction: () => {
+      return { mount: jest.fn() };
+    },
   });
 };

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyenAccount.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyenAccount.js
@@ -1,4 +1,4 @@
-const { onFieldValid, onBrand, createSession } = require('./commons/index');
+const { onFieldValid, onBrand } = require('./commons/index');
 const store = require('../../../store');
 
 let checkout;
@@ -53,12 +53,6 @@ store.checkoutConfiguration.onAdditionalDetails = (state) => {
 };
 
 async function initializeCardComponent() {
-  // card and checkout component creation
-  const session = await createSession();
-  store.checkoutConfiguration.session = {
-    id: session.id,
-    sessionData: session.sessionData,
-  };
   const cardNode = document.getElementById('card');
   checkout = await AdyenCheckout(store.checkoutConfiguration);
   card = checkout.create('card').mount(cardNode);
@@ -102,3 +96,8 @@ $('button[value="add-new-payment"]').on('click', (event) => {
     card?.showValidation();
   }
 });
+
+module.exports = {
+  initializeCardComponent,
+  submitAddCard,
+};

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/__tests__/adyenAccount.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/__tests__/adyenAccount.test.js
@@ -1,0 +1,86 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const store = require('../../../../../store');
+const {initializeCardComponent, submitAddCard} = require('../../adyenAccount')
+$.fn.modal = jest.fn();
+
+jest.mock('../../commons');
+jest.mock('../../../../../store');
+let checkout;
+// Mocking external dependencies
+jest.mock('../../../../../store', () => ({
+  checkoutConfiguration: {
+    amount: { value: 0, currency: 'EUR' },
+    paymentMethodsConfiguration: {
+      card: {
+        onChange: jest.fn(),
+      },
+    },
+    onAdditionalDetails: jest.fn(),
+  },
+}));   
+
+describe('submitAddCard', () => {
+  beforeEach(() => {
+    store.checkoutConfiguration = {};
+    
+    jest.clearAllMocks();
+  });
+
+  it('initialize card component', async () => {
+    document.body.innerHTML = `<div id="card"></div>`;
+    await initializeCardComponent();
+    expect(document.getElementById('card')).toBeDefined();
+  });
+
+  it('should send form data via ajax on submitAddCard call', () => {
+    const fakeResponse = {redirectAction : 'test'};
+    document.body.innerHTML = `<form id="payment-form" action="/fake-action">
+      <input type="text" name="fake" value="fake" />
+    </form>`;
+    $.ajax = jest.fn(({ success }) => {
+        success(fakeResponse);
+        return { fail: jest.fn() };
+      });
+    submitAddCard();
+    expect($.ajax).toHaveBeenCalledWith({
+      type: 'POST',
+      url: '/fake-action',
+      data: 'fake=fake',
+      async: false,
+      success: expect.any(Function),
+    });
+  });
+
+  it('should handle redirection action after successful form submission', () => {
+    const fakeRedirectAction = { type: 'redirect' };
+    document.body.innerHTML = `<form id="payment-form" action="/fake-action">
+      <input type="text" name="fake" value="fake" />
+    </form>`;
+    $.ajax = jest.fn(({ success }) => {
+      success({ redirectAction: fakeRedirectAction });
+      return { fail: jest.fn() };
+    });
+    window.location.href = '';
+    submitAddCard();
+    expect(window.location.href).toBe('http://localhost/');
+  }); 
+
+  it('should handle errors returned from the server during form submission', () => {
+    let formErrorsExist = false
+    const fakeErrorResponse = { error: 'Something went wrong' };
+    $.ajax = jest.fn(({ success }) => {
+      success(fakeErrorResponse);
+      return { fail: jest.fn() };
+    });
+    submitAddCard();
+    setTimeout(() => {
+        expect(formErrorsExist).toBeTruthy();
+        done();
+      }); // Timeout needed for completition of the test
+  }); 
+
+});
+

--- a/tests/playwright/fixtures/countriesEUR/FR.spec.mjs
+++ b/tests/playwright/fixtures/countriesEUR/FR.spec.mjs
@@ -77,7 +77,7 @@ test.describe.parallel(`${environment.name} EUR FR`, () => {
     await checkoutPage.expectSuccess();
   });
 
-  test('Amazon Pay Express @quick', async ({ page }) => {
+  test('Amazon Pay Express', async ({ page }) => {
     redirectShopper = new RedirectShopper(page);
     await checkoutPage.addProductToCart();
     await checkoutPage.navigateToCart(regionsEnum.EU);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Removing the /sessions call from the cartridge
- What existing problem does this pull request solve?
It removes completely the /sessions call from My Account as it is not necessary for mounting the card component inside My Account page. For rendering the stored payment methods inside My Account section `updateSaveCards()` takes care. 


## Tested scenarios
Description of tested scenarios:
- Adding cards from My Account
- Removing cards from My Account
- Saving card for logged in user in end of checkout and confirming it in My Account, and vice versa

**Fixed issue**:  SFI-560
