### PR TITLE
Passing amount to giftcard component on creation

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGiftcardComponent.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGiftcardComponent.js
@@ -184,6 +184,9 @@ function attachGiftCardFormListeners() {
       giftCardSelect.appendChild(newOption);
 
       giftCardSelect.value = selectedGiftCard.brand;
+      const giftCardAmount = store.partialPaymentsOrderObj.remainingAmount
+        ? store.partialPaymentsOrderObj.remainingAmount
+        : store.checkout.options.amount;
 
       giftCardContainer.innerHTML = '';
       const giftCardNode = store.checkout
@@ -191,6 +194,7 @@ function attachGiftCardFormListeners() {
           ...store.checkoutConfiguration.giftcard,
           brand: selectedGiftCard.brand,
           name: selectedGiftCard.name,
+          amount: giftCardAmount,
         })
         .mount(giftCardContainer);
       store.componentsObj.giftcard = { node: giftCardNode };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
When separating the cartridges, a silent bug was discover in the scenario when multiple giftcards were being used. The amount passed on component after the first giftcard applies was wrong, leading to the failure of the component rendering.
- What existing problem does this pull request solve?
This PR passes the amount to giftcard component when mounting it, either by getting it from `store.partialPaymentsOrderObj` (in case multiple giftcards are being used) or from `store.checkout.options.amount` (in case only one giftcard is used).


## Tested scenarios
Description of tested scenarios:
- Single giftcard payment
- Multiple giftcard payments
- Giftcard + card
- Giftcard + ideal
- Cancellation of giftcards

**Fixed issue**:  SFI-717
