### PR TITLE
Bugfix/paypal tax gross

### DIFF
--- a/jest/__mocks__/dw/order/TaxMgr.js
+++ b/jest/__mocks__/dw/order/TaxMgr.js
@@ -1,2 +1,3 @@
 export const getTaxJurisdictionID = jest.fn();
 export const getTaxRate = jest.fn();
+export const TAX_POLICY_GROSS = 0;

--- a/jest/__mocks__/dw/value/Money.js
+++ b/jest/__mocks__/dw/value/Money.js
@@ -24,6 +24,9 @@ function Money(isAvailable) {
     addRate() {
       return new Money(isAvailable);
     },
+    subtractRate() {
+      return new Money(isAvailable);
+    },
   };
 }
 

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/checkoutConfiguration.js
@@ -199,8 +199,9 @@ function getGiftCardConfig() {
         async: false,
         success: (data) => {
           giftcardBalance = data.balance;
-          document.querySelector('button[value="submit-payment"]').disabled =
-            false;
+          document.querySelector(
+            'button[value="submit-payment"]',
+          ).disabled = false;
           if (data.resultCode === constants.SUCCESS) {
             const {
               giftCardsInfoMessageContainer,
@@ -226,8 +227,9 @@ function getGiftCardConfig() {
                 initialPartialObject.totalDiscountedAmount;
             });
 
-            document.querySelector('button[value="submit-payment"]').disabled =
-              true;
+            document.querySelector(
+              'button[value="submit-payment"]',
+            ).disabled = true;
             giftCardsInfoMessageContainer.innerHTML = '';
             giftCardsInfoMessageContainer.classList.remove(
               'gift-cards-info-message-container',

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGiftcardComponent.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGiftcardComponent.js
@@ -96,8 +96,9 @@ function removeGiftCards() {
         giftCardsInfoMessageContainer.classList.remove(
           'gift-cards-info-message-container',
         );
-        document.querySelector('button[value="submit-payment"]').disabled =
-          false;
+        document.querySelector(
+          'button[value="submit-payment"]',
+        ).disabled = false;
 
         if (res.resultCode === constants.RECEIVED) {
           document

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/paypal/makeExpressPaymentsCall.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/paypal/makeExpressPaymentsCall.js
@@ -25,7 +25,7 @@ function makeExpressPaymentsCall(req, res, next) {
       paymentInstrument.paymentTransaction.paymentProcessor = paymentProcessor;
       paymentInstrument.custom.adyenPaymentData = req.body;
     });
-    // creates order number to be utilized for PayPal express
+    // Creates order number to be utilized for PayPal express
     const paypalExpressOrderNo = OrderMgr.createOrderNo();
     // Create request object with payment details
     const paymentRequest = AdyenHelper.createAdyenRequestObject(
@@ -39,9 +39,12 @@ function makeExpressPaymentsCall(req, res, next) {
         paymentInstrument.paymentTransaction.amount,
       ).getValueOrNull(),
     };
-    paymentRequest.lineItems = paypalHelper.getLineItems({
-      Basket: currentBasket,
-    });
+    paymentRequest.lineItems = paypalHelper.getLineItems(
+      {
+        Basket: currentBasket,
+      },
+      true,
+    );
     let result;
     Transaction.wrap(() => {
       result = adyenCheckout.doPaymentsCall(

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
@@ -85,6 +85,7 @@ let adyenHelperObj = {
    * @returns {{currencyCode: String, value: String}} - Shipping Cost including taxes
    */
   getShippingCost(shippingMethod, shipment) {
+    const { shippingAddress } = shipment;
     const shipmentShippingModel = ShippingMgr.getShipmentShippingModel(shipment);
     let shippingCost = shipmentShippingModel.getShippingCost(shippingMethod).getAmount();
     collections.forEach(shipment.getProductLineItems(), (lineItem) => {
@@ -96,10 +97,23 @@ let adyenHelperObj = {
         : new Money(0, product.getPriceModel().getPrice().getCurrencyCode());
       shippingCost = shippingCost.add(productShippingCost);
     })
+    shippingCost = TaxMgr.taxationPolicy === TaxMgr.TAX_POLICY_GROSS ? shippingCost.subtractRate(adyenHelperObj.getShippingTaxRate(shippingMethod, shippingAddress)) : shippingCost;
     return {
       value: shippingCost.getValue(),
       currencyCode: shippingCost.getCurrencyCode(),
     };
+  },
+
+  /**
+   * Returns tax rate for specific Shipment / ShippingMethod pair.
+   * @param {dw.order.ShippingMethod} shippingMethod - the default shipment of the current basket
+   * @param {dw.order.shippingAddress} shippingAddress - shippingAddress for the default shipment
+   * @returns {Number} - tax rate in decimals.(eg.: 0.02 for 2%)
+   */
+  getShippingTaxRate(shippingMethod, shippingAddress) {
+    const taxClassID = shippingMethod.getTaxClassID();
+    const taxJurisdictionID = shippingAddress ? TaxMgr.getTaxJurisdictionID(new ShippingLocation(shippingAddress)) : TaxMgr.getDefaultTaxJurisdictionID();
+    return TaxMgr.getTaxRate(taxClassID, taxJurisdictionID);
   },
 
   /**


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
- Tax calculation for paypal express when site is gross
- What existing problem does this pull request solve?
- For gross site remove the shipping tax from shipping cost and pass tax as tax_total 


## Tested scenarios
Description of tested scenarios: paypal express flow for net and gross site.

**Fixed issue**:  #1155 #SFI-925
