### PR TITLE
Pass correct payment instrument to the payments request

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/hooks/payment/processor/middlewares/authorize.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/hooks/payment/processor/middlewares/authorize.js
@@ -40,7 +40,6 @@ function authorize(order, paymentInstrument, paymentProcessor) {
   Transaction.begin();
   const result = adyenCheckout.createPaymentRequest({
     Order: order,
-    PaymentInstrument: paymentInstrument,
   });
   if (result.error) {
     return errorHandler();

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/__tests__/adyenCheckout.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/__tests__/adyenCheckout.test.js
@@ -11,22 +11,22 @@ describe('AdyenCheckout', () => {
                 getOrderNo: jest.fn(),
                 getOrderToken: jest.fn(),
                 getCustomerEmail: jest.fn(),
-            },
-            PaymentInstrument: {
-                custom: {
-                    adyenPaymentData: "{}",
-                    adyenPartialPaymentsOrder:
-                        '{"orderData":"b4c0!BQABAgBzO7ZwfyxJ9ifN0NIgUsuwBdUWb==...",' +
-                        '"remainingAmount":{"currency":"EUR","value":20799},' +
-                        '"amount":{"currency":"EUR","value":1000}}'
+                paymentInstrument: {
+                    custom: {
+                        adyenPaymentData: "{}",
+                        adyenPartialPaymentsOrder:
+                          '{"orderData":"b4c0!BQABAgBzO7ZwfyxJ9ifN0NIgUsuwBdUWb==...",' +
+                          '"remainingAmount":{"currency":"EUR","value":20799},' +
+                          '"amount":{"currency":"EUR","value":1000}}'
 
-                },
-                paymentTransaction: {
-                    amount: {
-                        value: 1000,
-                        currencyCode: "EUR"
+                    },
+                    paymentTransaction: {
+                        amount: {
+                            value: 1000,
+                            currencyCode: "EUR"
+                        }
                     }
-                }
+                },
             },
         };
 
@@ -45,23 +45,23 @@ describe('AdyenCheckout', () => {
                 getOrderNo: jest.fn(),
                 getOrderToken: jest.fn(),
                 getCustomerEmail: jest.fn(),
-            },
-            PaymentInstrument: {
-                custom: {
-                    adyenPaymentData: "{}",
-                    adyenPartialPaymentsOrder:
-                        '{"orderData":"b4c0!BQABAgBzO7ZwfyxJ9ifN0NIgUsuwBdUWb==...",' +
-                        '"remainingAmount":{"currency":"EUR","value":20799},' +
-                        '"amount":{"currency":"EUR","value":25799}}'
+                paymentInstrument: {
+                    custom: {
+                        adyenPaymentData: "{}",
+                        adyenPartialPaymentsOrder:
+                          '{"orderData":"b4c0!BQABAgBzO7ZwfyxJ9ifN0NIgUsuwBdUWb==...",' +
+                          '"remainingAmount":{"currency":"EUR","value":20799},' +
+                          '"amount":{"currency":"EUR","value":25799}}'
 
-                },
-                paymentTransaction: {
-                    amount: {
-                        value: 1000,
-                        currencyCode: "EUR"
+                    },
+                    paymentTransaction: {
+                        amount: {
+                            value: 1000,
+                            currencyCode: "EUR"
+                        }
                     }
                 }
-            },
+            }
         };
 
         const response =  adyenCheckout.createPaymentRequest(args);
@@ -79,23 +79,23 @@ describe('AdyenCheckout', () => {
                 getOrderNo: jest.fn(),
                 getOrderToken: jest.fn(),
                 getCustomerEmail: jest.fn(),
-            },
-            PaymentInstrument: {
-                custom: {
-                    adyenPaymentData: "{}",
-                    adyenPartialPaymentsOrder:
-                        '{"orderData":"b4c0!BQABAgBzO7ZwfyxJ9ifN0NIgUsuwBdUWb==...",' +
-                        '"remainingAmount":{"currency":"USD","value":20799},' +
-                        '"amount":{"currency":"USD","value":1000}}'
+                paymentInstrument: {
+                    custom: {
+                        adyenPaymentData: "{}",
+                        adyenPartialPaymentsOrder:
+                          '{"orderData":"b4c0!BQABAgBzO7ZwfyxJ9ifN0NIgUsuwBdUWb==...",' +
+                          '"remainingAmount":{"currency":"USD","value":20799},' +
+                          '"amount":{"currency":"USD","value":1000}}'
 
-                },
-                paymentTransaction: {
-                    amount: {
-                        value: 1000,
-                        currencyCode: "EUR"
+                    },
+                    paymentTransaction: {
+                        amount: {
+                            value: 1000,
+                            currencyCode: "EUR"
+                        }
                     }
                 }
-            },
+            }
         };
 
         const response =  adyenCheckout.createPaymentRequest(args);

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/adyenCheckout.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/adyenCheckout.js
@@ -139,7 +139,7 @@ function doPaymentsCall(order, paymentInstrument, paymentRequest) {
 function createPaymentRequest(args) {
   try {
     const order = args.Order;
-    const paymentInstrument = args.PaymentInstrument;
+    const { paymentInstrument } = order;
 
     // Create request object with payment details
     let paymentRequest = AdyenHelper.createAdyenRequestObject(

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/adyenCheckout.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/adyenCheckout.js
@@ -140,6 +140,7 @@ function createPaymentRequest(args) {
   try {
     const order = args.Order;
     const { paymentInstrument } = order;
+    console.log(paymentInstrument);
 
     // Create request object with payment details
     let paymentRequest = AdyenHelper.createAdyenRequestObject(

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/adyenCheckout.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/adyenCheckout.js
@@ -140,7 +140,6 @@ function createPaymentRequest(args) {
   try {
     const order = args.Order;
     const { paymentInstrument } = order;
-    console.log(paymentInstrument);
 
     // Create request object with payment details
     let paymentRequest = AdyenHelper.createAdyenRequestObject(

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/paymentFromComponent.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/paymentFromComponent.js
@@ -218,7 +218,6 @@ function paymentFromComponent(req, res, next) {
   Transaction.wrap(() => {
     result = adyenCheckout.createPaymentRequest({
       Order: order,
-      PaymentInstrument: paymentInstrument,
     });
   });
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Pass order payment instrument instead of basket one
- What existing problem does this pull request solve?
Set properly the payments transaction type (capture/auth)

## Tested scenarios
Description of tested scenarios:
- Card payents
- Alternative payments 
- Zero auth
- Giftcards

**Fixed issue**:  SFI-811
