### PR TITLE
Updated web components and added exposeExpiryDate to card config

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
@@ -20,6 +20,7 @@ function getCardConfig() {
       shopperEmail: window.customerEmail,
       merchantDisplayName: window.merchantAccount,
     },
+    exposeExpiryDate: false,
     onChange(state) {
       store.isValid = state.isValid;
       const method = state.data.paymentMethod.storedPaymentMethodId

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/config/constants.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/config/constants.js
@@ -98,6 +98,6 @@ module.exports = {
   APPLE_DOMAIN_URL:
     '/.well-known/apple-developer-merchantid-domain-association',
 
-  CHECKOUT_COMPONENT_VERSION: '5.61.0',
+  CHECKOUT_COMPONENT_VERSION: '5.64.0',
   VERSION: '24.2.0',
 };


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Updating Web Components to v5.64.0 and making use of the new functionalities.
- What existing problem does this pull request solve?
It updates web components to v5.64.0 and adds `exposeExpiryDate` which can be consumed `onFieldValid` callback.

## Tested scenarios
Description of tested scenarios:
- E2E pipeline

**Fixed issue**:  SFI-748
