### PR TITLE
Enabling/disabling apple pay express on pdp config

### DIFF
--- a/metadata/site_import/meta/system-objecttype-extensions.xml
+++ b/metadata/site_import/meta/system-objecttype-extensions.xml
@@ -518,7 +518,14 @@
                 <field-length>0</field-length>
             </attribute-definition>
             <attribute-definition attribute-id="ExpressPayments_enabled">
-                <display-name xml:lang="x-default">Enable express checkout</display-name>
+                <display-name xml:lang="x-default">Enable express checkout on cart and mini-cart</display-name>
+                <type>boolean</type>
+                <mandatory-flag>false</mandatory-flag>
+                <externally-managed-flag>false</externally-managed-flag>
+                <default-value>true</default-value>
+            </attribute-definition>
+            <attribute-definition attribute-id="ExpressPayments_Pdp_enabled">
+                <display-name xml:lang="x-default">Enable express checkout on PDP page</display-name>
                 <type>boolean</type>
                 <mandatory-flag>false</mandatory-flag>
                 <externally-managed-flag>false</externally-managed-flag>
@@ -534,6 +541,13 @@
             </attribute-definition>
             <attribute-definition attribute-id="ApplePayExpress_Enabled">
                 <display-name xml:lang="x-default">Enable Apple Pay express checkout</display-name>
+                <type>boolean</type>
+                <mandatory-flag>false</mandatory-flag>
+                <externally-managed-flag>false</externally-managed-flag>
+                <default-value>true</default-value>
+            </attribute-definition>
+            <attribute-definition attribute-id="ApplePayExpress_Pdp_Enabled">
+                <display-name xml:lang="x-default">Enable Apple Pay express on product detail page</display-name>
                 <type>boolean</type>
                 <mandatory-flag>false</mandatory-flag>
                 <externally-managed-flag>false</externally-managed-flag>
@@ -709,8 +723,10 @@
                 <attribute attribute-id="AdyenGiving_backgroundUrl"/>
                 <attribute attribute-id="AdyenGiving_logoUrl"/>
                 <attribute attribute-id="ExpressPayments_enabled"/>
+                <attribute attribute-id="ExpressPayments_Pdp_enabled"/>
                 <attribute attribute-id="ExpressPayments_order"/>
                 <attribute attribute-id="ApplePayExpress_Enabled"/>
+                <attribute attribute-id="ApplePayExpress_Pdp_Enabled"/>
                 <attribute attribute-id="AmazonPayExpress_Enabled"/>
                 <attribute attribute-id="PayPalExpress_Enabled"/>
                 <attribute attribute-id="PayPalExpress_ReviewPage_Enabled"/>

--- a/src/cartridges/bm_adyen/cartridge/static/default/js/adyenSettings.js
+++ b/src/cartridges/bm_adyen/cartridge/static/default/js/adyenSettings.js
@@ -27,6 +27,16 @@ const expressPaymentMethods = [
   },
 ];
 
+const expressPaymentMethodsOnPdp = [
+  {
+    id: 'applepay',
+    name: 'ApplePayExpress_Pdp_Enabled',
+    text: 'Apple Pay',
+    icon: window.applePayIcon,
+    checked: window.isApplePayExpressOnPdpEnabled,
+  },
+];
+
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.querySelector('#settingsForm');
   const troubleshootingForm = document.querySelector('#troubleshootingForm');
@@ -69,6 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const params = 'resizable=yes,width=1000,height=500,left=100,top=100';
 
   const draggableList = document.getElementById('draggable-list');
+  const draggableListPdp = document.getElementById('draggable-list-pdp');
 
   let ruleCounter = 0;
   const installmentsResult = {};
@@ -137,8 +148,9 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function addExpressEventListeners() {
-    const draggables = document.querySelectorAll('.draggable');
-    const dragListItems = document.querySelectorAll('.draggable-list li');
+    // Targeting only cart/mini-cart list as PDP doesn't need a swapping logic for the moment
+    const draggables = draggableList.querySelectorAll('.draggable');
+    const dragListItems = draggableList.querySelectorAll('.draggable-list li');
 
     draggables.forEach((draggable) => {
       draggable.addEventListener('dragstart', dragStart);
@@ -152,15 +164,19 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  function createExpressPaymentsComponent() {
+  function createExpressPaymentsComponent(
+    paymentMethodsArray,
+    draggableListContainer,
+  ) {
     const { expressMethodsOrder } = window;
     if (expressMethodsOrder) {
       const sortOrder = expressMethodsOrder.split(',');
-      expressPaymentMethods.sort(
+      paymentMethodsArray.sort(
         (a, b) => sortOrder.indexOf(a.id) - sortOrder.indexOf(b.id),
       );
     }
-    expressPaymentMethods.forEach((item, index) => {
+
+    paymentMethodsArray.forEach((item, index) => {
       const listItem = document.createElement('li');
       listItem.setAttribute('data-index', index.toString());
 
@@ -210,8 +226,7 @@ document.addEventListener('DOMContentLoaded', () => {
       `;
 
       listItems.push(listItem);
-
-      draggableList.appendChild(listItem);
+      draggableListContainer.appendChild(listItem);
     });
 
     addExpressEventListeners();
@@ -631,5 +646,6 @@ document.addEventListener('DOMContentLoaded', () => {
     window.location.reload();
   });
 
-  createExpressPaymentsComponent();
+  createExpressPaymentsComponent(expressPaymentMethods, draggableList);
+  createExpressPaymentsComponent(expressPaymentMethodsOnPdp, draggableListPdp);
 });

--- a/src/cartridges/bm_adyen/cartridge/templates/default/adyenSettings/settingCards/epmSettings.isml
+++ b/src/cartridges/bm_adyen/cartridge/templates/default/adyenSettings/settingCards/epmSettings.isml
@@ -7,6 +7,7 @@
     window.paypalIcon = "${URLUtils.staticURL('icons/paypal.svg')}";
 
     window.isApplePayEnabled = ${AdyenConfigs.isApplePayExpressEnabled() || false};
+    window.isApplePayExpressOnPdpEnabled = ${AdyenConfigs.isApplePayExpressOnPdpEnabled() || false};
     window.isAmazonPayEnabled = ${AdyenConfigs.isAmazonPayExpressEnabled() || false};
     window.isPayPalExpressEnabled = ${AdyenConfigs.isPayPalExpressEnabled() || false};
     window.isPayPalExpressReviewPageEnabled = ${AdyenConfigs.isPayPalExpressReviewPageEnabled() || false};
@@ -31,12 +32,28 @@
                   </div>
                </div>
             </div>
-            <label class="form-title mb-0" for="expressCheckoutHelp">Buttons display</label>
-            <small class="form-text mb-1">Customize the order that you would like to place the express buttons in the checkout.</small>
+            <label class="form-title mb-0" for="expressCheckoutHelp">Buttons display on cart and mini-cart page</label>
+            <small class="form-text mb-1">Customize the order that you would like to place the express buttons in the cart and mini-cart.</small>
          </div>
          <div class="express-settings collapse ${AdyenConfigs.areExpressPaymentsEnabled() ? 'show': ''}">
             <div class="form-group">
                 <ul class="draggable-list" id="draggable-list"></ul>
+            </div>
+         </div>
+         <div class="form-group">
+            <div class="row">
+               <div class="switch-button">
+                  <div class="form-check form-switch">
+                     <input class="form-check-input" type="checkbox" name="ExpressPayments_Pdp_enabled" id="expressPaymentsEnabledPdpChecked" data-bs-toggle="collapse" data-bs-target=".express-settings-pdp" ${AdyenConfigs.arePdpExpressPaymentsEnabled() ? 'checked': 'unchecked'}>
+                  </div>
+               </div>
+            </div>
+            <label class="form-title mb-0" for="expressCheckoutHelp">Buttons display on product detail page</label>
+            <small class="form-text mb-1">Customize the order that you would like to place the express buttons in the product detail page.</small>
+         </div>
+         <div class="express-settings-pdp collapse ${AdyenConfigs.arePdpExpressPaymentsEnabled() ? 'show': ''}">
+            <div class="form-group">
+                <ul class="draggable-list" id="draggable-list-pdp"></ul>
             </div>
          </div>
       </div>

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenConfigs.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenConfigs.js
@@ -135,8 +135,16 @@ const adyenConfigsObj = {
     return getCustomPreference('ExpressPayments_enabled');
   },
 
+  arePdpExpressPaymentsEnabled() {
+    return getCustomPreference('ExpressPayments_Pdp_enabled');
+  },
+
   isApplePayExpressEnabled() {
     return getCustomPreference('ApplePayExpress_Enabled');
+  },
+
+  isApplePayExpressOnPdpEnabled() {
+    return getCustomPreference('ApplePayExpress_Pdp_Enabled');
   },
 
   isAmazonPayExpressEnabled() {


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Enabling Apple Pay Express on Product Detail page.
- What existing problem does this pull request solve?
It implements the configuration on BM manager to enable/disable apple pay express in PDP, which can be later extended to other payment methods.


## Tested scenarios
Description of tested scenarios:
- Enable/disable the metadata fields responsible for the toggle

**Fixed issue**:  SFI-829
