### PR TITLE
Adding the C2P shopperEmail upon initial rendering

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyenCheckout.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyenCheckout.js
@@ -45,6 +45,14 @@ if (
   ] = window.googleMerchantID;
 }
 
+$('body').on('checkout:updateCheckoutView', (event, data) => {
+  if (data.order.orderEmail) {
+    const { clickToPayConfiguration } =
+      store.checkoutConfiguration.paymentMethodsConfiguration.card;
+    clickToPayConfiguration.shopperEmail = data.order.orderEmail;
+  }
+});
+
 // Submit the payment
 $('button[value="submit-payment"]').on('click', () => {
   if (store.paypalTerminatedEarly) {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
C2P not triggering upon initial rendering of the card component.
- What existing problem does this pull request solve?
Initializes the card component with the shopper email from the SFRA form in case of C2P

## Tested scenarios
Description of tested scenarios:

**Fixed issue**:  SFI-975
