### PR TITLE
Added the review page template and controller to render it

### DIFF
--- a/jest/sfccPathSetup.js
+++ b/jest/sfccPathSetup.js
@@ -113,6 +113,13 @@ jest.mock(
 );
 
 jest.mock(
+	'*/cartridge/adyen/scripts/expressPayments/paypal/handleCheckoutReview',
+	() =>
+	  require('../src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/paypal/handleCheckoutReview'),
+	{ virtual: true },
+);
+
+jest.mock(
   '*/cartridge/adyen/scripts/partialPayments/fetchGiftCards',
   () =>
     require('../src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/partialPayments/fetchGiftCards'),

--- a/jest/sfccPathSetup.js
+++ b/jest/sfccPathSetup.js
@@ -113,10 +113,10 @@ jest.mock(
 );
 
 jest.mock(
-	'*/cartridge/adyen/scripts/expressPayments/paypal/handleCheckoutReview',
-	() =>
-	  require('../src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/paypal/handleCheckoutReview'),
-	{ virtual: true },
+  '*/cartridge/adyen/scripts/expressPayments/paypal/handleCheckoutReview',
+  () =>
+    require('../src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/paypal/handleCheckoutReview'),
+  { virtual: true },
 );
 
 jest.mock(

--- a/src/cartridges/app_adyen_SFRA/cartridge/templates/default/cart/checkoutButtons.isml
+++ b/src/cartridges/app_adyen_SFRA/cartridge/templates/default/cart/checkoutButtons.isml
@@ -66,6 +66,8 @@
             window.makeExpressPaymentDetailsCall = "${URLUtils.https('Adyen-MakeExpressPaymentDetailsCall')}";
             window.saveShopperData = "${URLUtils.https('Adyen-SaveShopperData')}";
             window.paypalUpdateOrder = "${URLUtils.https('Adyen-paypalUpdateOrder')}";
+            window.paypalReviewPageEnabled = ${AdyenConfigs.isPayPalExpressReviewPageEnabled()};
+            window.checkoutReview = "${URLUtils.https('Adyen-CheckoutReview')}";
         </script>
         <div class="mb-sm-3">
             <a

--- a/src/cartridges/app_adyen_SFRA/cartridge/templates/default/cart/checkoutReview.isml
+++ b/src/cartridges/app_adyen_SFRA/cartridge/templates/default/cart/checkoutReview.isml
@@ -1,0 +1,3 @@
+<div class="checkoutReview">
+    <h1>Order Review Page</h1>
+</div>

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/config/constants.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/config/constants.js
@@ -100,6 +100,6 @@ module.exports = {
   APPLE_DOMAIN_URL:
     '/.well-known/apple-developer-merchantid-domain-association',
 
-  CHECKOUT_COMPONENT_VERSION: '5.61.0',
+  CHECKOUT_COMPONENT_VERSION: '5.65.0',
   VERSION: '24.2.0',
 };

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/paypal/handleCheckoutReview.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/paypal/handleCheckoutReview.js
@@ -1,0 +1,8 @@
+function handleCheckoutReview(req, res, next) {
+  res.render('cart/checkoutReview', {
+    // additional data may be required later
+  });
+  return next();
+}
+
+module.exports = handleCheckoutReview;

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/index.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/index.js
@@ -16,6 +16,7 @@ const notify = require('*/cartridge/adyen/webhooks/notify');
 const makeExpressPaymentsCall = require('*/cartridge/adyen/scripts/expressPayments/paypal/makeExpressPaymentsCall');
 const makeExpressPaymentDetailsCall = require('*/cartridge/adyen/scripts/expressPayments/paypal/makeExpressPaymentDetailsCall');
 const saveShopperData = require('*/cartridge/adyen/scripts/expressPayments/paypal/saveShopperData');
+const handleCheckoutReview = require('*/cartridge/adyen/scripts/expressPayments/paypal/handleCheckoutReview');
 
 module.exports = {
   getCheckoutPaymentMethods,
@@ -36,4 +37,5 @@ module.exports = {
   makeExpressPaymentsCall,
   makeExpressPaymentDetailsCall,
   saveShopperData,
+  handleCheckoutReview,
 };

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/Adyen.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/Adyen.js
@@ -100,6 +100,15 @@ server.get(
 );
 
 /**
+ * Show the review page template.
+ */
+server.get(
+  'CheckoutReview',
+  server.middleware.https,
+  adyen.handleCheckoutReview,
+);
+
+/**
  * Called by Adyen to update status of payments. It should always display [accepted] when finished.
  */
 server.post('Notify', server.middleware.https, adyen.notify);

--- a/tests/playwright/fixtures/countriesEUR/NL.spec.mjs
+++ b/tests/playwright/fixtures/countriesEUR/NL.spec.mjs
@@ -25,29 +25,29 @@ for (const environment of environments) {
 
     test('iDeal Success @quick', async ({ page }) => {
       redirectShopper = new RedirectShopper(page);
-      await redirectShopper.doIdealPayment(true);
+      await redirectShopper.doIdealPayment();
       await checkoutPage.completeCheckout();
-      await redirectShopper.completeIdealRedirect();
+      await redirectShopper.completeIdealRedirect(true);
       await checkoutPage.expectNonRedirectSuccess();
     });
 
     test('iDeal with restored cart success', async ({ page }) => {
       redirectShopper = new RedirectShopper(page);
-      await redirectShopper.doIdealPayment(true);
+      await redirectShopper.doIdealPayment();
       await checkoutPage.completeCheckout();
       await checkoutPage.goBackAndSubmitShipping()
-      await redirectShopper.doIdealPayment(true);
+      await redirectShopper.doIdealPayment();
       await checkoutPage.submitPayment();
       await checkoutPage.placeOrder();
-      await redirectShopper.completeIdealRedirect();
+      await redirectShopper.completeIdealRedirect(true);
       await checkoutPage.expectNonRedirectSuccess();
     });
 
     test('iDeal Fail @quick', async ({ page }) => {
       redirectShopper = new RedirectShopper(page);
-      await redirectShopper.doIdealPayment(false);
+      await redirectShopper.doIdealPayment();
       await checkoutPage.completeCheckout();
-      await redirectShopper.completeIdealRedirect();
+      await redirectShopper.completeIdealRedirect(false);
       await checkoutPage.expectRefusal();
     });
   });
@@ -65,7 +65,7 @@ for (const environment of environments) {
     });
     test('iDeal with restored cart Fail', async ({ page, context }) => {
       redirectShopper = new RedirectShopper(page);
-      await redirectShopper.doIdealPayment(true);
+      await redirectShopper.doIdealPayment();
       await checkoutPage.submitPayment();
       const checkoutURL = await checkoutPage.getLocation();
       await checkoutPage.placeOrder()
@@ -73,7 +73,7 @@ for (const environment of environments) {
       const newPage = await context.newPage();
       newPage.goto(checkoutURL);
 
-      await redirectShopper.completeIdealRedirect();
+      await redirectShopper.completeIdealRedirect(true);
       await checkoutPage.expectRefusal();
     });
 

--- a/tests/playwright/pages/CheckoutPageSFRA5.mjs
+++ b/tests/playwright/pages/CheckoutPageSFRA5.mjs
@@ -211,7 +211,7 @@ export default class CheckoutPageSFRA5 {
   };
 
   expectRefusal = async () => {
-    await expect(this.errorMessage).not.toBeEmpty();
+    await expect(this.errorMessage).not.toBeEmpty({ timeout: 25000 });
   };
 
   expectVoucher = async () => {

--- a/tests/playwright/pages/CheckoutPageSFRA6.mjs
+++ b/tests/playwright/pages/CheckoutPageSFRA6.mjs
@@ -231,7 +231,7 @@ export default class CheckoutPageSFRA {
   };
 
   expectRefusal = async () => {
-    await expect(this.errorMessage).not.toBeEmpty();
+    await expect(this.errorMessage).not.toBeEmpty({ timeout: 25000 });
   };
 
   expectVoucher = async () => {
@@ -254,9 +254,7 @@ export default class CheckoutPageSFRA {
   };
 
   navigateBack = async () => {
-    await this.page.waitForLoadState('networkidle', { timeout: 20000 });
     await this.page.goBack();
-    await this.page.waitForLoadState('networkidle', { timeout: 20000 });
   };
 
   loginUser = async (credentials) => {

--- a/tests/playwright/pages/PaymentMethodsPage.mjs
+++ b/tests/playwright/pages/PaymentMethodsPage.mjs
@@ -30,8 +30,6 @@ export default class PaymentMethodsPage {
 
     await this.page.locator('#rb_ideal').click();
     await iDealInput.click();
-    await iDealDropDown.click();
-    await issuer.click();
   };
 
   initiatePayPalPayment = async () => {
@@ -174,8 +172,11 @@ export default class PaymentMethodsPage {
     await this.page.locator('#SubmitForm').click();
   };
 
-  submitSimulator = async () => {
-    await this.page.locator('input[type="submit"]').click();
+  submitSimulator = async (testSuccess) => {
+    await this.page.locator('button[data-testid="payment-action-button"]').click();
+    await this.page.locator('button[data-testid="ideal-box-bank-item-TESTNL2A"]').click();
+    const actionButton = testSuccess ? this.page.getByRole('button', { name: 'Success', exact: true }) : this.page.getByRole('button', { name: 'Cancellation', exact: true });
+    await actionButton.click();
   };
 
   submitBankSimulator = async () => {

--- a/tests/playwright/paymentFlows/redirectShopper.mjs
+++ b/tests/playwright/paymentFlows/redirectShopper.mjs
@@ -5,12 +5,12 @@ export class RedirectShopper {
     this.paymentMethodsPage = new PaymentMethodsPage(page);
   }
 
-  doIdealPayment = async (testSuccess) => {
-    await this.paymentMethodsPage.initiateIdealPayment(testSuccess);
+  doIdealPayment = async () => {
+    await this.paymentMethodsPage.initiateIdealPayment();
   };
 
-  completeIdealRedirect = async () => {
-    await this.paymentMethodsPage.submitSimulator();
+  completeIdealRedirect = async (testSuccess) => {
+    await this.paymentMethodsPage.submitSimulator(testSuccess);
   };
 
   doBillDeskPayment = async (paymentMethod) => {


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Enabling the review page for PayPal Express.
- What existing problem does this pull request solve?
It renders a review page after closing PayPal modale, which will be extended to submit the payment details call and finalize the payment.


## Tested scenarios
Description of tested scenarios:
- PayPal Express flow redirection to review page if enabled
- PayPal Express flow without review page

**Fixed issue**:  SFI-788
