### PR TITLE
add currency for paypal express web-component

### DIFF
--- a/cartridges/app_adyen_SFRA/cartridge/client/default/js/paypalExpress.js
+++ b/cartridges/app_adyen_SFRA/cartridge/client/default/js/paypalExpress.js
@@ -292,6 +292,7 @@ function getPaypalButtonConfig(paypalConfig) {
     showPayButton: true,
     configuration: paypalConfig,
     returnUrl: window.returnUrl,
+    amount: JSON.parse(window.basketAmount),
     isExpress: true
   }, paypalReviewPageEnabled ? {
     userAction: 'continue'

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/paypalExpress.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/paypalExpress.js
@@ -153,6 +153,7 @@ function getPaypalButtonConfig(paypalConfig) {
     showPayButton: true,
     configuration: paypalConfig,
     returnUrl: window.returnUrl,
+    amount: JSON.parse(window.basketAmount),
     isExpress: true,
     ...(paypalReviewPageEnabled ? { userAction: 'continue' } : {}),
     onSubmit: async (state, component) => {


### PR DESCRIPTION
## Summary
I have added "amount" to Paypal express configurations to fix issue with different currency
I got this error:
Error: Expected currency from order api call to be USD, got GBP. Please ensure you are passing currency=GBP to the sdk url.
