### PR TITLE
Added a check to set address properties in case they are available

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/shippingMethods.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/shippingMethods.js
@@ -3,6 +3,22 @@ const Transaction = require('dw/system/Transaction');
 const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
 const AdyenHelper = require('*/cartridge/adyen/utils/adyenHelper');
 
+const addressMapping = {
+  city: 'setCity',
+  countryCode: 'setCountryCode',
+  stateCode: 'setStateCode',
+  postalCode: 'setPostalCode',
+};
+
+// Sets address properties for express PM
+function setAddressProperties(shippingAddress, inputAddress, mapping) {
+  Object.keys(inputAddress).forEach((key) => {
+    if (inputAddress[key] && mapping[key]) {
+      shippingAddress[mapping[key]](inputAddress[key]);
+    }
+  });
+}
+
 /**
  * Make a request to Adyen to get shipping methods
  */
@@ -26,10 +42,9 @@ function callGetShippingMethods(req, res, next) {
           .getDefaultShipment()
           .createShippingAddress();
       }
-      shippingAddress.setCity(address.city);
-      shippingAddress.setPostalCode(address.postalCode);
-      shippingAddress.setStateCode(address.stateCode);
-      shippingAddress.setCountryCode(address.countryCode);
+      if (address) {
+        setAddressProperties(shippingAddress, address, addressMapping);
+      }
     });
     const currentShippingMethodsModels =
       AdyenHelper.getApplicableShippingMethods(shipment, address);

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/shippingMethods.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/shippingMethods.js
@@ -10,7 +10,12 @@ const addressMapping = {
   postalCode: 'setPostalCode',
 };
 
-// Sets address properties for express PM
+/**
+ * Sets address properties for express PM
+ * @param {dw.order.shippingAddress} shippingAddress - shippingAddress for the default shipment
+ * @param {object} inputAddress - address coming from the input field based on shopper selection
+ * @param {object} mapping - address mapping between property and setter for that property
+ */
 function setAddressProperties(shippingAddress, inputAddress, mapping) {
   Object.keys(inputAddress).forEach((key) => {
     if (inputAddress[key] && mapping[key]) {


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Address was being set to undefined. This was introduced in #1079 , so it was not part of any previous release.
- What existing problem does this pull request solve?
Makes sure the address is always defined when setting it.

## Tested scenarios
Description of tested scenarios:
- Apple Pay Express Payments
- Amazon Pay Express Payments

**Fixed issue**:  SFI-800
