### PR TITLE
BCMC config is set wrong

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
@@ -25,7 +25,7 @@ function getCardConfig() {
       store.isValid = state.isValid;
       const method = state.data.paymentMethod.storedPaymentMethodId
         ? `storedCard${state.data.paymentMethod.storedPaymentMethodId}`
-        : constants.SCHEME;
+        : store.selectedMethod;
       store.updateSelectedPayment(method, 'isValid', store.isValid);
       store.updateSelectedPayment(method, 'stateData', state.data);
     },


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
When changing from /sessions to /paymentMethods we introduced a bug, which was blocking the place order button for BCMC orders. 
- What existing problem does this pull request solve?
Fixes `getCardConfig` to support BCMC again. 


## Tested scenarios
Description of tested scenarios:
- Card payments
- BCMC payments

**Fixed issue**: SFI-841
