### PR TITLE
Re-initialize checkout when order amount is changed

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -89,6 +89,7 @@ module.exports = {
     "object-curly-newline": ["error", {
       "ImportDeclaration": { multiline: true, "minProperties": 4 }
     }],
+    "import/prefer-default-export": "off",
     "implicit-arrow-linebreak": "off",
     "no-param-reassign": ["error", { "props": false }]
   },

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGenericComponent.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGenericComponent.js
@@ -216,7 +216,7 @@ function setGiftCardContainerVisibility() {
   }
 }
 
-async function initializeCheckout() {
+export async function initializeCheckout() {
   const paymentMethodsResponse = await getPaymentMethods();
   const giftCardsData = await fetchGiftCards();
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGiftcardComponent.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGiftcardComponent.js
@@ -1,6 +1,6 @@
 const store = require('../../../../store');
 const constants = require('../constants');
-const { INIT_CHECKOUT_EVENT } = require('./renderGenericComponent');
+const { initializeCheckout } = require('./renderGenericComponent');
 
 function getGiftCardElements() {
   const giftCardSelect = document.querySelector('#giftCardSelect');
@@ -106,8 +106,7 @@ function removeGiftCards() {
             ?.parentNode.remove();
           store.componentsObj?.giftcard?.node.unmount('component_giftcard');
         }
-        const event = new Event(INIT_CHECKOUT_EVENT);
-        document.dispatchEvent(event);
+        initializeCheckout();
       },
     });
   });

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/getCheckoutPaymentMethods.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/__tests__/getCheckoutPaymentMethods.test.js
@@ -56,7 +56,10 @@ describe('getCheckoutPaymentMethods', () => {
          new Logger.error('error'),
       );
       getCheckoutPaymentMethods(req, res, next);
-      expect(res.json).not.toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith({
+         error: true,
+       });      
       expect(Logger.fatal.mock.calls.length).toBe(1);
+      expect(next).toHaveBeenCalled();
    });
 });

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/getCheckoutPaymentMethods.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/getCheckoutPaymentMethods.js
@@ -34,9 +34,18 @@ function getCheckoutPaymentMethods(req, res, next) {
   const adyenURL = `${AdyenHelper.getLoadingContext()}images/logos/medium/`;
   const connectedTerminals = JSON.parse(getConnectedTerminals());
   const currency = currentBasket.getTotalGrossPrice().currencyCode;
-  const paymentAmount = currentBasket.getTotalGrossPrice().isAvailable()
-    ? AdyenHelper.getCurrencyValueForApi(currentBasket.getTotalGrossPrice())
-    : new dw.value.Money(1000, currency);
+  const getRemainingAmount = (giftCardResponse) => {
+    if (giftCardResponse && JSON.parse(giftCardResponse).remainingAmount) {
+      return JSON.parse(giftCardResponse).remainingAmount;
+    }
+    return {
+      currency,
+      value: AdyenHelper.getCurrencyValueForApi(
+        currentBasket.getTotalGrossPrice(),
+      ).value,
+    };
+  };
+  const paymentAmount = getRemainingAmount(session.privacy.giftCardResponse);
   let paymentMethods;
   try {
     paymentMethods = getPaymentMethods.getMethods(

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/getCheckoutPaymentMethods.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/adyen/getCheckoutPaymentMethods.js
@@ -25,30 +25,29 @@ function getConnectedTerminals() {
 }
 
 function getCheckoutPaymentMethods(req, res, next) {
-  const currentBasket = BasketMgr.getCurrentBasket();
-  const countryCode =
-    currentBasket.getShipments().length > 0 &&
-    currentBasket.getShipments()[0].shippingAddress
-      ? currentBasket.getShipments()[0].shippingAddress.getCountryCode().value
-      : getCountryCode(currentBasket, req.locale).value;
-  const adyenURL = `${AdyenHelper.getLoadingContext()}images/logos/medium/`;
-  const connectedTerminals = JSON.parse(getConnectedTerminals());
-  const currency = currentBasket.getTotalGrossPrice().currencyCode;
-  const getRemainingAmount = (giftCardResponse) => {
-    if (giftCardResponse && JSON.parse(giftCardResponse).remainingAmount) {
-      return JSON.parse(giftCardResponse).remainingAmount;
-    }
-    return {
-      currency,
-      value: AdyenHelper.getCurrencyValueForApi(
-        currentBasket.getTotalGrossPrice(),
-      ).value,
-    };
-  };
-  const paymentAmount = getRemainingAmount(session.privacy.giftCardResponse);
-  let paymentMethods;
   try {
-    paymentMethods = getPaymentMethods.getMethods(
+    const currentBasket = BasketMgr.getCurrentBasket();
+    const countryCode =
+      currentBasket.getShipments().length > 0 &&
+      currentBasket.getShipments()[0].shippingAddress
+        ? currentBasket.getShipments()[0].shippingAddress.getCountryCode().value
+        : getCountryCode(currentBasket, req.locale).value;
+    const adyenURL = `${AdyenHelper.getLoadingContext()}images/logos/medium/`;
+    const connectedTerminals = JSON.parse(getConnectedTerminals());
+    const currency = currentBasket.getTotalGrossPrice().currencyCode;
+    const getRemainingAmount = (giftCardResponse) => {
+      if (giftCardResponse && JSON.parse(giftCardResponse).remainingAmount) {
+        return JSON.parse(giftCardResponse).remainingAmount;
+      }
+      return {
+        currency,
+        value: AdyenHelper.getCurrencyValueForApi(
+          currentBasket.getTotalGrossPrice(),
+        ).value,
+      };
+    };
+    const paymentAmount = getRemainingAmount(session.privacy.giftCardResponse);
+    const paymentMethods = getPaymentMethods.getMethods(
       currentBasket,
       AdyenHelper.getCustomer(req.currentCustomer),
       countryCode,
@@ -65,6 +64,7 @@ function getCheckoutPaymentMethods(req, res, next) {
     AdyenLogs.fatal_log(
       `Failed to fetch payment methods ${JSON.stringify(err)}`,
     );
+    res.json({ error: true });
   }
   return next();
 }

--- a/tests/playwright/pages/AccountPageSFRA.mjs
+++ b/tests/playwright/pages/AccountPageSFRA.mjs
@@ -28,7 +28,7 @@ export default class AccountPageSFRA {
         .locator('.input-field')
         .type(cardInput.cvc);
     }
-    await this.page.waitForLoadState('networkidle', { timeout: 15000 });
+    await this.page.waitForLoadState('networkidle', { timeout: 20000 });
     await this.page.click('button[name="save"]');
   };
 
@@ -41,7 +41,7 @@ export default class AccountPageSFRA {
     const cardElement = this.savedCardElementGenerator(cardData);
     const deleteButton = cardElement.locator('../../button');
 
-    await this.page.waitForLoadState('networkidle', { timeout: 15000 });
+    await this.page.waitForLoadState('networkidle', { timeout: 20000 });
 
     await deleteButton.click();
     await this.page.click('.delete-confirmation-btn');
@@ -52,7 +52,7 @@ export default class AccountPageSFRA {
 
     await cardElement.waitFor({
       state: 'visible',
-      timeout: 15000,
+      timeout: 20000,
     });
   };
 
@@ -65,7 +65,7 @@ export default class AccountPageSFRA {
 
     await cardElement.waitFor({
       state: 'detached',
-      timeout: 15000,
+      timeout: 20000,
     });
   };
 

--- a/tests/playwright/pages/CheckoutPageSFRA5.mjs
+++ b/tests/playwright/pages/CheckoutPageSFRA5.mjs
@@ -88,7 +88,7 @@ export default class CheckoutPageSFRA5 {
 
   isPaymentModalShown = async (imgAltValue) => {
     await expect(this.paymentModal.locator(`img[alt='${imgAltValue}']`))
-      .toBeVisible({ timeout: 15000 });
+      .toBeVisible({ timeout: 20000 });
   }
 
   navigateToCheckout = async (locale) => {
@@ -101,7 +101,7 @@ export default class CheckoutPageSFRA5 {
 
   goToCheckoutPageWithFullCart = async (locale, itemCount = 1) => {
     await this.addProductToCart(locale, itemCount);
-    await this.successMessage.waitFor({ visible: true, timeout: 15000 });
+    await this.successMessage.waitFor({ visible: true, timeout: 20000 });
 
     await this.navigateToCheckout(locale);
     await this.checkoutGuest.click();
@@ -166,20 +166,20 @@ export default class CheckoutPageSFRA5 {
   };
 
   submitShipping = async () => {
-    await this.page.waitForLoadState('networkidle', { timeout: 15000 });
+    await this.page.waitForLoadState('networkidle', { timeout: 20000 });
     await this.shippingSubmit.click();
-    await this.page.waitForNavigation({ waitUntil: "networkidle", timeout: 15000 });
+    await this.page.waitForNavigation({ waitUntil: "networkidle", timeout: 20000 });
 
     // Ugly wait since the submit button takes time to mount.
     await new Promise(r => setTimeout(r, 2000));
   };
 
   submitPayment = async () => {
-    await this.page.waitForLoadState('networkidle', { timeout: 15000 });
+    await this.page.waitForLoadState('networkidle', { timeout: 20000 });
     await this.submitPaymentButton.click();
   };
   placeOrder = async () => {
-    await this.page.waitForLoadState('networkidle', { timeout: 15000 });
+    await this.page.waitForLoadState('networkidle', { timeout: 20000 });
     await this.placeOrderButton.click();
   };
 
@@ -193,7 +193,7 @@ export default class CheckoutPageSFRA5 {
   };
 
   goBackAndSubmitShipping = async () => {
-    await this.page.waitForNavigation('load', { timeout: 15000 });
+    await this.page.waitForNavigation('load', { timeout: 20000 });
     await this.navigateBack();
     await this.submitShipping();
   };
@@ -203,11 +203,11 @@ export default class CheckoutPageSFRA5 {
       url: /Order-Confirm/,
       timeout: 20000,
     });
-    await expect(this.thankYouMessage).toBeVisible({ timeout: 15000 });
+    await expect(this.thankYouMessage).toBeVisible({ timeout: 20000 });
   };
 
   expectNonRedirectSuccess = async () => {
-    await expect(this.thankYouMessage).toBeVisible({ timeout: 15000 });
+    await expect(this.thankYouMessage).toBeVisible({ timeout: 20000 });
   };
 
   expectRefusal = async () => {
@@ -215,13 +215,13 @@ export default class CheckoutPageSFRA5 {
   };
 
   expectVoucher = async () => {
-    await expect(this.voucherCode).toBeVisible({ timeout: 15000 });
+    await expect(this.voucherCode).toBeVisible({ timeout: 20000 });
   };
 
   expectQRcode = async () => {
-    await this.qrLoader.waitFor({ state: 'attached', timeout: 15000 });
-    await expect(this.qrLoaderAmount).toBeVisible({ timeout: 15000 });
-    await expect(this.qrImg).toBeVisible({ timeout: 15000 });
+    await this.qrLoader.waitFor({ state: 'attached', timeout: 20000 });
+    await expect(this.qrLoaderAmount).toBeVisible({ timeout: 20000 });
+    await expect(this.qrImg).toBeVisible({ timeout: 20000 });
   };
 
   expectGiftCardWarning = async () => {
@@ -229,14 +229,14 @@ export default class CheckoutPageSFRA5 {
   };
 
   getLocation = async () => {
-    await this.page.waitForLoadState('load', { timeout: 15000 });
+    await this.page.waitForLoadState('load', { timeout: 20000 });
     return await this.page.url();
   };
 
   navigateBack = async () => {
-    await this.page.waitForLoadState('networkidle', { timeout: 15000 });
+    await this.page.waitForLoadState('networkidle', { timeout: 20000 });
     await this.page.goBack();
-    await this.page.waitForLoadState('networkidle', { timeout: 15000 });
+    await this.page.waitForLoadState('networkidle', { timeout: 20000 });
   };
 
   loginUser = async (credentials) => {

--- a/tests/playwright/pages/CheckoutPageSFRA5.mjs
+++ b/tests/playwright/pages/CheckoutPageSFRA5.mjs
@@ -161,7 +161,6 @@ export default class CheckoutPageSFRA5 {
     /* After filling the shopper details, clicking "Next" has an autoscroll
     feature, which leads the email field to be missed, hence the flakiness.
     Waiting until the full page load prevents this situation */
-    await this.page.waitForLoadState('networkidle');
     await this.checkoutPageUserEmailInput.fill('');
     await this.checkoutPageUserEmailInput.fill('test@adyenTest.com');
     // Pressing Tab to simulate component re-rendering and waiting the components to re-mount

--- a/tests/playwright/pages/CheckoutPageSFRA5.mjs
+++ b/tests/playwright/pages/CheckoutPageSFRA5.mjs
@@ -158,9 +158,6 @@ export default class CheckoutPageSFRA5 {
   };
 
   setEmail = async () => {
-    /* After filling the shopper details, clicking "Next" has an autoscroll
-    feature, which leads the email field to be missed, hence the flakiness.
-    Waiting until the full page load prevents this situation */
     await this.checkoutPageUserEmailInput.fill('');
     await this.checkoutPageUserEmailInput.fill('test@adyenTest.com');
     // Pressing Tab to simulate component re-rendering and waiting the components to re-mount

--- a/tests/playwright/pages/CheckoutPageSFRA6.mjs
+++ b/tests/playwright/pages/CheckoutPageSFRA6.mjs
@@ -89,7 +89,7 @@ export default class CheckoutPageSFRA {
 
   isPaymentModalShown = async (imgAltValue) => {
     await expect(this.paymentModal.locator(`img[alt='${imgAltValue}']`))
-      .toBeVisible({ timeout: 15000 });
+      .toBeVisible({ timeout: 20000 });
   }
 
   navigateToCheckout = async (locale) => {
@@ -102,7 +102,7 @@ export default class CheckoutPageSFRA {
 
   goToCheckoutPageWithFullCart = async (locale, itemCount = 1) => {
     await this.addProductToCart(locale, itemCount);
-    await this.successMessage.waitFor({ visible: true, timeout: 15000 });
+    await this.successMessage.waitFor({ visible: true, timeout: 20000 });
 
     await this.navigateToCheckout(locale);
     await this.setEmail();
@@ -127,7 +127,7 @@ export default class CheckoutPageSFRA {
   };
 
   setShopperDetails = async (shopperDetails) => {
-    await this.customerInfoSection.waitFor({ visible: true, timeout: 15000 });
+    await this.customerInfoSection.waitFor({ visible: true, timeout: 20000 });
 
 
     await this.checkoutPageUserFirstNameInput.type(
@@ -175,16 +175,16 @@ export default class CheckoutPageSFRA {
   };
 
   submitShipping = async () => {
-    await this.page.waitForLoadState('networkidle', { timeout: 15000 });
+    await this.page.waitForLoadState('networkidle', { timeout: 20000 });
     await this.shippingSubmit.click();
-    await this.page.waitForNavigation({ waitUntil: "networkidle", timeout: 15000 });
+    await this.page.waitForNavigation({ waitUntil: "networkidle", timeout: 20000 });
 
     // Ugly wait since the submit button takes time to mount.
     await new Promise(r => setTimeout(r, 2000));
   };
 
   submitPayment = async () => {
-    await this.page.waitForLoadState('load', { timeout: 15000 });
+    await this.page.waitForLoadState('load', { timeout: 20000 });
     await this.submitPaymentButton.click();
   };
 
@@ -192,7 +192,7 @@ export default class CheckoutPageSFRA {
     let retries = 3;
     while (retries > 0) {
       try {
-        await this.page.waitForLoadState('load', { timeout: 15000 });
+        await this.page.waitForLoadState('load', { timeout: 20000 });
         await this.placeOrderButton.click();
         break; // Break out of the loop if successful
       } catch (error) {
@@ -212,7 +212,7 @@ export default class CheckoutPageSFRA {
   };
 
   goBackAndSubmitShipping = async () => {
-    await this.page.waitForNavigation('load', { timeout: 15000 });
+    await this.page.waitForNavigation('load', { timeout: 20000 });
     await this.navigateBack();
     await this.submitShipping();
   };
@@ -223,11 +223,11 @@ export default class CheckoutPageSFRA {
       url: /Order-Confirm/,
       timeout: 20000,
     });
-    await expect(this.thankYouMessage).toBeVisible({ timeout: 15000 });
+    await expect(this.thankYouMessage).toBeVisible({ timeout: 20000 });
   };
 
   expectNonRedirectSuccess = async () => {
-    await expect(this.thankYouMessage).toBeVisible({ timeout: 15000 });
+    await expect(this.thankYouMessage).toBeVisible({ timeout: 20000 });
   };
 
   expectRefusal = async () => {
@@ -235,13 +235,13 @@ export default class CheckoutPageSFRA {
   };
 
   expectVoucher = async () => {
-    await expect(this.voucherCode).toBeVisible({ timeout: 15000 });
+    await expect(this.voucherCode).toBeVisible({ timeout: 20000 });
   };
 
   expectQRcode = async () => {
-    await this.qrLoader.waitFor({ state: 'attached', timeout: 15000 });
-    await expect(this.qrLoaderAmount).toBeVisible({ timeout: 15000 });
-    await expect(this.qrImg).toBeVisible({ timeout: 15000 });
+    await this.qrLoader.waitFor({ state: 'attached', timeout: 20000 });
+    await expect(this.qrLoaderAmount).toBeVisible({ timeout: 20000 });
+    await expect(this.qrImg).toBeVisible({ timeout: 20000 });
   };
 
   expectGiftCardWarning = async () => {
@@ -249,14 +249,14 @@ export default class CheckoutPageSFRA {
   };
 
   getLocation = async () => {
-    await this.page.waitForLoadState('load', { timeout: 15000 });
+    await this.page.waitForLoadState('load', { timeout: 20000 });
     return await this.page.url();
   };
 
   navigateBack = async () => {
-    await this.page.waitForLoadState('networkidle', { timeout: 15000 });
+    await this.page.waitForLoadState('networkidle', { timeout: 20000 });
     await this.page.goBack();
-    await this.page.waitForLoadState('networkidle', { timeout: 15000 });
+    await this.page.waitForLoadState('networkidle', { timeout: 20000 });
   };
 
   loginUser = async (credentials) => {

--- a/tests/playwright/pages/PaymentMethodsPage.mjs
+++ b/tests/playwright/pages/PaymentMethodsPage.mjs
@@ -184,7 +184,6 @@ export default class PaymentMethodsPage {
 
   initiateCardPayment = async (cardInput) => {
     await this.page.locator('#rb_scheme').click();
-    await this.page.waitForLoadState('networkidle', { timeout: 20000 });
 
     const ccComponentWrapper = this.page.locator("#component_scheme");
 

--- a/tests/playwright/pages/PaymentMethodsPage.mjs
+++ b/tests/playwright/pages/PaymentMethodsPage.mjs
@@ -42,7 +42,7 @@ export default class PaymentMethodsPage {
 
     // Click PayPal radio button
     await this.page.click('#rb_paypal');
-    await this.page.waitForLoadState('networkidle', { timeout: 15000 });
+    await this.page.waitForLoadState('networkidle', { timeout: 20000 });
 
     // Capture popup for interaction
     const [popup] = await Promise.all([
@@ -79,7 +79,7 @@ export default class PaymentMethodsPage {
     if (normalFlow) {
       await this.page.click("#rb_amazonpay");
     }
-    await this.page.waitForLoadState('domcontentloaded', { timeout: 15000 });
+    await this.page.waitForLoadState('domcontentloaded', { timeout: 20000 });
     await this.page.click(".adyen-checkout__amazonpay__button");
   
     // Amazon Sandbox selectors
@@ -95,7 +95,7 @@ export default class PaymentMethodsPage {
     await this.passwordInput.click();
     await this.passwordInput.type(paymentData.AmazonPay.password);
     await this.loginButton.click();
-    await this.page.waitForLoadState("networkidle", { timeout: 15000 });
+    await this.page.waitForLoadState("networkidle", { timeout: 20000 });
 
     if (await this.amazonCaptcha.isVisible()){
       return false;
@@ -117,7 +117,7 @@ export default class PaymentMethodsPage {
       await this.rejectionCard.click();
       await this.confirmPaymentChangeButton.click();
     }
-    await this.page.waitForLoadState("networkidle", { timeout: 15000 });
+    await this.page.waitForLoadState("networkidle", { timeout: 20000 });
     this.submitButton = this.page.locator(
       'input[class="a-button-input"]'
     );
@@ -184,7 +184,7 @@ export default class PaymentMethodsPage {
 
   initiateCardPayment = async (cardInput) => {
     await this.page.locator('#rb_scheme').click();
-    await this.page.waitForLoadState('networkidle', { timeout: 15000 });
+    await this.page.waitForLoadState('networkidle', { timeout: 20000 });
 
     const ccComponentWrapper = this.page.locator("#component_scheme");
 
@@ -220,10 +220,10 @@ export default class PaymentMethodsPage {
     const giftCardBrand = this.page.locator(`li[data-brand=${giftCardInput.brand}]`)
     await this.page.locator("#giftCardUl").waitFor({
       state: 'visible',
-      timeout: 15000,
+      timeout: 20000,
     });
     await giftCardBrand.click();
-    await this.page.waitForLoadState('networkidle', { timeout: 15000 });
+    await this.page.waitForLoadState('networkidle', { timeout: 20000 });
 
     const giftCardNumberInputField = giftCardComponentWrapper
       .frameLocator('.adyen-checkout__card__cardNumber__input iframe')
@@ -318,12 +318,12 @@ export default class PaymentMethodsPage {
     //Simulation of the redirect to the Oney page
     await this.page.waitForNavigation({
       url: /.*staging.e-payments.oney/,
-      timeout: 15000,
+      timeout: 20000,
     });
   };
 
   initiateKlarnaPayment = async (klarnaVariant) => {
-    await this.page.waitForLoadState('networkidle', { timeout: 15000 });
+    await this.page.waitForLoadState('networkidle', { timeout: 20000 });
     let klarnaSelector = this.page.locator('#rb_klarna');
     if (klarnaVariant) {
       klarnaSelector =
@@ -338,7 +338,7 @@ export default class PaymentMethodsPage {
   waitForKlarnaLoad = async () => {
     await this.page.waitForNavigation({
       url: /.*playground.klarna/,
-      timeout: 15000,
+      timeout: 20000,
       waitUntil: 'load',
     });
   };
@@ -353,7 +353,7 @@ export default class PaymentMethodsPage {
 
   async continueOnKlarna(skipModal) {
     await this.waitForKlarnaLoad();
-    await this.page.waitForLoadState('networkidle', { timeout: 15000 });
+    await this.page.waitForLoadState('networkidle', { timeout: 20000 });
     this.klarnaIframe = this.page.frameLocator(
       '#klarna-apf-iframe',
     );
@@ -366,7 +366,7 @@ export default class PaymentMethodsPage {
     await this.klarnaContinueButton.click();
     await this.klarnaVerificationCodeInput.waitFor({
       state: 'visible',
-      timeout: 15000,
+      timeout: 20000,
     });
     await this.klarnaVerificationCodeInput.fill('123456');
     if (this.klarnaSelectPlanButton.isVisible() && !skipModal) {
@@ -375,7 +375,7 @@ export default class PaymentMethodsPage {
     }
     await this.klarnaBuyButton.waitFor({
       state: 'visible',
-      timeout: 15000,
+      timeout: 20000,
     });
     await this.klarnaBuyButton.click();
   }
@@ -425,10 +425,10 @@ export default class PaymentMethodsPage {
       '#invoice_kp-invoice-payment-method',
     );
 
-    await this.page.waitForNavigation('networkidle', { timeout: 15000 });
-    await this.klarnaPaymentMethodGroup.waitFor('visible', { timeout: 15000 });
-    await this.page.waitForLoadState('networkidle', { timeout: 15000 });
-    await this.klarnaBuyButton.waitFor('visible', { timeout: 15000 });
+    await this.page.waitForNavigation('networkidle', { timeout: 20000 });
+    await this.klarnaPaymentMethodGroup.waitFor('visible', { timeout: 20000 });
+    await this.page.waitForLoadState('networkidle', { timeout: 20000 });
+    await this.klarnaBuyButton.waitFor('visible', { timeout: 20000 });
 
     await this.klarnaBuyButton.click();
     await this.klarnaIdNumberField.fill('811228-9874');
@@ -437,7 +437,7 @@ export default class PaymentMethodsPage {
 
   cancelKlarnaPayment = async () => {
     await this.waitForKlarnaLoad();
-    await this.page.waitForLoadState('networkidle', { timeout: 15000 });
+    await this.page.waitForLoadState('networkidle', { timeout: 20000 });
     this.klarnaIframe = this.page.frameLocator(
       '#klarna-apf-iframe',
     );
@@ -445,7 +445,7 @@ export default class PaymentMethodsPage {
     this.secondCancelButton = this.klarnaIframe.locator("button[title='Close']");
     await this.firstCancelButton.waitFor({
       state: 'visible',
-      timeout: 15000,
+      timeout: 20000,
     });
     await this.firstCancelButton.click();
     await this.secondCancelButton.first().click();
@@ -458,8 +458,8 @@ export default class PaymentMethodsPage {
     const backButton = this.page.locator("button[name='backLink']");
 
     await rejectCookies.click();
-    await giroBankDropdown.waitFor({ state: 'visible', timeout: 15000 });
-    await backButton.waitFor({ state: 'visible', timeout: 15000 });
+    await giroBankDropdown.waitFor({ state: 'visible', timeout: 20000 });
+    await backButton.waitFor({ state: 'visible', timeout: 20000 });
     await backButton.click();
   };
 
@@ -520,7 +520,7 @@ export default class PaymentMethodsPage {
   };
 
   cancelVippsPayment = async () => {
-    await expect(this.page.locator('.cancel-link')).toBeVisible({ timeout: 15000 });
+    await expect(this.page.locator('.cancel-link')).toBeVisible({ timeout: 20000 });
     await this.page.click('.cancel-link');
   };
 
@@ -529,18 +529,18 @@ export default class PaymentMethodsPage {
     await this.page.click("button[data-testid='continue-button']");
     await this.page.locator("div[data-testid='spinner']").waitFor({
       state: 'visible',
-      timeout: 15000,
+      timeout: 20000,
     });
     await this.page.click("button[data-testid='continue-button']");
     await this.page.locator('input[name="loginid"]').type('idabarese51');
     await this.page.click("button[data-testid='continue-button']");
     await this.page.locator("div[data-testid='spinner']").waitFor({
       state: 'visible',
-      timeout: 15000,
+      timeout: 20000,
     });
     await this.page.locator("div[data-testid='spinner']").waitFor({
       state: 'detached',
-      timeout: 15000,
+      timeout: 20000,
     });
 
     const oneTimeCodeLocator = await this.page.locator(
@@ -554,7 +554,7 @@ export default class PaymentMethodsPage {
     await this.page.click("button[data-testid='continue-button']");
     await this.page.locator("div[data-testid='spinner']").waitFor({
       state: 'visible',
-      timeout: 15000,
+      timeout: 20000,
     });
     await this.page.click("button[data-testid='continue-button']");
 
@@ -612,7 +612,7 @@ export default class PaymentMethodsPage {
   MultiBancoVoucherExists = async () => {
     await expect(
       this.page.locator('.adyen-checkout__voucher-result--multibanco'),
-    ).toBeVisible({ timeout: 15000 });
+    ).toBeVisible({ timeout: 20000 });
   };
 
   initiateSEPAPayment = async () => {

--- a/tests/playwright/paymentFlows/pending.mjs
+++ b/tests/playwright/paymentFlows/pending.mjs
@@ -39,7 +39,7 @@ export class PendingPayments {
 
   waitForThirdPartyPaymentLoader = async () => {
     const checkoutLoader = this.page.locator('.adyen-checkout__await');
-    await checkoutLoader.waitFor({ state: 'attached', timeout: 15000 });
+    await checkoutLoader.waitFor({ state: 'attached', timeout: 20000 });
     await checkoutLoader.waitFor({ state: 'detached', timeout: 20000 });
   };
 }

--- a/tests/playwright/paymentFlows/redirectShopper.mjs
+++ b/tests/playwright/paymentFlows/redirectShopper.mjs
@@ -106,7 +106,7 @@ export class RedirectShopper {
   };
 
   completeEPSRedirect = async (success) => {
-    await this.page.waitForLoadState('networkidle', { timeout: 15000 });
+    await this.page.waitForLoadState('networkidle', { timeout: 20000 });
     if (success) {
       await this.paymentMethodsPage.confirmSimulator();
     } else {


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
When we switched from /sessions to /paymentMethods, a check was missing for updating the remaining amount passed to components to complete the payment. 
Also, the updation of amount in component was failing when giftcards were being removed. This also gets fixed by this PR.
- What existing problem does this pull request solve?
Updating the remaining amount properly when paying with giftcards and when removing giftcards.

_Note : The bug was present only in develop branch and was not part of any release._

## Tested scenarios
Description of tested scenarios:
- Giftcards + Apple Pay
- Giftcards + iDeal
- Giftcards + Cards
- Giftcards removal and proceeding with payment

**Fixed issue**:  SFI-649
