### PR TITLE
Merchant reference set for PayPal Express

### DIFF
--- a/jest/sfccCartridgeMocks.js
+++ b/jest/sfccCartridgeMocks.js
@@ -240,6 +240,7 @@ jest.mock('*/cartridge/adyen/utils/adyenHelper', () => ({
     })),
     isAdyenGivingAvailable: jest.fn(() => true),
     isApplePay: jest.fn(() => true),
+	isPayPalExpress: jest.fn(() => false),
     getAdyenGivingConfig: jest.fn(() => true),
     getApplicationInfo: jest.fn(() => ({
       externalPlatform: { version: 'SFRA' },

--- a/jest/sfccCartridgeMocks.js
+++ b/jest/sfccCartridgeMocks.js
@@ -240,7 +240,7 @@ jest.mock('*/cartridge/adyen/utils/adyenHelper', () => ({
     })),
     isAdyenGivingAvailable: jest.fn(() => true),
     isApplePay: jest.fn(() => true),
-	isPayPalExpress: jest.fn(() => false),
+    isPayPalExpress: jest.fn(() => false),
     getAdyenGivingConfig: jest.fn(() => true),
     getApplicationInfo: jest.fn(() => ({
       externalPlatform: { version: 'SFRA' },

--- a/metadata/site_import/meta/system-objecttype-extensions.xml
+++ b/metadata/site_import/meta/system-objecttype-extensions.xml
@@ -44,6 +44,14 @@
                 <externally-managed-flag>false</externally-managed-flag>
                 <min-length>0</min-length>
             </attribute-definition>
+			<attribute-definition attribute-id="Adyen_paypalExpressResponse">
+                <display-name xml:lang="x-default">Adyen PayPal Express Response</display-name>
+                <description xml:lang="x-default">PayPal Express response used to render the confirmation form</description>
+                <type>text</type>
+                <mandatory-flag>false</mandatory-flag>
+                <externally-managed-flag>false</externally-managed-flag>
+                <min-length>0</min-length>
+            </attribute-definition>
         </custom-attribute-definitions>
         <group-definitions>
             <attribute-group group-id="AdyenPayments">
@@ -53,6 +61,7 @@
                 <attribute attribute-id="Adyen_paymentMethod"/>
                 <attribute attribute-id="Adyen_value"/>
                 <attribute attribute-id="Adyen_donationAmount"/>
+				<attribute attribute-id="Adyen_paypalExpressResponse"/>
             </attribute-group>
         </group-definitions>
     </type-extension>

--- a/metadata/site_import/meta/system-objecttype-extensions.xml
+++ b/metadata/site_import/meta/system-objecttype-extensions.xml
@@ -44,7 +44,7 @@
                 <externally-managed-flag>false</externally-managed-flag>
                 <min-length>0</min-length>
             </attribute-definition>
-			<attribute-definition attribute-id="Adyen_paypalExpressResponse">
+            <attribute-definition attribute-id="Adyen_paypalExpressResponse">
                 <display-name xml:lang="x-default">Adyen PayPal Express Response</display-name>
                 <description xml:lang="x-default">PayPal Express response used to render the confirmation form</description>
                 <type>text</type>
@@ -61,7 +61,7 @@
                 <attribute attribute-id="Adyen_paymentMethod"/>
                 <attribute attribute-id="Adyen_value"/>
                 <attribute attribute-id="Adyen_donationAmount"/>
-				<attribute attribute-id="Adyen_paypalExpressResponse"/>
+                <attribute attribute-id="Adyen_paypalExpressResponse"/>
             </attribute-group>
         </group-definitions>
     </type-extension>

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/paypalExpress.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/paypalExpress.js
@@ -19,8 +19,6 @@ function callPaymentFromComponent(data, component) {
       data: JSON.stringify(data),
     },
     success(response) {
-      helpers.createShowConfirmationForm(window.showConfirmationAction);
-      helpers.setOrderFormData(response);
       handlePaypalResponse(response, component);
     },
   });
@@ -43,6 +41,10 @@ function makeExpressPaymentDetailsCall(data) {
     data: JSON.stringify({ data }),
     contentType: 'application/json; charset=utf-8',
     async: false,
+    success(response) {
+      helpers.createShowConfirmationForm(window.showConfirmationAction);
+      helpers.setOrderFormData(response);
+    },
   });
 }
 
@@ -79,6 +81,9 @@ async function mountPaypalComponent() {
       },
       onAdditionalDetails: (state) => {
         makeExpressPaymentDetailsCall(state.data);
+        document.querySelector('#additionalDetailsHidden').value =
+          JSON.stringify(state.data);
+        document.querySelector('#showConfirmationForm').submit();
       },
     };
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/adyenCheckout.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/adyenCheckout.js
@@ -155,9 +155,9 @@ function createPaymentRequest(args) {
 
     paymentRequest = AdyenHelper.add3DS2Data(paymentRequest);
     const paymentMethodType = paymentRequest.paymentMethod.type;
-    const isPayPalExpress =
-      paymentRequest.paymentMethod.type === 'paypal' &&
-      paymentRequest.paymentMethod.subtype === 'express';
+    const isPayPalExpress = AdyenHelper.isPayPalExpress(
+      paymentRequest.paymentMethod,
+    );
 
     // Add Risk data
     if (AdyenConfigs.getAdyenBasketFieldsEnabled()) {

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/showConfirmation/handlePaymentFromComponent.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/showConfirmation/handlePaymentFromComponent.js
@@ -104,6 +104,7 @@ function handlePaymentResult(result, order, adyenPaymentInstrument, options) {
   Transaction.wrap(() => {
     order.custom.Adyen_pspReference = result.pspReference;
     order.custom.Adyen_eventCode = result.resultCode;
+    order.custom.Adyen_paypalExpressResponse = null;
   });
   return handlePaymentError(order, adyenPaymentInstrument, options);
 }
@@ -156,7 +157,6 @@ function handlePayment(stateData, order, options) {
 
   Transaction.wrap(() => {
     adyenPaymentInstrument.custom.adyenPaymentData = null;
-    order.custom.Adyen_paypalExpressResponse = null;
   });
 
   return handlePaymentResult(

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/showConfirmation/handlePaymentFromComponent.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/showConfirmation/handlePaymentFromComponent.js
@@ -156,6 +156,7 @@ function handlePayment(stateData, order, options) {
 
   Transaction.wrap(() => {
     adyenPaymentInstrument.custom.adyenPaymentData = null;
+	order.custom.Adyen_paypalExpressResponse = null;
   });
 
   return handlePaymentResult(

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/showConfirmation/handlePaymentFromComponent.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/showConfirmation/handlePaymentFromComponent.js
@@ -156,7 +156,7 @@ function handlePayment(stateData, order, options) {
 
   Transaction.wrap(() => {
     adyenPaymentInstrument.custom.adyenPaymentData = null;
-	order.custom.Adyen_paypalExpressResponse = null;
+    order.custom.Adyen_paypalExpressResponse = null;
   });
 
   return handlePaymentResult(

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
@@ -32,6 +32,7 @@ const collections = require('*/cartridge/scripts/util/collections');
 const ShippingMgr = require('dw/order/ShippingMgr');
 const ShippingMethodModel = require('*/cartridge/models/shipping/shippingMethod');
 const PaymentInstrument = require('dw/order/PaymentInstrument');
+const OrderMgr = require('dw/order/OrderMgr');
 const StringUtils = require('dw/util/StringUtils');
 //script includes
 const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
@@ -339,6 +340,13 @@ let adyenHelperObj = {
     return false;
   },
 
+  isPayPalExpress(paymentMethod){
+	if (paymentMethod.type === 'paypal' && paymentMethod.subtype === 'express'){
+		return true;
+	}
+	return false;
+  },
+
   // Get stored card token of customer saved card based on matched cardUUID
   getCardToken(cardUUID, customer) {
     let token = '';
@@ -503,6 +511,13 @@ let adyenHelperObj = {
       reference = order.getOrderNo();
       orderToken = order.getOrderToken();
     }
+
+	// creates order number to be utilized for PayPal express
+	if (adyenHelperObj.isPayPalExpress){
+		const paypalExpressOrderNo = OrderMgr.createOrderNo();
+		session.privacy.paypalExpressOrderNo = paypalExpressOrderNo;
+		reference = paypalExpressOrderNo;
+	}
 
     let signature = '';
     //Create signature to verify returnUrl if there is an order

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
@@ -513,7 +513,7 @@ let adyenHelperObj = {
     }
 
 	// creates order number to be utilized for PayPal express
-	if (adyenHelperObj.isPayPalExpress){
+	if (adyenHelperObj.isPayPalExpress(stateData.paymentMethod)){
 		const paypalExpressOrderNo = OrderMgr.createOrderNo();
 		session.privacy.paypalExpressOrderNo = paypalExpressOrderNo;
 		reference = paypalExpressOrderNo;


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Enabling PayPal express payments.
- What existing problem does this pull request solve?
This PR creates the order number beforehand ( similar to giftcards ) , and uses it as a merchant reference for PayPal express flow. Moreover, some adjustments are done to `showConfirmation` flow to be re-used with PayPal express and show the confirmation page.


## Tested scenarios
Description of tested scenarios:
- PayPal Express Payment
- End of checkout PayPal Payment
- E2E pipeline

**Fixed issue**:  
