### PR TITLE
fix: properly handling the first selected pm, also the multiple tx va…

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
@@ -272,12 +272,17 @@ function getGiftCardConfig() {
 }
 
 function handleOnChange(state) {
-  store.isValid = state.isValid;
-  if (!store.componentsObj[store.selectedMethod]) {
-    store.componentsObj[store.selectedMethod] = {};
+  let { type } = state.data.paymentMethod;
+  const multipleTxVariantComponents = constants.MULTIPLE_TX_VARIANTS_COMPONENTS;
+  if (multipleTxVariantComponents.includes(store.selectedMethod)) {
+    type = store.selectedMethod;
   }
-  store.componentsObj[store.selectedMethod].isValid = store.isValid;
-  store.componentsObj[store.selectedMethod].stateData = state.data;
+  store.isValid = state.isValid;
+  if (!store.componentsObj[type]) {
+    store.componentsObj[type] = {};
+  }
+  store.componentsObj[type].isValid = store.isValid;
+  store.componentsObj[type].stateData = state.data;
 }
 
 const actionHandler = async (action) => {

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/constants.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/constants.js
@@ -22,4 +22,5 @@ module.exports = {
     'applepay',
     'cashapp',
   ],
+  MULTIPLE_TX_VARIANTS_COMPONENTS: ['upi'],
 };


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Validation was failing when the first pre-selected pm was being used to complete a payment, preventing the shopper to go to order review page. This issue was happening only for components which don't have additional fields.
- What existing problem does this pull request solve?
Changes `handleOnChange` function to get the type of payment method from stateData and handles the multiple tx variant components.


## Tested scenarios
Description of tested scenarios:
- iDeal payments
- UPI Payments

**Fixed issue**:  SFI-795
