### PR TITLE
Enable linting for files which previously were corresponding to `int_adyen_overlay`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,8 +12,11 @@ src/cartridges/app_adyen_SFRA/cartridge/client/default/js/bundle.js
 src/cartridges/app_adyen_SFRA/cartridge/client/default/js/checkout/checkoutSFRA5.js
 src/cartridges/app_adyen_SFRA/cartridge/client/default/js/checkout/checkoutSFRA6.js
 src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/placeOrder.js
-src/cartridges/int_adyen_SFRA/cartridge/scripts
-src/cartridges/int_adyen_SFRA/cartridge/adyen/
+src/cartridges/int_adyen_SFRA/cartridge/adyen/webhooks
+src/cartridges/int_adyen_SFRA/cartridge/scripts/util/adyenHelper.js
+src/cartridges/int_adyen_SFRA/cartridge/scripts/util/adyenConfigs.js
+src/cartridges/int_adyen_SFRA/cartridge/scripts/adyenGetOpenInvoiceData.js
+src/cartridges/int_adyen_SFRA/cartridge/scripts/adyenTerminalApi.js
 
 # Test files
 src/cartridges/int_adyen_SFRA/test

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -90,6 +90,11 @@ module.exports = {
       "ImportDeclaration": { multiline: true, "minProperties": 4 }
     }],
     "implicit-arrow-linebreak": "off",
-    "no-param-reassign": ["error", { "props": false }]
+    "no-param-reassign": ["error", { "props": false }],
+    "no-plusplus": "off",
+    "import/extensions": "off",
+    "camelcase": "off",
+    "no-bitwise": "off",
+	"no-underscore-dangle": "off"
   },
 };

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/logs/adyenCustomLogs.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/logs/adyenCustomLogs.js
@@ -1,4 +1,4 @@
-var Logger = require('dw/system/Logger');
+const Logger = require('dw/system/Logger');
 
 function fatal_log(msg) {
   return Logger.getLogger('Adyen_fatal', 'Adyen').fatal(msg);

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/webhooks/checkNotificationAuth.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/webhooks/checkNotificationAuth.js
@@ -41,28 +41,31 @@ function check(request) {
   );
 }
 
-function compareHmac(hmacSignature, merchantSignature){
+function compareHmac(hmacSignature, merchantSignature) {
   let bitwiseComparison;
-  if (hmacSignature.length !== merchantSignature.length){
+  if (hmacSignature.length !== merchantSignature.length) {
     return false;
   }
   for (let i = 0; i < hmacSignature.length; i++) {
-    bitwiseComparison |= hmacSignature.charCodeAt(i) ^ merchantSignature.charCodeAt(i);
+    bitwiseComparison |=
+      hmacSignature.charCodeAt(i) ^ merchantSignature.charCodeAt(i);
   }
   return bitwiseComparison === 0;
-};
+}
 
-function validateHmacSignature(request){
+function validateHmacSignature(request) {
   const notificationData = request.form;
   const hmacSignature = notificationData['additionalData.hmacSignature'];
   const merchantSignature = AuthenticationUtils.calculateHmacSignature(request);
   // Checking for timing attacks
-  if (compareHmac(hmacSignature, merchantSignature)){
+  if (compareHmac(hmacSignature, merchantSignature)) {
     return true;
-  };
-  AdyenLogs.error_log(`HMAC signatures mismatch, the notification request is not valid`);
+  }
+  AdyenLogs.error_log(
+    'HMAC signatures mismatch, the notification request is not valid',
+  );
   return false;
-};
+}
 
 module.exports = {
   check,

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/webhooks/deleteCustomObjects.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/webhooks/deleteCustomObjects.js
@@ -21,11 +21,20 @@
 
 const CustomObjectMgr = require('dw/object/CustomObjectMgr');
 
-//script include
+// script include
 const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
 
-function execute(args) {
-  return handle(args.orderID);
+function remove(co) {
+  AdyenLogs.info_log(
+    `Remove CO object with merchantReference ${co.custom.merchantReference} and pspReferenceNumber ${co.custom.pspReference}`,
+  );
+  try {
+    CustomObjectMgr.remove(co);
+  } catch (e) {
+    AdyenLogs.error_log(
+      `Error occured during delete CO, ID: ${co.custom.orderId}, erorr message ${e.message}`,
+    );
+  }
 }
 
 function handle(orderID) {
@@ -48,17 +57,8 @@ function handle(orderID) {
   return PIPELET_NEXT;
 }
 
-function remove(co) {
-  AdyenLogs.info_log(
-    `Remove CO object with merchantReference ${co.custom.merchantReference} and pspReferenceNumber ${co.custom.pspReference}`,
-  );
-  try {
-    CustomObjectMgr.remove(co);
-  } catch (e) {
-    AdyenLogs.error_log(
-      `Error occured during delete CO, ID: ${co.custom.orderId}, erorr message ${e.message}`,
-    );
-  }
+function execute(args) {
+  return handle(args.orderID);
 }
 
 module.exports = {

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/webhooks/libs/libAuthenticationUtils.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/webhooks/libs/libAuthenticationUtils.js
@@ -48,7 +48,7 @@ function checkGivenCredentials(baHeader, baUser, baPassword) {
   return false;
 }
 
-function constructPayload(notificationData){
+function constructPayload(notificationData) {
   const signedDataList = [];
   signedDataList.push(notificationData.pspReference);
   signedDataList.push(notificationData.originalReference);
@@ -59,22 +59,28 @@ function constructPayload(notificationData){
   signedDataList.push(notificationData.eventCode);
   signedDataList.push(notificationData.success);
   return signedDataList.join(constants.NOTIFICATION_PAYLOAD_DATA_SEPARATOR);
-};
+}
 
-function calculateHmacSignature(request){
-  try{
-    const hmacKey = Encoding.fromHex(new Bytes(AdyenConfigs.getAdyenHmacKey(), 'UTF-8'));
+function calculateHmacSignature(request) {
+  try {
+    const hmacKey = Encoding.fromHex(
+      new Bytes(AdyenConfigs.getAdyenHmacKey(), 'UTF-8'),
+    );
     const payload = constructPayload(request.form);
     const macSHA256 = new Mac(Mac.HMAC_SHA_256);
-    const merchantSignature = Encoding.toBase64(macSHA256.digest(payload, hmacKey));
-    return merchantSignature;
-  }
-  catch(e) {
-    AdyenLogs.fatal_log(
-      `Cannot calculate HMAC signature: ${e.toString()} in ${e.fileName}:${e.lineNumber}`,
+    const merchantSignature = Encoding.toBase64(
+      macSHA256.digest(payload, hmacKey),
     );
-  };
-};
+    return merchantSignature;
+  } catch (e) {
+    AdyenLogs.fatal_log(
+      `Cannot calculate HMAC signature: ${e.toString()} in ${e.fileName}:${
+        e.lineNumber
+      }`,
+    );
+    return { error: true };
+  }
+}
 
 module.exports = {
   checkGivenCredentials,

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/adyenDeleteRecurringPayment.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/adyenDeleteRecurringPayment.js
@@ -25,6 +25,7 @@ const AdyenConfigs = require('*/cartridge/scripts/util/adyenConfigs');
 const constants = require('*/cartridge/adyenConstants/constants');
 const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
 
+// eslint-disable-next-line complexity
 function deleteRecurringPayment(args) {
   try {
     const customer = args.Customer ? args.Customer : null;
@@ -49,15 +50,18 @@ function deleteRecurringPayment(args) {
       merchantAccount: AdyenConfigs.getAdyenMerchantAccount(),
       shopperReference: customerID,
       recurringDetailReference,
-      contract : constants.CONTRACT.ONECLICK, 
+      contract: constants.CONTRACT.ONECLICK,
     };
 
-    AdyenHelper.executeCall(constants.SERVICE.RECURRING_DISABLE, requestObject);
-    
+    return AdyenHelper.executeCall(
+      constants.SERVICE.RECURRING_DISABLE,
+      requestObject,
+    );
   } catch (e) {
     AdyenLogs.fatal_log(
       `Adyen: ${e.toString()} in ${e.fileName}:${e.lineNumber}`,
     );
+    return { error: true };
   }
 }
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/adyenGetPaymentMethods.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/adyenGetPaymentMethods.js
@@ -26,6 +26,7 @@ const constants = require('*/cartridge/adyenConstants/constants');
 const blockedPayments = require('*/cartridge/scripts/config/blockedPaymentMethods.json');
 const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
 
+// eslint-disable-next-line complexity
 function getMethods(basket, customer, countryCode) {
   try {
     let paymentAmount;
@@ -55,7 +56,7 @@ function getMethods(basket, customer, countryCode) {
       paymentMethodsRequest.countryCode = countryCode;
     }
 
-    if(request.getLocale()){
+    if (request.getLocale()) {
       paymentMethodsRequest.shopperLocale = request.getLocale();
     }
 
@@ -72,13 +73,18 @@ function getMethods(basket, customer, countryCode) {
       paymentMethodsRequest.shopperReference = customerID;
     }
 
-    paymentMethodsRequest.blockedPaymentMethods = blockedPayments.blockedPaymentMethods;
+    paymentMethodsRequest.blockedPaymentMethods =
+      blockedPayments.blockedPaymentMethods;
 
-    return AdyenHelper.executeCall(constants.SERVICE.CHECKOUTPAYMENTMETHODS, paymentMethodsRequest);
+    return AdyenHelper.executeCall(
+      constants.SERVICE.CHECKOUTPAYMENTMETHODS,
+      paymentMethodsRequest,
+    );
   } catch (e) {
     AdyenLogs.fatal_log(
       `Adyen: ${e.toString()} in ${e.fileName}:${e.lineNumber}`,
     );
+    return { error: true };
   }
 }
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/adyenGiving.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/adyenGiving.js
@@ -27,11 +27,11 @@ const AdyenConfigs = require('*/cartridge/scripts/util/adyenConfigs');
 const constants = require('*/cartridge/adyenConstants/constants');
 const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
 
+// eslint-disable-next-line complexity
 function donate(donationReference, donationAmount, orderToken) {
   try {
-
-    if (session.privacy.orderNo !== donationReference){
-      throw new Error(`Donation reference is invalid`);
+    if (session.privacy.orderNo !== donationReference) {
+      throw new Error('Donation reference is invalid');
     }
 
     let paymentMethodVariant;
@@ -39,20 +39,29 @@ function donate(donationReference, donationAmount, orderToken) {
     const paymentInstrument = order.getPaymentInstruments(
       AdyenHelper.getOrderMainPaymentInstrumentType(order),
     )[0];
-    const donationToken = paymentInstrument.paymentTransaction.custom.Adyen_donationToken;
-    const originalReference = paymentInstrument.paymentTransaction.custom.Adyen_pspReference;
-    const paymentData = JSON.parse(paymentInstrument.paymentTransaction.custom.Adyen_log);
-    const paymentCurrency = paymentData.amount.currency || paymentData.fullResponse?.amount?.currency;
+    const donationToken =
+      paymentInstrument.paymentTransaction.custom.Adyen_donationToken;
+    const originalReference =
+      paymentInstrument.paymentTransaction.custom.Adyen_pspReference;
+    const paymentData = JSON.parse(
+      paymentInstrument.paymentTransaction.custom.Adyen_log,
+    );
+    const paymentCurrency =
+      paymentData.amount.currency || paymentData.fullResponse?.amount?.currency;
     const availableDonationAmounts = AdyenHelper.getDonationAmounts();
-    paymentMethodVariant = paymentData.paymentMethod?.type || paymentData.fullResponse?.paymentMethod?.type;
+    paymentMethodVariant =
+      paymentData.paymentMethod?.type ||
+      paymentData.fullResponse?.paymentMethod?.type;
 
     // for iDeal donations, the payment method variant needs to be set to sepadirectdebit
     if (paymentMethodVariant === 'ideal') {
       paymentMethodVariant = 'sepadirectdebit';
     }
     // for Apple Pay donations, the payment method variant needs to be the brand
-    if (paymentMethodVariant === 'applepay'){
-      paymentMethodVariant = paymentData.paymentMethod?.brand || paymentData.fullResponse?.paymentMethod?.brand;
+    if (paymentMethodVariant === 'applepay') {
+      paymentMethodVariant =
+        paymentData.paymentMethod?.brand ||
+        paymentData.fullResponse?.paymentMethod?.brand;
     }
     const requestObject = {
       merchantAccount: AdyenConfigs.getAdyenMerchantAccount(),
@@ -62,34 +71,40 @@ function donate(donationReference, donationAmount, orderToken) {
       donationOriginalPspReference: originalReference,
       donationToken,
       paymentMethod: {
-        type: paymentMethodVariant
+        type: paymentMethodVariant,
       },
       shopperInteraction: constants.SHOPPER_INTERACTIONS.CONT_AUTH,
     };
 
-    if (availableDonationAmounts.indexOf(parseInt(donationAmount.value)) === -1){
-      throw new Error(`Donation amount is invalid`);
+    if (
+      availableDonationAmounts.indexOf(parseInt(donationAmount.value, 10)) ===
+      -1
+    ) {
+      throw new Error('Donation amount is invalid');
     }
 
-    if (paymentCurrency !== donationAmount.currency){
-      throw new Error(`Donation currency is invalid`);
+    if (paymentCurrency !== donationAmount.currency) {
+      throw new Error('Donation currency is invalid');
     }
 
-    const response = AdyenHelper.executeCall(constants.SERVICE.ADYENGIVING, requestObject);    
+    const response = AdyenHelper.executeCall(
+      constants.SERVICE.ADYENGIVING,
+      requestObject,
+    );
 
     Transaction.wrap(() => {
-      const order = OrderMgr.getOrder(donationReference);
       order.custom.Adyen_donationAmount = JSON.stringify(donationAmount);
       // Donation token is deleted in case the donation is completed once
-      if (response.status === constants.DONATION_RESULT.COMPLETED){
+      if (response.status === constants.DONATION_RESULT.COMPLETED) {
         paymentInstrument.paymentTransaction.custom.Adyen_donationToken = null;
-      };
+      }
     });
     return response;
   } catch (e) {
     AdyenLogs.error_log(
       `Adyen: ${e.toString()} in ${e.fileName}:${e.lineNumber}`,
     );
+    return { error: true };
   }
 }
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/adyenLevelTwoThreeData.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/adyenLevelTwoThreeData.js
@@ -19,49 +19,71 @@
  * Add all product and shipping line items to request
  */
 
-
 const AdyenConfigs = require('*/cartridge/scripts/util/adyenConfigs');
 
 const LineItemHelper = require('*/cartridge/scripts/util/lineItemHelper');
 
-function getLineItems({ Order: order, Basket: basket }) {
-    if (!(order || basket)) return null;
-    const orderOrBasket = order || basket;
-    const allLineItems = orderOrBasket.getProductLineItems();
-    const shopperReference = getShopperReference(orderOrBasket);
-
-    return allLineItems.toArray().reduce((acc, lineItem, index) => {
-        const description = LineItemHelper.getDescription(lineItem);
-        const id = LineItemHelper.getId(lineItem);
-        const quantity = LineItemHelper.getQuantity(lineItem);
-        const itemAmount = LineItemHelper.getItemAmount(lineItem).divide(quantity);
-        const vatAmount = LineItemHelper.getVatAmount(lineItem).divide(quantity);
-        const commodityCode = AdyenConfigs.getAdyenLevel23CommodityCode();
-        const currentLineItem = {
-            [`enhancedSchemeData.itemDetailLine${index + 1}.unitPrice`]: itemAmount.value.toFixed(),
-            [`enhancedSchemeData.itemDetailLine${index + 1}.totalAmount`]: parseFloat(itemAmount.value.toFixed()) + parseFloat(vatAmount.value.toFixed()),
-            [`enhancedSchemeData.itemDetailLine${index + 1}.quantity`]: quantity,
-            [`enhancedSchemeData.itemDetailLine${index + 1}.unitOfMeasure`]: 'EAC',
-            ...(commodityCode && { [`enhancedSchemeData.itemDetailLine${index + 1}.commodityCode`]: commodityCode }),
-            ...(description && { [`enhancedSchemeData.itemDetailLine${index + 1}.description`]: description.substring(0, 26).replace(/[^\x00-\x7F]/g, '') }),
-            ...(id && { [`enhancedSchemeData.itemDetailLine${index + 1}.productCode`]: id.substring(0, 12) }),
-        };
-
-        return {
-            ...acc,
-            ...currentLineItem,
-            'enhancedSchemeData.totalTaxAmount': acc['enhancedSchemeData.totalTaxAmount'] + parseFloat(vatAmount.value.toFixed()),
-        };
-    }, { 'enhancedSchemeData.totalTaxAmount': 0.0, 'enhancedSchemeData.customerReference': shopperReference.substring(0, 25) });
+// eslint-disable-next-line complexity
+function getShopperReference(orderOrBasket) {
+  const customer = orderOrBasket.getCustomer();
+  const isRegistered = customer && customer.registered;
+  const profile = isRegistered && customer.getProfile();
+  const profileCustomerNo = profile && profile.getCustomerNo();
+  const orderNo = profileCustomerNo || orderOrBasket.getCustomerNo();
+  return orderNo || customer.getID() || 'no-unique-ref';
 }
 
-function getShopperReference(orderOrBasket) {
-    const customer = orderOrBasket.getCustomer();
-    const isRegistered = customer && customer.registered;
-    const profile = isRegistered && customer.getProfile();
-    const profileCustomerNo = profile && profile.getCustomerNo();
-    const orderNo = profileCustomerNo || orderOrBasket.getCustomerNo();
-    return orderNo || customer.getID() || 'no-unique-ref';
+function getLineItems({ Order: order, Basket: basket }) {
+  if (!(order || basket)) return null;
+  const orderOrBasket = order || basket;
+  const allLineItems = orderOrBasket.getProductLineItems();
+  const shopperReference = getShopperReference(orderOrBasket);
+
+  return allLineItems.toArray().reduce(
+    (acc, lineItem, index) => {
+      const description = LineItemHelper.getDescription(lineItem);
+      const id = LineItemHelper.getId(lineItem);
+      const quantity = LineItemHelper.getQuantity(lineItem);
+      const itemAmount =
+        LineItemHelper.getItemAmount(lineItem).divide(quantity);
+      const vatAmount = LineItemHelper.getVatAmount(lineItem).divide(quantity);
+      const commodityCode = AdyenConfigs.getAdyenLevel23CommodityCode();
+      const currentLineItem = {
+        [`enhancedSchemeData.itemDetailLine${index + 1}.unitPrice`]:
+          itemAmount.value.toFixed(),
+        [`enhancedSchemeData.itemDetailLine${index + 1}.totalAmount`]:
+          parseFloat(itemAmount.value.toFixed()) +
+          parseFloat(vatAmount.value.toFixed()),
+        [`enhancedSchemeData.itemDetailLine${index + 1}.quantity`]: quantity,
+        [`enhancedSchemeData.itemDetailLine${index + 1}.unitOfMeasure`]: 'EAC',
+        ...(commodityCode && {
+          [`enhancedSchemeData.itemDetailLine${index + 1}.commodityCode`]:
+            commodityCode,
+        }),
+        ...(description && {
+          [`enhancedSchemeData.itemDetailLine${index + 1}.description`]:
+            // eslint-disable-next-line no-control-regex
+            description.substring(0, 26).replace(/[^\x00-\x7F]/g, ''),
+        }),
+        ...(id && {
+          [`enhancedSchemeData.itemDetailLine${index + 1}.productCode`]:
+            id.substring(0, 12),
+        }),
+      };
+
+      return {
+        ...acc,
+        ...currentLineItem,
+        'enhancedSchemeData.totalTaxAmount':
+          acc['enhancedSchemeData.totalTaxAmount'] +
+          parseFloat(vatAmount.value.toFixed()),
+      };
+    },
+    {
+      'enhancedSchemeData.totalTaxAmount': 0.0,
+      'enhancedSchemeData.customerReference': shopperReference.substring(0, 25),
+    },
+  );
 }
 
 module.exports.getLineItems = getLineItems;

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/adyenZeroAuth.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/adyenZeroAuth.js
@@ -30,7 +30,6 @@ const constants = require('*/cartridge/adyenConstants/constants');
 
 function zeroAuthPayment(customer, paymentInstrument) {
   try {
-
     let zeroAuthRequest = AdyenHelper.createAdyenRequestObject(
       null,
       paymentInstrument,
@@ -43,10 +42,13 @@ function zeroAuthPayment(customer, paymentInstrument) {
       value: 0,
     };
 
-    zeroAuthRequest.returnUrl = URLUtils.https('Adyen-Redirect3DS1Response').toString();
+    zeroAuthRequest.returnUrl = URLUtils.https(
+      'Adyen-Redirect3DS1Response',
+    ).toString();
 
     zeroAuthRequest.storePaymentMethod = true;
-    zeroAuthRequest.recurringProcessingModel = constants.RECURRING_PROCESSING_MODEL.CARD_ON_FILE;
+    zeroAuthRequest.recurringProcessingModel =
+      constants.RECURRING_PROCESSING_MODEL.CARD_ON_FILE;
     zeroAuthRequest.shopperReference = customer.getProfile().getCustomerNo();
     zeroAuthRequest.shopperEmail = customer.getProfile().getEmail();
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/updateSavedCards.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/updateSavedCards.js
@@ -28,7 +28,31 @@ const constants = require('*/cartridge/adyenConstants/constants');
 const AdyenHelper = require('*/cartridge/scripts/util/adyenHelper');
 const AdyenConfigs = require('*/cartridge/scripts/util/adyenConfigs');
 const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
+const getPaymentMethods = require('*/cartridge/scripts/adyenGetPaymentMethods');
 
+function getOneClickPaymentMethods(customer) {
+  const { storedPaymentMethods } = getPaymentMethods.getMethods(
+    null,
+    customer,
+    '',
+  );
+  const oneClickPaymentMethods = [];
+  if (storedPaymentMethods) {
+    for (let i = 0; i < storedPaymentMethods.length; i++) {
+      if (
+        storedPaymentMethods[i].supportedShopperInteractions &&
+        storedPaymentMethods[i].supportedShopperInteractions.indexOf(
+          'Ecommerce',
+        ) > -1
+      ) {
+        oneClickPaymentMethods.push(storedPaymentMethods[i]);
+      }
+    }
+  }
+  return oneClickPaymentMethods;
+}
+
+/* eslint-disable */
 function updateSavedCards(args) {
   try {
     const customer = args.CurrentCustomer;
@@ -41,7 +65,7 @@ function updateSavedCards(args) {
       return { error: true };
     }
 
-    if(AdyenConfigs.getAdyenRecurringPaymentsEnabled()) {
+    if (AdyenConfigs.getAdyenRecurringPaymentsEnabled()) {
       const oneClickPaymentMethods = getOneClickPaymentMethods(customer);
       // To make it compatible with upgrade from older versions (<= 19.2.2),
       // first delete payment instruments with METHOD_CREDIT_CARD
@@ -102,36 +126,11 @@ function updateSavedCards(args) {
         }
       });
     }
-      return { error: false };
+    return { error: false };
   } catch (ex) {
-    AdyenLogs.error_log(
-      `${ex.toString()} in ${ex.fileName}:${ex.lineNumber}`,
-    );
+    AdyenLogs.error_log(`${ex.toString()} in ${ex.fileName}:${ex.lineNumber}`);
     return { error: true };
   }
-}
-
-function getOneClickPaymentMethods(customer) {
-  const getPaymentMethods = require('*/cartridge/scripts/adyenGetPaymentMethods');
-  const { storedPaymentMethods } = getPaymentMethods.getMethods(
-    null,
-    customer,
-    '',
-  );
-  const oneClickPaymentMethods = [];
-  if(storedPaymentMethods) {
-    for (let i = 0; i < storedPaymentMethods.length; i++) {
-      if (
-          storedPaymentMethods[i].supportedShopperInteractions &&
-          storedPaymentMethods[i].supportedShopperInteractions.indexOf(
-              'Ecommerce',
-          ) > -1
-      ) {
-        oneClickPaymentMethods.push(storedPaymentMethods[i]);
-      }
-    }
-  }
-  return oneClickPaymentMethods;
 }
 
 module.exports = {

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/util/giftCardsHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/util/giftCardsHelper.js
@@ -16,21 +16,24 @@
  * This file is open source and available under the MIT license.
  * See the LICENSE file for more info.
  */
-const constants = require('*/cartridge/adyenConstants/constants');
-const AdyenHelper = require('*/cartridge/scripts/util/adyenHelper');
 const Transaction = require('dw/system/Transaction');
-//script includes
+// script includes
 const PaymentMgr = require('dw/order/PaymentMgr');
 const Money = require('dw/value/Money');
+const AdyenHelper = require('*/cartridge/scripts/util/adyenHelper');
+const constants = require('*/cartridge/adyenConstants/constants');
 
-let giftCardsHelper = {
+const giftCardsHelper = {
   createGiftCardPaymentInstrument(parsedGiftCardObj, divideBy, order) {
     let paymentInstrument;
     const paidGiftCardAmount = {
       value: parsedGiftCardObj.giftCard.amount.value,
-      currency: parsedGiftCardObj.giftCard.amount.currency
+      currency: parsedGiftCardObj.giftCard.amount.currency,
     };
-    const paidGiftCardAmountFormatted = new Money(paidGiftCardAmount.value, paidGiftCardAmount.currency).divide(divideBy);
+    const paidGiftCardAmountFormatted = new Money(
+      paidGiftCardAmount.value,
+      paidGiftCardAmount.currency,
+    ).divide(divideBy);
     Transaction.wrap(() => {
       paymentInstrument = order.createPaymentInstrument(
         constants.METHOD_ADYEN_COMPONENT,
@@ -40,18 +43,28 @@ let giftCardsHelper = {
         paymentInstrument.paymentMethod,
       );
       paymentInstrument.paymentTransaction.paymentProcessor = paymentProcessor;
-      paymentInstrument.paymentTransaction.transactionID = parsedGiftCardObj.giftCard.pspReference;
-      paymentInstrument.custom.adyenPaymentMethod = parsedGiftCardObj.giftCard.name;
-      paymentInstrument.custom[`${constants.OMS_NAMESPACE}__Adyen_Payment_Method`] = parsedGiftCardObj.giftCard.name;
-      paymentInstrument.custom.Adyen_Payment_Method_Variant = parsedGiftCardObj.giftCard.brand;
+      paymentInstrument.paymentTransaction.transactionID =
+        parsedGiftCardObj.giftCard.pspReference;
+      paymentInstrument.custom.adyenPaymentMethod =
+        parsedGiftCardObj.giftCard.name;
+      paymentInstrument.custom[
+        `${constants.OMS_NAMESPACE}__Adyen_Payment_Method`
+      ] = parsedGiftCardObj.giftCard.name;
+      paymentInstrument.custom.Adyen_Payment_Method_Variant =
+        parsedGiftCardObj.giftCard.brand;
       paymentInstrument.custom[
         `${constants.OMS_NAMESPACE}__Adyen_Payment_Method_Variant`
-        ] = parsedGiftCardObj.giftCard.brand;
-      paymentInstrument.paymentTransaction.custom.Adyen_log = JSON.stringify(parsedGiftCardObj);
-      paymentInstrument.paymentTransaction.custom.Adyen_pspReference = parsedGiftCardObj.giftCard.pspReference;
-    })
-    AdyenHelper.setPaymentTransactionType(paymentInstrument, parsedGiftCardObj.giftCard);
-  }
+      ] = parsedGiftCardObj.giftCard.brand;
+      paymentInstrument.paymentTransaction.custom.Adyen_log =
+        JSON.stringify(parsedGiftCardObj);
+      paymentInstrument.paymentTransaction.custom.Adyen_pspReference =
+        parsedGiftCardObj.giftCard.pspReference;
+    });
+    AdyenHelper.setPaymentTransactionType(
+      paymentInstrument,
+      parsedGiftCardObj.giftCard,
+    );
+  },
 };
 
 module.exports = giftCardsHelper;

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/util/lineItemHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/util/lineItemHelper.js
@@ -77,7 +77,10 @@ const __LineItemHelper = {
     ) {
       return AdyenHelper.getCurrencyValueForApi(lineItem.getAdjustedTax());
     }
-    if (lineItem instanceof dw.order.PriceAdjustment && lineItem.getPromotion().getPromotionClass() !== 'ORDER') {
+    if (
+      lineItem instanceof dw.order.PriceAdjustment &&
+      lineItem.getPromotion().getPromotionClass() !== 'ORDER'
+    ) {
       return AdyenHelper.getCurrencyValueForApi(lineItem.tax);
     }
     return new dw.value.Money(0, lineItem.getTax().getCurrencyCode());

--- a/src/cartridges/int_adyen_SFRA/cartridge/scripts/util/riskDataHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/scripts/util/riskDataHelper.js
@@ -26,14 +26,13 @@ const __RiskDataHelper = {
     const productLines = order.getProductLineItems().toArray();
     let itemNr = 1;
     const basketData = {};
+    // eslint-disable-next-line complexity
     productLines.forEach((item) => {
       const quantity = LineItemHelper.getQuantity(item);
-      basketData[`riskdata.basket.item${itemNr}.itemID`] = LineItemHelper.getId(
-        item,
-      );
-      basketData[
-        `riskdata.basket.item${itemNr}.productTitle`
-      ] = LineItemHelper.getDescription(item);
+      basketData[`riskdata.basket.item${itemNr}.itemID`] =
+        LineItemHelper.getId(item);
+      basketData[`riskdata.basket.item${itemNr}.productTitle`] =
+        LineItemHelper.getDescription(item);
       basketData[`riskdata.basket.item${itemNr}.amountPerItem`] =
         LineItemHelper.getItemAmount(item).divide(quantity).value.toFixed();
       basketData[`riskdata.basket.item${itemNr}.currency`] =
@@ -47,9 +46,8 @@ const __RiskDataHelper = {
       basketData[`riskdata.basket.item${itemNr}.brand`] = item.product
         ? item.product.brand
         : '';
-      basketData[
-        `riskdata.basket.item${itemNr}.manufacturerName`
-      ] = item.product ? item.product.manufacturerName : '';
+      basketData[`riskdata.basket.item${itemNr}.manufacturerName`] =
+        item.product ? item.product.manufacturerName : '';
       basketData[`riskdata.basket.item${itemNr}.category`] =
         item.product && item.product.primaryCategory
           ? item.product.primaryCategory.displayName


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Linting was not setup for the files previously corresponding to `int_adyen_overlay`.
- What existing problem does this pull request solve?
It enabled linting rules for the files which now are moved to `int_adyen_SFRA`. Some of them are still being excluded since refactoring is required to pass some of the current rules we do have in place.

## Tested scenarios
Description of tested scenarios:

**Fixed issue**: SFI-645
