### PR TITLE
Removing payment status fields and improving api call trigger

### DIFF
--- a/src/cartridges/bm_adyen/cartridge/controllers/AdyenSettings.js
+++ b/src/cartridges/bm_adyen/cartridge/controllers/AdyenSettings.js
@@ -2,6 +2,7 @@ const server = require('server');
 const Transaction = require('dw/system/Transaction');
 const csrfProtection = require('dw/web/CSRFProtection');
 const URLUtils = require('dw/web/URLUtils');
+const PaymentMgr = require('dw/order/PaymentMgr');
 const AdyenConfigs = require('*/cartridge/adyen/utils/adyenConfigs');
 const AdyenHelper = require('*/cartridge/adyen/utils/adyenHelper');
 const constants = require('*/cartridge/adyen/config/constants');
@@ -87,16 +88,19 @@ server.post('TestConnection', server.middleware.https, (req, res, next) => {
 });
 
 server.get('GetStores', server.middleware.https, (req, res, next) => {
-  try {
-    bmHelper.saveMetadataField('Adyen_StoreId', []);
-    const stores = managementApi.fetchAllStores();
-    bmHelper.saveMetadataField('Adyen_StoreId', stores);
-    res.json({ success: true, stores });
-  } catch (error) {
-    AdyenLogs.error_log('Error while fetching stores:', error);
-    res.json({ success: false });
+  if (PaymentMgr.getPaymentMethod(constants.METHOD_ADYEN_POS).isActive()) {
+    try {
+      bmHelper.saveMetadataField('Adyen_StoreId', []);
+      const stores = managementApi.fetchAllStores();
+      bmHelper.saveMetadataField('Adyen_StoreId', stores);
+      res.json({ success: true, stores });
+    } catch (error) {
+      AdyenLogs.error_log('Error while fetching stores:', error);
+      res.json({ success: false });
+    }
+    return next();
   }
-  return next();
+  return {};
 });
 
 module.exports = server.exports();

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/pos/adyenTerminalApi.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/pos/adyenTerminalApi.js
@@ -167,10 +167,6 @@ function createTerminalPayment(order, paymentInstrument, terminalId) {
       }
       if (paymentResponse.result === constants.RESULTCODES.SUCCESS) {
         order.custom.Adyen_eventCode = constants.RESULTCODES.AUTHORISATION;
-        // Set payment status and export status
-        order.setPaymentStatus(Order.PAYMENT_STATUS_PAID);
-        order.setConfirmationStatus(Order.CONFIRMATION_STATUS_CONFIRMED);
-        order.setExportStatus(Order.EXPORT_STATUS_READY);
         result = { error: false, authorized: true };
       } else if(paymentResponse.result === constants.RESULTCODES.FAILURE) {
         order.custom.Adyen_eventCode = constants.RESULTCODES.FAILURE;


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Removing payment status fields as they are set by the webhook processing job, and triggered the management API call only if POS is enabled as payment method in SFCC.
- What existing problem does this pull request solve?
Order having status paid from API call and not by webhook.

## Tested scenarios
Description of tested scenarios:
- POS payments

**Fixed issue**: SFI-1145