### PR TITLE
Remove conditional cardholdername logic

### DIFF
--- a/metadata/site_import/meta/system-objecttype-extensions.xml
+++ b/metadata/site_import/meta/system-objecttype-extensions.xml
@@ -407,13 +407,6 @@
                 <externally-managed-flag>false</externally-managed-flag>
                 <default-value>true</default-value>
             </attribute-definition>
-            <attribute-definition attribute-id="AdyenCardHolderName_enabled">
-                <display-name xml:lang="x-default">Show input field for card holder name</display-name>
-                <type>boolean</type>
-                <mandatory-flag>false</mandatory-flag>
-                <externally-managed-flag>false</externally-managed-flag>
-                <default-value>true</default-value>
-            </attribute-definition>
             <attribute-definition attribute-id="AdyenLevel23DataEnabled">
                 <display-name xml:lang="x-default">Level 2/3 Data Authorisation Enabled</display-name>
                 <type>boolean</type>
@@ -704,7 +697,6 @@
                 <attribute attribute-id="AdyenCreditCardInstallments"/>
                 <attribute attribute-id="AdyenBasketFieldsEnabled"/>
                 <attribute attribute-id="AdyenLevel23DataEnabled"/>
-                <attribute attribute-id="AdyenCardHolderName_enabled"/>
                 <attribute attribute-id="AdyenLevel23_CommodityCode"/>
                 <attribute attribute-id="AdyenSalePaymentMethods"/>
                 <attribute attribute-id="AdyenInstallments_enabled"/>

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyenCheckout.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyenCheckout.js
@@ -31,10 +31,6 @@ $('#dwfrm_billing').submit(function apiRequest(e) {
 });
 
 setCheckoutConfiguration();
-if (window.cardholderNameBool !== 'null') {
-  store.checkoutConfiguration.paymentMethodsConfiguration.card.hasHolderName = true;
-  store.checkoutConfiguration.paymentMethodsConfiguration.card.holderNameRequired = true;
-}
 
 if (
   window.googleMerchantID !== 'null' &&

--- a/src/cartridges/app_adyen_SFRA/cartridge/templates/default/checkout/billing/adyenComponentForm.isml
+++ b/src/cartridges/app_adyen_SFRA/cartridge/templates/default/checkout/billing/adyenComponentForm.isml
@@ -58,7 +58,6 @@
     <script>
          window.installments = '${pdict.adyen.installments}';
          window.googleMerchantID = '${pdict.adyen.googleMerchantID}';
-         window.cardholderNameBool = '${pdict.adyen.cardholderNameBool}';
          window.merchantAccount = '${pdict.adyen.merchantAccount}';
          window.customerEmail = '${customer && customer.profile && customer.profile.email ? customer.profile.email : ''}';
          var showStoreDetails = ${customer.authenticated && adyenRecurringPaymentsEnabled};

--- a/src/cartridges/bm_adyen/cartridge/templates/default/adyenSettings/settingCards/cardSettings.isml
+++ b/src/cartridges/bm_adyen/cartridge/templates/default/adyenSettings/settingCards/cardSettings.isml
@@ -13,20 +13,6 @@
       </h7>
       <div class="mt-2">
          <div class="form-group">
-            <label class="form-title mb-0" for="cardHolderNameEnabled">Cardholder’s name</label>
-            <small id="cardHolderNameEnabledHelp" class="form-text mb-1">This allows you to show the input field for the cardholder’s name. </small>
-            <div class="radio-buttons">
-               <div class="form-check form-check-inline">
-                  <input class="form-check-input" type="radio" name="AdyenCardHolderName_enabled" id="cardHolderYes" value=true ${AdyenConfigs.getAdyenCardholderNameEnabled() ? 'checked': ''}>
-                  <label class="form-check-label" for="cardHolderYes">Enable</label>
-               </div>
-               <div class="form-check form-check-inline">
-                  <input class="form-check-input" type="radio" name="AdyenCardHolderName_enabled" id="cardHolderNo" value=false ${!AdyenConfigs.getAdyenCardholderNameEnabled() ? 'checked': ''}>
-                  <label class="form-check-label" for="cardHolderNo">Disable</label>
-               </div>
-            </div>
-         </div>
-         <div class="form-group">
             <div class='row'>
                <div class="switch-button">
                   <div class="form-check form-switch">

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenConfigs.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenConfigs.js
@@ -113,10 +113,6 @@ const adyenConfigsObj = {
     return getCustomPreference('AdyenBasketFieldsEnabled');
   },
 
-  getAdyenCardholderNameEnabled: function () {
-    return getCustomPreference('AdyenCardHolderName_enabled');
-  },
-
   getAdyenLevel23DataEnabled: function () {
     return getCustomPreference('AdyenLevel23DataEnabled');
   },

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout/__tests__/__snapshots__/begin.test.js.snap
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout/__tests__/__snapshots__/begin.test.js.snap
@@ -7,7 +7,6 @@ exports[`Begin should not attempt to restore cart when no order number is cached
       "adyen": {
         "SFRA6Enabled": false,
         "adyenClientKey": "mocked_client_key",
-        "cardholderNameBool": true,
         "clientKey": "mocked_client_key",
         "environment": "test",
         "googleMerchantID": "mocked_google_merchant_id",
@@ -26,7 +25,6 @@ exports[`Begin should set view data 1`] = `
       "adyen": {
         "SFRA6Enabled": false,
         "adyenClientKey": "mocked_client_key",
-        "cardholderNameBool": true,
         "clientKey": "mocked_client_key",
         "environment": "test",
         "googleMerchantID": "mocked_google_merchant_id",

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout/begin.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout/begin.js
@@ -67,7 +67,6 @@ function begin(req, res, next) {
   const adyenClientKey = AdyenConfigs.getAdyenClientKey();
   const googleMerchantID = AdyenConfigs.getGoogleMerchantID();
   const merchantAccount = AdyenConfigs.getAdyenMerchantAccount();
-  const cardholderNameBool = AdyenConfigs.getAdyenCardholderNameEnabled();
   const SFRA6Enabled = AdyenConfigs.getAdyenSFRA6Compatibility();
 
   const viewData = res.getViewData();
@@ -77,7 +76,6 @@ function begin(req, res, next) {
     installments,
     googleMerchantID,
     merchantAccount,
-    cardholderNameBool,
     adyenClientKey,
     SFRA6Enabled,
   };


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
After implementing new visa compliance rules, the conditional cardholder name logic is not anymore required, as we set the `hasHolderName` and `holderNameRequired` to true by default in the card config.  
- What existing problem does this pull request solve?
Removes the metadata fields and logic related to conditional cardholder name boolean.


## Tested scenarios
Description of tested scenarios:
- Card payments
- Stored card payments

**Fixed issue**:  SFI-872
