### PR TITLE
Removing PAYMENT_STATUS_PAID after payment response

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/adyenCheckout.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/adyenCheckout.js
@@ -100,12 +100,6 @@ function doPaymentsCall(order, paymentInstrument, paymentRequest) {
     // Check the response object from /payment call
     if (acceptedResultCodes.indexOf(resultCode) !== -1) {
       paymentResponse.decision = 'ACCEPT';
-      // if 3D Secure is used, the statuses will be updated later
-      if (resultCode === constants.RESULTCODES.AUTHORISED) {
-        order.setPaymentStatus(Order.PAYMENT_STATUS_PAID);
-        order.setExportStatus(Order.EXPORT_STATUS_READY);
-        AdyenLogs.info_log('Payment result: Authorised');
-      }
     } else if (presentToShopperResultCodes.indexOf(resultCode) !== -1) {
       paymentResponse.decision = 'ACCEPT';
       if (responseObject.action) {


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
It's a follow-up of #1255 . A part of code is removed to allow orders ( non-3ds payments ) to flow to OMS.
- What existing problem does this pull request solve?
Orders not passing to OMS

## Tested scenarios
Description of tested scenarios:
- No 3DS cards
- 3DS cards
- iDeal

**Fixed issue**:  SFI-1129
