### PR TITLE
Calculate correct tax for applePay express

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/applePayExpress.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/applePayExpress.js
@@ -233,6 +233,7 @@ initializeCheckout()
             country: shippingContact.country,
             countryCode: shippingContact.countryCode,
             stateCode: shippingContact.administrativeArea,
+            postalCode: shippingContact.postalCode,
           })}`,
         );
         if (shippingMethods.ok) {

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/__tests__/shippingMethods.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/__tests__/shippingMethods.test.js
@@ -61,7 +61,7 @@ describe('Shipping methods', () => {
     const setPostalCodeMock = jest.fn()
     const setStateCodeMock = jest.fn()
     const setCountryCodeMock = jest.fn()
-    const currentBasket = {
+    const currentBasketMock = {
       getDefaultShipment: jest.fn(() =>({
         createShippingAddress: jest.fn(() => ({
           setCity: setCityMock,
@@ -71,7 +71,7 @@ describe('Shipping methods', () => {
         }))
       })),
     };
-    BasketMgr.getCurrentBasket.mockReturnValueOnce(currentBasket);
+    BasketMgr.getCurrentBasket.mockReturnValueOnce(currentBasketMock);
     callGetShippingMethods(req, res, next);
     expect(setCityMock).toHaveBeenCalledWith('Amsterdam');
     expect(setPostalCodeMock).toHaveBeenCalledWith('1001');

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/__tests__/shippingMethods.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/__tests__/shippingMethods.test.js
@@ -1,4 +1,5 @@
 /* eslint-disable global-require */
+const BasketMgr = require('dw/order/BasketMgr');
 const AdyenHelper = require('*/cartridge/adyen/utils/adyenHelper');
 
 let res;
@@ -6,6 +7,7 @@ let req;
 const next = jest.fn();
 
 const callGetShippingMethods = require('../shippingMethods');
+const Logger = require("../../../../../../../../jest/__mocks__/dw/system/Logger");
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -15,6 +17,7 @@ beforeEach(() => {
       city: 'Amsterdam',
       countryCode: 'NL',
       stateCode: 'AMS',
+      postalCode: '1001',
       shipmentUUID: 'mocked_uuid',
     },
     locale: { id: 'nl_NL' },
@@ -51,5 +54,29 @@ describe('Shipping methods', () => {
     );
     callGetShippingMethods(req, res, next);
     expect(res.json).not.toHaveBeenCalled();
+  });
+  it('Should update shipping address for the basket', () => {
+    const Logger = require('../../../../../../../../jest/__mocks__/dw/system/Logger');
+    const setCityMock = jest.fn()
+    const setPostalCodeMock = jest.fn()
+    const setStateCodeMock = jest.fn()
+    const setCountryCodeMock = jest.fn()
+    const currentBasket = {
+      getDefaultShipment: jest.fn(() =>({
+        createShippingAddress: jest.fn(() => ({
+          setCity: setCityMock,
+          setPostalCode: setPostalCodeMock,
+          setStateCode: setStateCodeMock,
+          setCountryCode: setCountryCodeMock
+        }))
+      })),
+    };
+    BasketMgr.getCurrentBasket.mockReturnValueOnce(currentBasket);
+    callGetShippingMethods(req, res, next);
+    expect(setCityMock).toHaveBeenCalledWith('Amsterdam');
+    expect(setPostalCodeMock).toHaveBeenCalledWith('1001');
+    expect(setStateCodeMock).toHaveBeenCalledWith('AMS');
+    expect(setCountryCodeMock).toHaveBeenCalledWith('NL');
+    expect(Logger.error.mock.calls.length).toBe(0);
   });
 });


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
- tax was not calculated correctly for applePay express when tax changes with change in shipping address
- What existing problem does this pull request solve?
- Calculate correct tax for applePay express


## Tested scenarios
Description of tested scenarios: 
 - applePay express

**Fixed issue**:  SFI-705
