### PR TITLE
Changed the manufacturer field name to align with API requirements

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/riskDataHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/riskDataHelper.js
@@ -46,8 +46,9 @@ const __RiskDataHelper = {
       basketData[`riskdata.basket.item${itemNr}.brand`] = item.product
         ? item.product.brand
         : '';
-      basketData[`riskdata.basket.item${itemNr}.manufacturerName`] =
-        item.product ? item.product.manufacturerName : '';
+      basketData[`riskdata.basket.item${itemNr}.manufacturer`] = item.product
+        ? item.product.manufacturerName
+        : '';
       basketData[`riskdata.basket.item${itemNr}.category`] =
         item.product && item.product.primaryCategory
           ? item.product.primaryCategory.displayName


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
The `Manufacturer` field name being passed to the basket risk data was wrong.
- What existing problem does this pull request solve?
It updates `manufacturerName` to `manufacturer` as mentioned in the [docs](https://docs.adyen.com/api-explorer/Checkout/70/post/payments#request-additionalData-listOfValues-AdditionalDataRisk_riskdata-basket-item_itemNr_-manufacturer).

## Tested scenarios
Description of tested scenarios:
- Card Payments
- Redirect Payments

**Fixed issue**:  SFI-438