### PR TITLE
Remove redunadant check in for donations

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
@@ -295,8 +295,7 @@ let adyenHelperObj = {
 
   // determines whether Adyen Giving is available based on the donation token 
   isAdyenGivingAvailable(paymentInstrument) {
-    // Adyen giving is only available for BCMC in POS
-    return paymentInstrument.paymentTransaction.custom.Adyen_donationToken && paymentInstrument.paymentTransaction.custom.Adyen_paymentMethod !== 'bcmc';
+    return paymentInstrument.paymentTransaction.custom.Adyen_donationToken;
   },
 
   // gets the ID for ratePay using the custom preference and the encoded session ID


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Donations should be available only when donationToken is there.
- What existing problem does this pull request solve?
It removes a check which is not anymore required, as the issue got solved on the platform.

## Tested scenarios
Description of tested scenarios:
- iDeal donations
- Card donations
- Payment methods without donation token shouldn't offer giving

**Fixed issue**:  SFI-840
