### PR TITLE
set isExpressPdp for all pdp payment methods on root instead separately

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/googlePayExpress.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/googlePayExpress.js
@@ -259,8 +259,7 @@ async function onShippingOptionChange(shippingAddress, shippingOptionData) {
   };
 }
 
-async function init(paymentMethodsResponse, isExpressPdp) {
-  window.isExpressPdp = isExpressPdp;
+async function init(paymentMethodsResponse) {
   initializeCheckout(paymentMethodsResponse)
     .then(async () => {
       const googlePayPaymentMethod =

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/product/expressPayments.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/product/expressPayments.js
@@ -45,11 +45,11 @@ function getExpressPaymentButtons(product) {
 }
 
 function renderApplePayButton(paymentMethods) {
-  applePayExpressModule.init(paymentMethods, true);
+  applePayExpressModule.init(paymentMethods);
 }
 
 function renderGooglePayButton(paymentMethods) {
-  googlePayExpressModule.init(paymentMethods, true);
+  googlePayExpressModule.init(paymentMethods);
 }
 
 function renderExpressPaymentButtons() {
@@ -69,6 +69,7 @@ function renderExpressPaymentButtons() {
         ...expressPaymentButtons,
         $productForm,
       );
+      window.isExpressPdp = true;
       renderApplePayButton(paymentMethods);
       renderGooglePayButton(paymentMethods);
     } else {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
One variable for all payment methods
- What existing problem does this pull request solve?
Keep clean init functions instead of conditional

## Tested scenarios
Description of tested scenarios:
- Google Pay PDP
- Apple Pay PDP

