### PR TITLE
PayPal handle cancellations

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/__tests__/checkoutConfiguration.test.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/__tests__/checkoutConfiguration.test.js
@@ -108,17 +108,6 @@ describe('Checkout Configuration', () => {
       );
     });
 
-    it('handles onCancel', () => {
-      document.body.innerHTML = `
-        <div id="merchantReference"></div>
-        <div id="adyenPaymentMethodName"></div>
-        <div id="orderToken"></div>
-      `;
-      store.paypalTerminatedEarly = true;    
-      paypal.onCancel({}, {});
-      expect(store.paypalTerminatedEarly).toBe(false);
-    });
-
     it('handles onError', () => {
       document.body.innerHTML = `
         <div id="showConfirmationForm"></div>
@@ -260,6 +249,7 @@ describe('Checkout Configuration', () => {
       document.body.innerHTML = `
         <div id="lb_cashapp">CashApp</div>
         <div id="adyenPaymentMethodName"></div>
+        <button value="submit-payment"></button>
       `;
       store.selectedMethod = 'cashapp';
       store.componentsObj = { cashapp: { stateData: { foo: 'bar' } } };

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/paymentMethodsConfiguration/paypal/paypalConfig.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/paymentMethodsConfiguration/paypal/paypalConfig.js
@@ -15,9 +15,9 @@ class PaypalConfig {
     this.helpers.paymentFromComponent(state.data, component);
   };
 
-  onCancel = async (data, component) => {
+  onCancel = (data, component) => {
     this.store.paypalTerminatedEarly = false;
-    await this.helpers.paymentFromComponent(
+    this.helpers.paymentFromComponent(
       {
         cancelTransaction: true,
         merchantReference: document.querySelector('#merchantReference').value,
@@ -27,9 +27,19 @@ class PaypalConfig {
     );
   };
 
-  onError = async (error, component) => {
-    await this.onCancel(component);
-    component.setStatus('ready');
+  onError = (error, component) => {
+    this.store.paypalTerminatedEarly = false;
+    this.helpers.paymentFromComponent(
+      {
+        cancelTransaction: true,
+        merchantReference: document.querySelector('#merchantReference').value,
+        orderToken: document.querySelector('#orderToken').value,
+      },
+      component,
+    );
+    if (component) {
+      component.setStatus('ready');
+    }
     document.querySelector('#showConfirmationForm').submit();
   };
 

--- a/src/cartridges/app_adyen_SFRA/cartridge/templates/default/adyen/adyenExpressMetadata.isml
+++ b/src/cartridges/app_adyen_SFRA/cartridge/templates/default/adyen/adyenExpressMetadata.isml
@@ -1,3 +1,8 @@
+<isset name="AdyenHelper" value="${require('*/cartridge/adyen/utils/adyenHelper')}" scope="pdict"/>
+<isset name="AdyenConfigs" value="${require('*/cartridge/adyen/utils/adyenConfigs')}" scope="page" />
+<script src="${pdict.AdyenHelper.getCheckoutUrl()}" type="text/javascript"></script>
+<link rel="stylesheet" type="text/css" href="${pdict.AdyenHelper.getCheckoutCSS()}"/>
+<link rel="stylesheet" href="${URLUtils.staticURL('/css/adyenCss.css')}" />
 <script type="text/javascript">
    window.environment = "${AdyenConfigs.getAdyenEnvironment()}";
    window.clientKey = "${AdyenConfigs.getAdyenClientKey()}",

--- a/src/cartridges/app_adyen_SFRA/cartridge/templates/default/adyen/adyenExpressMetadata.isml
+++ b/src/cartridges/app_adyen_SFRA/cartridge/templates/default/adyen/adyenExpressMetadata.isml
@@ -1,11 +1,9 @@
-<isset name="AdyenHelper" value="${require('*/cartridge/adyen/utils/adyenHelper')}" scope="pdict"/>
-<isset name="AdyenConfigs" value="${require('*/cartridge/adyen/utils/adyenConfigs')}" scope="pdict" />
-<script src="${AdyenHelper.getCheckoutUrl()}" type="text/javascript"></script>
-<link rel="stylesheet" type="text/css" href="${AdyenHelper.getCheckoutCSS()}"/>
+<script src="${pdict.AdyenHelper.getCheckoutUrl()}" type="text/javascript"></script>
+<link rel="stylesheet" type="text/css" href="${pdict.AdyenHelper.getCheckoutCSS()}"/>
 <link rel="stylesheet" href="${URLUtils.staticURL('/css/adyenCss.css')}" />
 <script type="text/javascript">
-   window.environment = "${AdyenConfigs.getAdyenEnvironment()}";
-   window.clientKey = "${AdyenConfigs.getAdyenClientKey()}",
+   window.environment = "${pdict.AdyenConfigs.getAdyenEnvironment()}";
+   window.clientKey = "${pdict.AdyenConfigs.getAdyenClientKey()}",
    window.locale = "${request.locale}";
    window.countryCode = window.locale.slice(-2);
 
@@ -17,22 +15,22 @@
    window.showConfirmationAction = "${URLUtils.https('Adyen-ShowConfirmationPaymentFromComponent')}";
    window.returnUrl = "${URLUtils.https('Cart-Show')}";
    window.createTemporaryBasketUrl = "${URLUtils.https('Adyen-CreateTemporaryBasket')}";
-   window.fractionDigits = "${AdyenHelper.getFractionDigits()}"
+   window.fractionDigits = "${pdict.AdyenHelper.getFractionDigits()}"
 
-   window.expressMethodsOrder = "${AdyenConfigs.getExpressPaymentsOrder()}";
-   window.isApplePayExpressEnabled = "${AdyenConfigs.isApplePayExpressEnabled()}";
-   window.isApplePayExpressOnPdpEnabled = "${AdyenConfigs.isApplePayExpressOnPdpEnabled()}";
-   window.isAmazonPayExpressEnabled = "${AdyenConfigs.isAmazonPayExpressEnabled()}";
-   window.isPayPalExpressEnabled = "${AdyenConfigs.isPayPalExpressEnabled()}";
-   window.isPayPalExpressReviewPageEnabled = "${AdyenConfigs.isPayPalExpressReviewPageEnabled()}";
-   window.isGooglePayExpressEnabled = "${AdyenConfigs.isGooglePayExpressEnabled()}";
-   window.isGooglePayExpressOnPdpEnabled = "${AdyenConfigs.isGooglePayExpressOnPdpEnabled()}";
+   window.expressMethodsOrder = "${pdict.AdyenConfigs.getExpressPaymentsOrder()}";
+   window.isApplePayExpressEnabled = "${pdict.AdyenConfigs.isApplePayExpressEnabled()}";
+   window.isApplePayExpressOnPdpEnabled = "${pdict.AdyenConfigs.isApplePayExpressOnPdpEnabled()}";
+   window.isAmazonPayExpressEnabled = "${pdict.AdyenConfigs.isAmazonPayExpressEnabled()}";
+   window.isPayPalExpressEnabled = "${pdict.AdyenConfigs.isPayPalExpressEnabled()}";
+   window.isPayPalExpressReviewPageEnabled = "${pdict.AdyenConfigs.isPayPalExpressReviewPageEnabled()}";
+   window.isGooglePayExpressEnabled = "${pdict.AdyenConfigs.isGooglePayExpressEnabled()}";
+   window.isGooglePayExpressOnPdpEnabled = "${pdict.AdyenConfigs.isGooglePayExpressOnPdpEnabled()}";
 
-   window.basketAmount = "${AdyenHelper.getBasketAmount()}".replace(/&quot;/g, '\"');
+   window.basketAmount = "${pdict.AdyenHelper.getBasketAmount()}".replace(/&quot;/g, '\"');
    window.makeExpressPaymentsCall = "${URLUtils.https('Adyen-MakeExpressPaymentsCall')}";
    window.makeExpressPaymentDetailsCall = "${URLUtils.https('Adyen-MakeExpressPaymentDetailsCall')}";
    window.saveShopperData = "${URLUtils.https('Adyen-SaveShopperData')}";
    window.paypalUpdateOrder = "${URLUtils.https('Adyen-paypalUpdateOrder')}";
-   window.paypalReviewPageEnabled = ${AdyenConfigs.isPayPalExpressReviewPageEnabled()};
+   window.paypalReviewPageEnabled = ${pdict.AdyenConfigs.isPayPalExpressReviewPageEnabled()};
    window.checkoutReview = "${URLUtils.https('Adyen-CheckoutReview')}";
 </script>

--- a/src/cartridges/app_adyen_SFRA/cartridge/templates/default/adyen/adyenExpressMetadata.isml
+++ b/src/cartridges/app_adyen_SFRA/cartridge/templates/default/adyen/adyenExpressMetadata.isml
@@ -1,9 +1,11 @@
-<script src="${pdict.AdyenHelper.getCheckoutUrl()}" type="text/javascript"></script>
-<link rel="stylesheet" type="text/css" href="${pdict.AdyenHelper.getCheckoutCSS()}"/>
-<link rel="stylesheet" href="${URLUtils.staticURL('/css/adyenCss.css')}" />
+<isset name="AdyenHelper" value="${require('*/cartridge/adyen/utils/adyenHelper')}" scope="page"/>
+<isset name="AdyenConfigs" value="${require('*/cartridge/adyen/utils/adyenConfigs')}" scope="page" />
+<script src="${AdyenHelper.getCheckoutUrl()}" type="text/javascript"></script>
+<link rel="stylesheet" type="text/css" href="${AdyenHelper.getCheckoutCSS()}"/>
+<link rel="stylesheet" type="text/css" href="${URLUtils.staticURL('/css/adyenCss.css')}" />
 <script type="text/javascript">
-   window.environment = "${pdict.AdyenConfigs.getAdyenEnvironment()}";
-   window.clientKey = "${pdict.AdyenConfigs.getAdyenClientKey()}",
+   window.environment = "${AdyenConfigs.getAdyenEnvironment()}";
+   window.clientKey = "${AdyenConfigs.getAdyenClientKey()}",
    window.locale = "${request.locale}";
    window.countryCode = window.locale.slice(-2);
 
@@ -15,22 +17,22 @@
    window.showConfirmationAction = "${URLUtils.https('Adyen-ShowConfirmationPaymentFromComponent')}";
    window.returnUrl = "${URLUtils.https('Cart-Show')}";
    window.createTemporaryBasketUrl = "${URLUtils.https('Adyen-CreateTemporaryBasket')}";
-   window.fractionDigits = "${pdict.AdyenHelper.getFractionDigits()}"
+   window.fractionDigits = "${AdyenHelper.getFractionDigits()}"
 
-   window.expressMethodsOrder = "${pdict.AdyenConfigs.getExpressPaymentsOrder()}";
-   window.isApplePayExpressEnabled = "${pdict.AdyenConfigs.isApplePayExpressEnabled()}";
-   window.isApplePayExpressOnPdpEnabled = "${pdict.AdyenConfigs.isApplePayExpressOnPdpEnabled()}";
-   window.isAmazonPayExpressEnabled = "${pdict.AdyenConfigs.isAmazonPayExpressEnabled()}";
-   window.isPayPalExpressEnabled = "${pdict.AdyenConfigs.isPayPalExpressEnabled()}";
-   window.isPayPalExpressReviewPageEnabled = "${pdict.AdyenConfigs.isPayPalExpressReviewPageEnabled()}";
-   window.isGooglePayExpressEnabled = "${pdict.AdyenConfigs.isGooglePayExpressEnabled()}";
-   window.isGooglePayExpressOnPdpEnabled = "${pdict.AdyenConfigs.isGooglePayExpressOnPdpEnabled()}";
+   window.expressMethodsOrder = "${AdyenConfigs.getExpressPaymentsOrder()}";
+   window.isApplePayExpressEnabled = "${AdyenConfigs.isApplePayExpressEnabled()}";
+   window.isApplePayExpressOnPdpEnabled = "${AdyenConfigs.isApplePayExpressOnPdpEnabled()}";
+   window.isAmazonPayExpressEnabled = "${AdyenConfigs.isAmazonPayExpressEnabled()}";
+   window.isPayPalExpressEnabled = "${AdyenConfigs.isPayPalExpressEnabled()}";
+   window.isPayPalExpressReviewPageEnabled = "${AdyenConfigs.isPayPalExpressReviewPageEnabled()}";
+   window.isGooglePayExpressEnabled = "${AdyenConfigs.isGooglePayExpressEnabled()}";
+   window.isGooglePayExpressOnPdpEnabled = "${AdyenConfigs.isGooglePayExpressOnPdpEnabled()}";
 
-   window.basketAmount = "${pdict.AdyenHelper.getBasketAmount()}".replace(/&quot;/g, '\"');
+   window.basketAmount = "${AdyenHelper.getBasketAmount()}".replace(/&quot;/g, '\"');
    window.makeExpressPaymentsCall = "${URLUtils.https('Adyen-MakeExpressPaymentsCall')}";
    window.makeExpressPaymentDetailsCall = "${URLUtils.https('Adyen-MakeExpressPaymentDetailsCall')}";
    window.saveShopperData = "${URLUtils.https('Adyen-SaveShopperData')}";
    window.paypalUpdateOrder = "${URLUtils.https('Adyen-paypalUpdateOrder')}";
-   window.paypalReviewPageEnabled = ${pdict.AdyenConfigs.isPayPalExpressReviewPageEnabled()};
+   window.paypalReviewPageEnabled = ${AdyenConfigs.isPayPalExpressReviewPageEnabled()};
    window.checkoutReview = "${URLUtils.https('Adyen-CheckoutReview')}";
 </script>

--- a/src/cartridges/app_adyen_SFRA/cartridge/templates/default/adyen/adyenExpressMetadata.isml
+++ b/src/cartridges/app_adyen_SFRA/cartridge/templates/default/adyen/adyenExpressMetadata.isml
@@ -1,4 +1,3 @@
-<isset name="AdyenHelper" value="${require('*/cartridge/adyen/utils/adyenHelper')}" scope="page"/>
 <isset name="AdyenConfigs" value="${require('*/cartridge/adyen/utils/adyenConfigs')}" scope="page" />
 <script src="${pdict.AdyenHelper.getCheckoutUrl()}" type="text/javascript"></script>
 <link rel="stylesheet" type="text/css" href="${pdict.AdyenHelper.getCheckoutCSS()}"/>
@@ -17,7 +16,7 @@
    window.showConfirmationAction = "${URLUtils.https('Adyen-ShowConfirmationPaymentFromComponent')}";
    window.returnUrl = "${URLUtils.https('Cart-Show')}";
    window.createTemporaryBasketUrl = "${URLUtils.https('Adyen-CreateTemporaryBasket')}";
-   window.fractionDigits = "${AdyenHelper.getFractionDigits()}"
+   window.fractionDigits = "${pdict.AdyenHelper.getFractionDigits()}"
 
    window.expressMethodsOrder = "${AdyenConfigs.getExpressPaymentsOrder()}";
    window.isApplePayExpressEnabled = "${AdyenConfigs.isApplePayExpressEnabled()}";
@@ -28,7 +27,7 @@
    window.isGooglePayExpressEnabled = "${AdyenConfigs.isGooglePayExpressEnabled()}";
    window.isGooglePayExpressOnPdpEnabled = "${AdyenConfigs.isGooglePayExpressOnPdpEnabled()}";
 
-   window.basketAmount = "${AdyenHelper.getBasketAmount()}".replace(/&quot;/g, '\"');
+   window.basketAmount = "${pdict.AdyenHelper.getBasketAmount()}".replace(/&quot;/g, '\"');
    window.makeExpressPaymentsCall = "${URLUtils.https('Adyen-MakeExpressPaymentsCall')}";
    window.makeExpressPaymentDetailsCall = "${URLUtils.https('Adyen-MakeExpressPaymentDetailsCall')}";
    window.saveShopperData = "${URLUtils.https('Adyen-SaveShopperData')}";

--- a/src/cartridges/app_adyen_SFRA/cartridge/templates/default/adyen/adyenExpressMetadata.isml
+++ b/src/cartridges/app_adyen_SFRA/cartridge/templates/default/adyen/adyenExpressMetadata.isml
@@ -1,4 +1,4 @@
-<isset name="AdyenHelper" value="${require('*/cartridge/adyen/utils/adyenHelper')}" scope="pdict"/>
+<isset name="AdyenHelper" value="${require('*/cartridge/adyen/utils/adyenHelper')}" scope="page"/>
 <isset name="AdyenConfigs" value="${require('*/cartridge/adyen/utils/adyenConfigs')}" scope="page" />
 <script src="${pdict.AdyenHelper.getCheckoutUrl()}" type="text/javascript"></script>
 <link rel="stylesheet" type="text/css" href="${pdict.AdyenHelper.getCheckoutCSS()}"/>

--- a/src/cartridges/app_adyen_SFRA/cartridge/templates/default/adyen/adyenExpressMetadata.isml
+++ b/src/cartridges/app_adyen_SFRA/cartridge/templates/default/adyen/adyenExpressMetadata.isml
@@ -1,6 +1,7 @@
-<isset name="AdyenConfigs" value="${require('*/cartridge/adyen/utils/adyenConfigs')}" scope="page" />
-<script src="${pdict.AdyenHelper.getCheckoutUrl()}" type="text/javascript"></script>
-<link rel="stylesheet" type="text/css" href="${pdict.AdyenHelper.getCheckoutCSS()}"/>
+<isset name="AdyenHelper" value="${require('*/cartridge/adyen/utils/adyenHelper')}" scope="pdict"/>
+<isset name="AdyenConfigs" value="${require('*/cartridge/adyen/utils/adyenConfigs')}" scope="pdict" />
+<script src="${AdyenHelper.getCheckoutUrl()}" type="text/javascript"></script>
+<link rel="stylesheet" type="text/css" href="${AdyenHelper.getCheckoutCSS()}"/>
 <link rel="stylesheet" href="${URLUtils.staticURL('/css/adyenCss.css')}" />
 <script type="text/javascript">
    window.environment = "${AdyenConfigs.getAdyenEnvironment()}";
@@ -16,7 +17,7 @@
    window.showConfirmationAction = "${URLUtils.https('Adyen-ShowConfirmationPaymentFromComponent')}";
    window.returnUrl = "${URLUtils.https('Cart-Show')}";
    window.createTemporaryBasketUrl = "${URLUtils.https('Adyen-CreateTemporaryBasket')}";
-   window.fractionDigits = "${pdict.AdyenHelper.getFractionDigits()}"
+   window.fractionDigits = "${AdyenHelper.getFractionDigits()}"
 
    window.expressMethodsOrder = "${AdyenConfigs.getExpressPaymentsOrder()}";
    window.isApplePayExpressEnabled = "${AdyenConfigs.isApplePayExpressEnabled()}";
@@ -27,7 +28,7 @@
    window.isGooglePayExpressEnabled = "${AdyenConfigs.isGooglePayExpressEnabled()}";
    window.isGooglePayExpressOnPdpEnabled = "${AdyenConfigs.isGooglePayExpressOnPdpEnabled()}";
 
-   window.basketAmount = "${pdict.AdyenHelper.getBasketAmount()}".replace(/&quot;/g, '\"');
+   window.basketAmount = "${AdyenHelper.getBasketAmount()}".replace(/&quot;/g, '\"');
    window.makeExpressPaymentsCall = "${URLUtils.https('Adyen-MakeExpressPaymentsCall')}";
    window.makeExpressPaymentDetailsCall = "${URLUtils.https('Adyen-MakeExpressPaymentDetailsCall')}";
    window.saveShopperData = "${URLUtils.https('Adyen-SaveShopperData')}";

--- a/src/cartridges/app_adyen_SFRA/cartridge/templates/default/cart/checkoutButtons.isml
+++ b/src/cartridges/app_adyen_SFRA/cartridge/templates/default/cart/checkoutButtons.isml
@@ -1,8 +1,3 @@
-<isset name="AdyenHelper" value="${require('*/cartridge/adyen/utils/adyenHelper')}" scope="pdict"/>
-<isset name="AdyenConfigs" value="${require('*/cartridge/adyen/utils/adyenConfigs')}" scope="page" />
-<script src="${pdict.AdyenHelper.getCheckoutUrl()}" type="text/javascript"></script>
-<link rel="stylesheet" type="text/css" href="${pdict.AdyenHelper.getCheckoutCSS()}"/>
-<link rel="stylesheet" href="${URLUtils.staticURL('/css/adyenCss.css')}" />
 <input type="hidden" id="adyen-token" name="${pdict.csrf.tokenName}" value="${pdict.csrf.token}"/>
 <isif condition="${request.getHttpQueryString() && request.getHttpQueryString().indexOf('amazonCheckoutSessionId') > -1} ">
     <script type="text/javascript">

--- a/src/cartridges/app_adyen_SFRA/cartridge/templates/default/product/components/addToCartButtonExtension.isml
+++ b/src/cartridges/app_adyen_SFRA/cartridge/templates/default/product/components/addToCartButtonExtension.isml
@@ -1,8 +1,3 @@
-<isset name="AdyenHelper" value="${require('*/cartridge/adyen/utils/adyenHelper')}" scope="pdict"/>
-<isset name="AdyenConfigs" value="${require('*/cartridge/adyen/utils/adyenConfigs')}" scope="page" />
-<script src="${pdict.AdyenHelper.getCheckoutUrl()}" type="text/javascript"></script>
-<link rel="stylesheet" type="text/css" href="${pdict.AdyenHelper.getCheckoutCSS()}"/>
-<link rel="stylesheet" href="${URLUtils.staticURL('/css/adyenCss.css')}" />
 <isinclude template="adyen/adyenExpressMetadata" />
 <input type="hidden" id="adyen-token" name="${pdict.csrf.tokenName}" value="${pdict.csrf.token}"/>
 <div id="express-payment-buttons"></div>


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Handle cancel as part of onError
- What existing problem does this pull request solve?
In the new web v6 cancellations are part of onError callback

## Tested scenarios
Description of tested scenarios:
- PayPal end of checkout

**Fixed issue**:  SFI-1101
