### PR TITLE
fix problem with payment method value in custom attribute

### DIFF
--- a/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
+++ b/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
@@ -578,8 +578,12 @@ var adyenHelperObj = {
       paymentInstrument.paymentTransaction.custom.Adyen_paymentMethod = result.additionalData.paymentMethod;
       order.custom.Adyen_paymentMethod = result.additionalData.paymentMethod;
     } else if (result.paymentMethod) {
-      paymentInstrument.paymentTransaction.custom.Adyen_paymentMethod = JSON.stringify(result.paymentMethod.type);
-      order.custom.Adyen_paymentMethod = JSON.stringify(result.paymentMethod.type);
+      var type = result.paymentMethod.type;
+      if (typeof type === 'object') {
+        type = JSON.stringify(result.paymentMethod.type);
+      }
+      paymentInstrument.paymentTransaction.custom.Adyen_paymentMethod = type;
+      order.custom.Adyen_paymentMethod = type;
     }
 
     // For authenticated shoppers we are setting the token on other place already


### PR DESCRIPTION
## Summary
I check if the value is an object before using JSON.stringify. The issue arises because result.paymentMethod.type is a string, and after converting it with JSON.stringify, the value becomes "paypal", which breaks the OMS and ERP systems.
<img width="1057" alt="image" src="https://github.com/user-attachments/assets/ffd5161e-cc58-476f-abd4-1be688d000b0">



## Tested scenarios
Description of tested scenarios:

**Fixed issue**:  <!-- #-prefixed issue number -->
