### PR TITLE
Potential Partial Payment Exploit Fix

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGiftcardComponent.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGiftcardComponent.js
@@ -52,63 +52,62 @@ function showGiftCardCancelButton(show) {
 }
 
 function removeGiftCards() {
-  store.addedGiftCards?.forEach((card) => {
+  if (store.addedGiftCards) {
     $.ajax({
-      type: 'POST',
-      url: window.cancelPartialPaymentOrderUrl,
-      data: JSON.stringify(card),
-      contentType: 'application/json; charset=utf-8',
-      async: false,
-      success(res) {
-        const adyenPartialPaymentsOrder = document.querySelector(
-          '#adyenPartialPaymentsOrder',
-        );
-
-        const {
-          giftCardsList,
-          giftCardAddButton,
-          giftCardSelect,
-          giftCardUl,
-          giftCardsInfoMessageContainer,
-          giftCardSelectContainer,
-          cancelMainPaymentGiftCard,
-          giftCardInformation,
-        } = getGiftCardElements();
-
-        adyenPartialPaymentsOrder.value = null;
-        giftCardsList.innerHTML = '';
-        giftCardAddButton.style.display = 'block';
-        giftCardSelect.value = null;
-        giftCardSelectContainer.classList.add('invisible');
-        giftCardSelect.classList.remove('invisible');
-        giftCardUl.innerHTML = '';
-
-        cancelMainPaymentGiftCard.classList.add('invisible');
-        showGiftCardCancelButton(false);
-        giftCardInformation?.remove();
-
-        store.checkout.options.amount = res.amount;
-        store.partialPaymentsOrderObj = null;
-        store.addedGiftCards = null;
-        store.adyenOrderData = null;
-
-        giftCardsInfoMessageContainer.innerHTML = '';
-        giftCardsInfoMessageContainer.classList.remove(
-          'gift-cards-info-message-container',
-        );
-        document.querySelector('button[value="submit-payment"]').disabled =
-          false;
-
-        if (res.resultCode === constants.RECEIVED) {
-          document
-            .querySelector('#cancelGiftCardContainer')
-            ?.parentNode.remove();
-          store.componentsObj?.giftcard?.node.unmount('component_giftcard');
-        }
-        initializeCheckout();
-      },
+        type: 'POST',
+        url: window.cancelPartialPaymentOrderUrl,
+        contentType: 'application/json; charset=utf-8',
+        async: false,
+        success(res) {
+          const adyenPartialPaymentsOrder = document.querySelector(
+            '#adyenPartialPaymentsOrder',
+          );
+    
+          const {
+            giftCardsList,
+            giftCardAddButton,
+            giftCardSelect,
+            giftCardUl,
+            giftCardsInfoMessageContainer,
+            giftCardSelectContainer,
+            cancelMainPaymentGiftCard,
+            giftCardInformation,
+          } = getGiftCardElements();
+    
+          adyenPartialPaymentsOrder.value = null;
+          giftCardsList.innerHTML = '';
+          giftCardAddButton.style.display = 'block';
+          giftCardSelect.value = null;
+          giftCardSelectContainer.classList.add('invisible');
+          giftCardSelect.classList.remove('invisible');
+          giftCardUl.innerHTML = '';
+    
+          cancelMainPaymentGiftCard.classList.add('invisible');
+          showGiftCardCancelButton(false);
+          giftCardInformation?.remove();
+    
+          store.checkout.options.amount = res.amount;
+          store.partialPaymentsOrderObj = null;
+          store.addedGiftCards = null;
+          store.adyenOrderData = null;
+    
+          giftCardsInfoMessageContainer.innerHTML = '';
+          giftCardsInfoMessageContainer.classList.remove(
+            'gift-cards-info-message-container',
+          );
+          document.querySelector('button[value="submit-payment"]').disabled =
+            false;
+    
+          if (res.resultCode === constants.RECEIVED) {
+            document
+              .querySelector('#cancelGiftCardContainer')
+              ?.parentNode.remove();
+            store.componentsObj?.giftcard?.node.unmount('component_giftcard');
+          }
+          initializeCheckout();
+        },
     });
-  });
+  }
 }
 
 function giftCardBrands() {

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/partialPayments/cancelPartialPaymentOrder.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/partialPayments/cancelPartialPaymentOrder.js
@@ -12,12 +12,17 @@ const clearForms = require('*/cartridge/adyen/utils/clearForms');
 function cancelPartialPaymentOrder(req, res, next) {
   try {
     const currentBasket = BasketMgr.getCurrentBasket();
-    const request = JSON.parse(req.body);
-    const { partialPaymentsOrder } = request;
+
+    const partialPaymentData = JSON.parse(session.privacy.partialPaymentData);
+    if (!partialPaymentData) {
+        throw new Error(
+            `No partial payment data stored in session, possible bad actor attempt to refund card`
+        );
+    }
 
     const cancelOrderRequest = {
       merchantAccount: AdyenConfigs.getAdyenMerchantAccount(),
-      order: partialPaymentsOrder,
+      order: partialPaymentData.order,
     };
 
     const response =


### PR DESCRIPTION
## Summary
A partial payment gift card used in an order can be refunded by a bad actor after the order has been placed. I implemented this fix for a client (though their Adyen code is highly customized, and I have not tested the fix with vanilla Adyen cartridge code).

Due to the sensitive nature of this issue, for reproduction steps, please contact me directly via the unofficial SFCC slack, or via email davidlinke[at]davidlinke.com.