### PR TITLE
Tax calculation for paypal express

### DIFF
--- a/jest/__mocks__/dw/order/BasketMgr.js
+++ b/jest/__mocks__/dw/order/BasketMgr.js
@@ -41,6 +41,11 @@ export const getAdjustedMerchandizeTotalGrossPrice = jest.fn(() => ({
   isAvailable,
 }));
 
+export const getAdjustedMerchandizeTotalNetPrice = jest.fn(() => ({
+  currencyCode: 'EUR',
+  isAvailable,
+}));
+
 export const getCreditCardToken = jest.fn(() => 'mockedCreditCardToken');
 export const getPaymentMethod = jest.fn(() => 'mockedPaymentMethod');
 
@@ -132,6 +137,7 @@ export const getCurrentBasket = jest.fn(() => ({
   getAllProductLineItems,
   getTotalGrossPrice,
   getAdjustedMerchandizeTotalGrossPrice,
+  getAdjustedMerchandizeTotalNetPrice,
   getPaymentInstruments,
   removeAllPaymentInstruments: jest.fn(),
   removePaymentInstrument: jest.fn(),

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/paypal/makeExpressPaymentsCall.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/paypal/makeExpressPaymentsCall.js
@@ -17,7 +17,7 @@ function makeExpressPaymentsCall(req, res, next) {
       currentBasket.removeAllPaymentInstruments();
       paymentInstrument = currentBasket.createPaymentInstrument(
         constants.METHOD_ADYEN_COMPONENT,
-        currentBasket.getAdjustedMerchandizeTotalGrossPrice(),
+        currentBasket.getAdjustedMerchandizeTotalNetPrice(),
       );
       const { paymentProcessor } = PaymentMgr.getPaymentMethod(
         paymentInstrument.paymentMethod,

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/shippingMethods.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/shippingMethods.js
@@ -2,6 +2,7 @@ const BasketMgr = require('dw/order/BasketMgr');
 const Transaction = require('dw/system/Transaction');
 const Resource = require('dw/web/Resource');
 const URLUtils = require('dw/web/URLUtils');
+const basketCalculationHelpers = require('*/cartridge/scripts/helpers/basketCalculationHelpers');
 const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
 const AdyenHelper = require('*/cartridge/adyen/utils/adyenHelper');
 const { PAYMENTMETHODS } = require('*/cartridge/adyen/config/constants');
@@ -42,7 +43,9 @@ function callGetShippingMethods(req, res, next) {
       return next();
     }
     updateShippingAddress(currentBasket, address);
-    currentBasket.updateTotals();
+    Transaction.wrap(() => {
+      basketCalculationHelpers.calculateTotals(currentBasket);
+    });
     const currentShippingMethodsModels =
       AdyenHelper.getApplicableShippingMethods(
         currentBasket.getDefaultShipment(),

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/__tests__/paypalHelper.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/__tests__/paypalHelper.test.js
@@ -87,8 +87,6 @@ describe('paypalHelper', () => {
       }]
       currentBasket = {
         currencyCode: 'USD',
-        getAdjustedShippingTotalGrossPrice: jest.fn(),
-        getAdjustedMerchandizeTotalGrossPrice: jest.fn(),
       }
 
       result = {
@@ -96,7 +94,13 @@ describe('paypalHelper', () => {
         paymentData: 'test',
         amount: {
           currency: 'USD',
-          value: 2000
+          value: 1000
+        },
+        taxTotal: {
+          amount: {
+            currency: 'USD',
+            value: 1000
+          }
         },
         deliveryMethods:[{
           reference: '001',

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
@@ -86,7 +86,6 @@ let adyenHelperObj = {
    * @returns {{currencyCode: String, value: String}} - Shipping Cost including taxes
    */
   getShippingCost(shippingMethod, shipment) {
-    const { shippingAddress } = shipment
     const shipmentShippingModel = ShippingMgr.getShipmentShippingModel(shipment);
     let shippingCost = shipmentShippingModel.getShippingCost(shippingMethod).getAmount();
     collections.forEach(shipment.getProductLineItems(), (lineItem) => {

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
@@ -98,23 +98,10 @@ let adyenHelperObj = {
         : new Money(0, product.getPriceModel().getPrice().getCurrencyCode());
       shippingCost = shippingCost.add(productShippingCost);
     })
-    shippingCost = shippingAddress ? shippingCost.addRate(adyenHelperObj.getShippingTaxRate(shippingMethod, shippingAddress)) : shippingCost;
     return {
       value: shippingCost.getValue(),
       currencyCode: shippingCost.getCurrencyCode(),
     };
-  },
-
-  /**
-   * Returns tax rate for specific Shipment / ShippingMethod pair.
-   * @param {dw.order.ShippingMethod} shippingMethod - the default shipment of the current basket
-   * @param {dw.order.shippingAddress} shippingAddress - shippingAddress for the default shipment
-   * @returns {Number} - tax rate in decimals.(eg.: 0.02 for 2%)
-   */
-  getShippingTaxRate(shippingMethod, shippingAddress) {
-    const taxClassID = shippingMethod.getTaxClassID();
-    const taxJurisdictionID = TaxMgr.getTaxJurisdictionID(new ShippingLocation(shippingAddress));
-    return TaxMgr.getTaxRate(taxClassID, taxJurisdictionID);
   },
 
   /**

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/paypalHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/paypalHelper.js
@@ -76,7 +76,7 @@ function getLineItems({ Order: order, Basket: basket }) {
  * Returns applicable shipping methods(excluding store pickup methods)
  * for specific Shipment / ShippingAddress pair.
  * @param {String} pspReference - the pspReference returned from adyen /payments endpoint
- * @param {dw.order.basket} amount - a shipment of the current basket
+ * @param {dw.order.basket} currentBasket - a shipment of the current basket
  * @param {dw.util.ArrayList<ApplicableShippingMethodModel>} currentShippingMethods
  *        - a shipment of the current basket
  * @param {String} paymentData - encrypted payment data from paypal component
@@ -88,18 +88,14 @@ function createPaypalUpdateOrderRequest(
   currentShippingMethods,
   paymentData,
 ) {
-  const adjustedShippingTotalGrossPrice = {
+  const totalGrossPrice = {
     currency: currentBasket.currencyCode,
-    value: AdyenHelper.getCurrencyValueForApi(
-      currentBasket.getAdjustedShippingTotalGrossPrice(),
-    ).value,
+    value: AdyenHelper.getCurrencyValueForApi(currentBasket.totalGrossPrice)
+      .value,
   };
-  const adjustedMerchandizeTotalGrossPrice = {
+  const totalTax = {
     currency: currentBasket.currencyCode,
-    value:
-      AdyenHelper.getCurrencyValueForApi(
-        currentBasket.getAdjustedMerchandizeTotalGrossPrice(),
-      ).value + adjustedShippingTotalGrossPrice.value,
+    value: AdyenHelper.getCurrencyValueForApi(currentBasket.totalTax).value,
   };
   const deliveryMethods = currentShippingMethods.map((shippingMethod) => {
     const { currencyCode, value } = shippingMethod.shippingCost;
@@ -119,7 +115,10 @@ function createPaypalUpdateOrderRequest(
   return {
     pspReference,
     paymentData,
-    amount: adjustedMerchandizeTotalGrossPrice,
+    amount: totalGrossPrice,
+    taxTotal: {
+      amount: totalTax,
+    },
     deliveryMethods,
   };
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
- Pass taxTotal property to /paypal/UpdateOrder endpoint
- What existing problem does this pull request solve?
- Tax calculation for PayPal Express when tax rates change with address


## Tested scenarios
Description of tested scenarios:
1. payPal Express flow

**Fixed issue**:  #-SFI-860
