### PR TITLE
Intermediate result codes

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/templates/default/checkout/confirmation/confirmation.isml
+++ b/src/cartridges/app_adyen_SFRA/cartridge/templates/default/checkout/confirmation/confirmation.isml
@@ -1,0 +1,57 @@
+<isset name="AdyenHelper" value="${require('*/cartridge/adyen/utils/adyenHelper')}" scope="pdict"/>
+
+<isdecorate template="common/layout/page">
+    <isscript>
+        var assets = require('*/cartridge/scripts/assets.js');
+        assets.addCss('/css/checkout/checkout.css');
+        assets.addJs('/js/checkoutRegistration.js');
+    </isscript>
+
+    <isif condition="${pdict.reportingURLs && pdict.reportingURLs.length}">
+        <isinclude template="reporting/reportingUrls"/>
+    </isif>
+
+    <div class="hero slant-down hero-confirmation">
+        <h1 class="page-title">${Resource.msg('title.thank.you.page', 'confirmation', null)}</h1>
+    </div>
+
+    <div class="container receipt 
+        <isif condition="${pdict.order.shipping.length > 1}">multi-ship</isif>">
+        <div class="row">
+            <div class="${pdict.returningCustomer ? 'col-sm-6 offset-sm-3' : 'col-sm-6 offset-sm-3 offset-md-0'}">
+                <h2 class="order-thank-you-msg">
+				<!-- This is a hardcoded message for INTERMEDIATE result codes. For non-English locales, consider adding it to a properties file to ensure proper localization -->
+                    <isif condition="${pdict.AdyenHelper.isIntermediateResultCode(pdict.order.orderNumber)}">
+                        Your payment is being processed. We will notify you via an email once it's confirmed. You can close this page now.
+                    <iselse>
+                        ${Resource.msg('msg.placed.order.thank.you', 'confirmation', null)}
+                    </iselse>
+                    </isif>
+                </h2>
+
+                <isif condition="${pdict.order.orderEmail}">
+                    <p class="order-thank-you-email-msg">
+                        <isprint value="${Resource.msgf('info.receive.email.confirmation', 'confirmation', null, pdict.order.orderEmail)}" encoding="htmlcontent"/>
+                    </p>
+                </isif>
+            </div>
+        </div>
+
+        <div class="row">
+            <isif condition="${pdict.returningCustomer === false && pdict.order.orderEmail}">
+                <div class="col-sm-6 offset-sm-3 offset-md-0 push-md-6">
+                    <isinclude template="checkout/confirmation/confirmationCreateAccount"/>
+                </div>
+            </isif>
+
+            <div class="${pdict.returningCustomer ? 'col-sm-6 offset-sm-3' : 'col-sm-6 offset-sm-3 offset-md-0 pull-md-6'}">
+                <isinclude template="checkout/confirmation/confirmationDetails"/>
+                <div class="mb-3">
+                    <a href="${URLUtils.url('Home-Show')}" class="btn btn-primary btn-block order-confirmation-continue-shopping" role="button" aria-pressed="true">
+                        ${Resource.msg('button.continue.shopping', 'confirmation', null)}
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</isdecorate>

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
@@ -32,6 +32,7 @@ const Money = require('dw/value/Money');
 const TaxMgr = require('dw/order/TaxMgr');
 const ShippingLocation = require('dw/order/ShippingLocation');
 const BasketMgr = require('dw/order/BasketMgr');
+const OrderMgr = require('dw/order/OrderMgr');
 //script includes
 const ShippingMethodModel = require('*/cartridge/models/shipping/shippingMethod');
 const collections = require('*/cartridge/scripts/util/collections');
@@ -915,6 +916,17 @@ let adyenHelperObj = {
       });
     }
   },
+
+  isIntermediateResultCode(orderNo) {
+    const order = OrderMgr.getOrder(orderNo);
+    const paymentInstrument = order.getPaymentInstruments(
+        adyenHelperObj.getOrderMainPaymentInstrumentType(order),
+    )[0];
+    const resultCode = paymentInstrument.paymentTransaction.custom.authCode;
+	AdyenLogs.fatal_log(`result code ${resultCode}`);
+    
+    return resultCode === constants.RESULTCODES.PENDING || resultCode === constants.RESULTCODES.RECEIVED;
+},
 
   executeCall(serviceType, requestObject) {
     const service = this.getService(serviceType);

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
@@ -922,9 +922,7 @@ let adyenHelperObj = {
     const paymentInstrument = order.getPaymentInstruments(
         adyenHelperObj.getOrderMainPaymentInstrumentType(order),
     )[0];
-    const resultCode = paymentInstrument.paymentTransaction.custom.authCode;
-	AdyenLogs.fatal_log(`result code ${resultCode}`);
-    
+    const resultCode = paymentInstrument.paymentTransaction.custom.authCode;    
     return resultCode === constants.RESULTCODES.PENDING || resultCode === constants.RESULTCODES.RECEIVED;
 },
 


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Intermediate result codes should have a meaningful confirmation page, stating that an email will confirm the order.
- What existing problem does this pull request solve?
The inconsistency between final result codes and intermediate result codes in confirmation page.

## Tested scenarios
Description of tested scenarios:
- Intermediate result codes
- Final result codes

**Fixed issue**:  SFI-1066
