### PR TITLE
Rendering PayPal Expres button

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/paypalExpress.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/paypalExpress.js
@@ -1,0 +1,38 @@
+const { getPaymentMethods } = require('./commons');
+
+const PAYPAL = 'paypal';
+
+async function mountPaypalComponent() {
+  try {
+    const data = await getPaymentMethods();
+    const paymentMethodsResponse = data?.AdyenPaymentMethods;
+    const applicationInfo = data?.applicationInfo;
+    const checkout = await AdyenCheckout({
+      environment: window.environment,
+      clientKey: window.clientKey,
+      locale: window.locale,
+      analytics: {
+        analyticsData: { applicationInfo },
+      },
+    });
+
+    const paypalConfig = paymentMethodsResponse?.paymentMethods.find(
+      (pm) => pm.type === PAYPAL,
+    )?.configuration;
+    if (!paypalConfig) return;
+
+    const paypalButtonConfig = {
+      showPayButton: true,
+      configuration: paypalConfig,
+      returnUrl: window.returnUrl,
+      isExpress: true,
+    };
+
+    const paypalExpressButton = checkout.create(PAYPAL, paypalButtonConfig);
+    paypalExpressButton.mount('#paypal-container');
+  } catch (e) {
+    //
+  }
+}
+
+mountPaypalComponent();

--- a/src/cartridges/app_adyen_SFRA/cartridge/templates/default/cart/checkoutButtons.isml
+++ b/src/cartridges/app_adyen_SFRA/cartridge/templates/default/cart/checkoutButtons.isml
@@ -76,7 +76,7 @@
             <div id="express-container" class="hidden">
                 <div data-method="applepay" class="expressComponent applepay" style="padding:0"></div>
                 <div data-method="amazonpay" class="expressComponent" id="amazonpay-container"></div>
-				<div data-method="paypal" class="expressComponent" id="paypal-container"></div>
+			    <div data-method="paypal" class="expressComponent" id="paypal-container"></div>
             </div>
             <script src="${URLUtils.httpsStatic('/js/expressPaymentMethodsVisibility.js')}" type="text/javascript"></script>
         </isif>
@@ -88,6 +88,6 @@
             <script src="${URLUtils.httpsStatic('/js/amazonPayExpressPart1.js')}" type="text/javascript"></script>
         </isif>
 		<!--This has to be conditional when adding the BM manager enable/disable feature-->
-		<script src="${URLUtils.httpsStatic('/js/paypalExpress.js')}" type="text/javascript"></script>
+	    <script src="${URLUtils.httpsStatic('/js/paypalExpress.js')}" type="text/javascript"></script>
     </iselse>
 </isif>

--- a/src/cartridges/app_adyen_SFRA/cartridge/templates/default/cart/checkoutButtons.isml
+++ b/src/cartridges/app_adyen_SFRA/cartridge/templates/default/cart/checkoutButtons.isml
@@ -76,7 +76,7 @@
             <div id="express-container" class="hidden">
                 <div data-method="applepay" class="expressComponent applepay" style="padding:0"></div>
                 <div data-method="amazonpay" class="expressComponent" id="amazonpay-container"></div>
-                <div data-method="paypal" class="expressComponent applepay" id="paypal-container"></div>
+                <div data-method="paypal" class="expressComponent" id="paypal-container"></div>
             </div>
             <script src="${URLUtils.httpsStatic('/js/expressPaymentMethodsVisibility.js')}" type="text/javascript"></script>
         </isif>

--- a/src/cartridges/app_adyen_SFRA/cartridge/templates/default/cart/checkoutButtons.isml
+++ b/src/cartridges/app_adyen_SFRA/cartridge/templates/default/cart/checkoutButtons.isml
@@ -76,6 +76,7 @@
             <div id="express-container" class="hidden">
                 <div data-method="applepay" class="expressComponent applepay" style="padding:0"></div>
                 <div data-method="amazonpay" class="expressComponent" id="amazonpay-container"></div>
+				<div data-method="paypal" class="expressComponent" id="paypal-container"></div>
             </div>
             <script src="${URLUtils.httpsStatic('/js/expressPaymentMethodsVisibility.js')}" type="text/javascript"></script>
         </isif>
@@ -86,5 +87,7 @@
         <isif condition="${AdyenConfigs.areExpressPaymentsEnabled() && AdyenConfigs.isAmazonPayExpressEnabled()}">
             <script src="${URLUtils.httpsStatic('/js/amazonPayExpressPart1.js')}" type="text/javascript"></script>
         </isif>
+		<!--This has to be conditional when adding the BM manager enable/disable feature-->
+		<script src="${URLUtils.httpsStatic('/js/paypalExpress.js')}" type="text/javascript"></script>
     </iselse>
 </isif>

--- a/src/cartridges/app_adyen_SFRA/cartridge/templates/default/cart/checkoutButtons.isml
+++ b/src/cartridges/app_adyen_SFRA/cartridge/templates/default/cart/checkoutButtons.isml
@@ -87,7 +87,7 @@
         <isif condition="${AdyenConfigs.areExpressPaymentsEnabled() && AdyenConfigs.isAmazonPayExpressEnabled()}">
             <script src="${URLUtils.httpsStatic('/js/amazonPayExpressPart1.js')}" type="text/javascript"></script>
         </isif>
-		<!--This has to be conditional when adding the BM manager enable/disable feature-->
-		<script src="${URLUtils.httpsStatic('/js/paypalExpress.js')}" type="text/javascript"></script>
+        <!--This has to be conditional when adding the BM manager enable/disable feature-->
+        <script src="${URLUtils.httpsStatic('/js/paypalExpress.js')}" type="text/javascript"></script>
     </iselse>
 </isif>

--- a/src/cartridges/app_adyen_SFRA/cartridge/templates/default/cart/checkoutButtons.isml
+++ b/src/cartridges/app_adyen_SFRA/cartridge/templates/default/cart/checkoutButtons.isml
@@ -76,7 +76,7 @@
             <div id="express-container" class="hidden">
                 <div data-method="applepay" class="expressComponent applepay" style="padding:0"></div>
                 <div data-method="amazonpay" class="expressComponent" id="amazonpay-container"></div>
-			    <div data-method="paypal" class="expressComponent" id="paypal-container"></div>
+                <div data-method="paypal" class="expressComponent applepay" id="paypal-container"></div>
             </div>
             <script src="${URLUtils.httpsStatic('/js/expressPaymentMethodsVisibility.js')}" type="text/javascript"></script>
         </isif>
@@ -88,6 +88,6 @@
             <script src="${URLUtils.httpsStatic('/js/amazonPayExpressPart1.js')}" type="text/javascript"></script>
         </isif>
 		<!--This has to be conditional when adding the BM manager enable/disable feature-->
-	    <script src="${URLUtils.httpsStatic('/js/paypalExpress.js')}" type="text/javascript"></script>
+		<script src="${URLUtils.httpsStatic('/js/paypalExpress.js')}" type="text/javascript"></script>
     </iselse>
 </isif>


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Adding PayPal express functionality to the cartridge.
- What existing problem does this pull request solve?
It renders the PayPal express button on cart and mini-cart.

## Tested scenarios
Description of tested scenarios:
- Rendering PayPal Express button

**Fixed issue**:  SFI-699
