### PR TITLE
Redirect to confirmation page for POS

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGenericComponent.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGenericComponent.js
@@ -275,6 +275,7 @@ export async function initializeCheckout() {
 
   if (paymentMethodsResponse.adyenConnectedTerminals) {
     renderPosTerminals(paymentMethodsResponse.adyenConnectedTerminals);
+    document.querySelector('button[value="submit-payment"]').disabled = false;
   }
 
   helpers.createShowConfirmationForm(

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGenericComponent.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGenericComponent.js
@@ -263,8 +263,6 @@ export async function initializeCheckout() {
     paymentMethodsResponse.adyenDescriptions,
   );
 
-  renderPosTerminals(paymentMethodsResponse.adyenConnectedTerminals);
-
   renderGiftCardLogo(paymentMethodsResponse.imagePath);
 
   const firstPaymentMethod = document.querySelector(
@@ -273,6 +271,10 @@ export async function initializeCheckout() {
   if (firstPaymentMethod) {
     firstPaymentMethod.checked = true;
     helpers.displaySelectedMethod(firstPaymentMethod.value);
+  }
+
+  if (paymentMethodsResponse.adyenConnectedTerminals) {
+    renderPosTerminals(paymentMethodsResponse.adyenConnectedTerminals);
   }
 
   helpers.createShowConfirmationForm(

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/placeOrder.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/placeOrder.js
@@ -143,11 +143,11 @@ function placeOrder(req, res, next) {
     // Handles payment authorization
     var handlePaymentResult = adyenHelpers.handlePayments(order);
 
-    const mainPaymentInstrument = order.getPaymentInstruments(
-      AdyenHelper.getOrderMainPaymentInstrumentType(order)
-    )[0];
-
+	let mainPaymentInstrument;
     if (giftCardsAdded) {
+		mainPaymentInstrument = order.getPaymentInstruments(
+			AdyenHelper.getOrderMainPaymentInstrumentType(order)
+		  )[0];
         giftCardsAdded.forEach((giftCard) => {
             const divideBy = AdyenHelper.getDivisorForCurrency(mainPaymentInstrument.paymentTransaction.getAmount());
             const amount = {

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/placeOrder.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/placeOrder.js
@@ -143,11 +143,11 @@ function placeOrder(req, res, next) {
     // Handles payment authorization
     var handlePaymentResult = adyenHelpers.handlePayments(order);
 
-	let mainPaymentInstrument;
+    let mainPaymentInstrument;
     if (giftCardsAdded) {
-		mainPaymentInstrument = order.getPaymentInstruments(
-			AdyenHelper.getOrderMainPaymentInstrumentType(order)
-		  )[0];
+	mainPaymentInstrument = order.getPaymentInstruments(
+	    AdyenHelper.getOrderMainPaymentInstrumentType(order)
+	)[0];
         giftCardsAdded.forEach((giftCard) => {
             const divideBy = AdyenHelper.getDivisorForCurrency(mainPaymentInstrument.paymentTransaction.getAmount());
             const amount = {


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Rendering to confirmation page upon successful response from terminal API and making place order button clickable for POS payments.
- What existing problem does this pull request solve?
Shows confirmation page for successful order / error page for not successful orders. It also enables the place order button.

## Tested scenarios
Description of tested scenarios:
- Successful transactions
- Failure transactions

**Fixed issue**: SFI-845, SFI-846
