### PR TITLE
Removing the end of line logic from domain association

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
@@ -199,9 +199,8 @@ function getGiftCardConfig() {
         async: false,
         success: (data) => {
           giftcardBalance = data.balance;
-          document.querySelector(
-            'button[value="submit-payment"]',
-          ).disabled = false;
+          document.querySelector('button[value="submit-payment"]').disabled =
+            false;
           if (data.resultCode === constants.SUCCESS) {
             const {
               giftCardsInfoMessageContainer,
@@ -227,9 +226,8 @@ function getGiftCardConfig() {
                 initialPartialObject.totalDiscountedAmount;
             });
 
-            document.querySelector(
-              'button[value="submit-payment"]',
-            ).disabled = true;
+            document.querySelector('button[value="submit-payment"]').disabled =
+              true;
             giftCardsInfoMessageContainer.innerHTML = '';
             giftCardsInfoMessageContainer.classList.remove(
               'gift-cards-info-message-container',

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGiftcardComponent.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGiftcardComponent.js
@@ -96,9 +96,8 @@ function removeGiftCards() {
         giftCardsInfoMessageContainer.classList.remove(
           'gift-cards-info-message-container',
         );
-        document.querySelector(
-          'button[value="submit-payment"]',
-        ).disabled = false;
+        document.querySelector('button[value="submit-payment"]').disabled =
+          false;
 
         if (res.resultCode === constants.RECEIVED) {
           document

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/RedirectURL.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/RedirectURL.js
@@ -12,7 +12,7 @@ server.prepend('Start', (req, res, next) => {
     const applePayDomainAssociation =
       AdyenConfigs.getApplePayDomainAssociation();
     res.setHttpHeader(dw.system.Response.CONTENT_TYPE, 'text/plain');
-    response.getWriter().println(applePayDomainAssociation);
+    response.getWriter().print(applePayDomainAssociation);
     return null;
   }
   return next();


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
The changes that were done to Apple Pay domain association file on 16th of May.
- What existing problem does this pull request solve?
It replaces `println` to `print` as the new domain association file doesn't have an /n at end.


## Tested scenarios
Description of tested scenarios:

**Fixed issue**:  SFI-875
