### PR TITLE
Initialize payment methods objects properly

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/store/index.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/store/index.js
@@ -54,6 +54,9 @@ class Store {
   }
 
   updateSelectedPayment(method, key, val) {
+    if (!this.componentsObj[method]) {
+      this.componentsObj[method] = {};
+    }
     this.componentsObj[method][key] = val;
   }
 }

--- a/tests/playwright/pages/PaymentMethodsPage.mjs
+++ b/tests/playwright/pages/PaymentMethodsPage.mjs
@@ -191,7 +191,7 @@ export default class PaymentMethodsPage {
 
   submitSimulator = async (testSuccess) => {
     await this.page.locator('button[data-testid="payment-action-button"]').click();
-    await this.page.locator('div[id="bank-item-TESTNL2A"]').click();
+    await this.page.locator('button[id="bank-item-TESTNL2A"]').click();
     const actionButton = testSuccess ? this.page.getByRole('button', { name: 'Success', exact: true }) : this.page.getByRole('button', { name: 'Cancellation', exact: true });
     await actionButton.click();
   };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Initialize empty object before setting the value
- What existing problem does this pull request solve?
Throwing console error

## Tested scenarios
Description of tested scenarios:
- 3DS payments
- payments from component

**Fixed issue**:  SFI-852
