### PR TITLE
Separate configs for bcmc and scheme

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/paymentMethodsConfiguration/bcmc/bcmcConfig.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/paymentMethodsConfiguration/bcmc/bcmcConfig.js
@@ -1,0 +1,18 @@
+const CardConfig = require('../card/cardConfig');
+
+class BcmcConfig extends CardConfig {
+  onChange = (state) => {
+    this.store.updateSelectedPayment('bcmc', 'isValid', state.isValid);
+    this.store.updateSelectedPayment('bcmc', 'stateData', state.data);
+  };
+
+  getConfig() {
+    const baseConfig = super.getConfig();
+    return {
+      ...baseConfig,
+      onChange: this.onChange,
+    };
+  }
+}
+
+module.exports = BcmcConfig;

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/paymentMethodsConfiguration/card/cardConfig.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/paymentMethodsConfiguration/card/cardConfig.js
@@ -15,17 +15,8 @@ class CardConfig {
   }
 
   onChange = (state) => {
-    this.store.isValid = state.isValid;
-    this.store.updateSelectedPayment(
-      this.store.selectedMethod,
-      'isValid',
-      this.store.isValid,
-    );
-    this.store.updateSelectedPayment(
-      this.store.selectedMethod,
-      'stateData',
-      state.data,
-    );
+    this.store.updateSelectedPayment('scheme', 'isValid', state.isValid);
+    this.store.updateSelectedPayment('scheme', 'stateData', state.data);
   };
 
   onSubmit = () => {

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/paymentMethodsConfiguration/index.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/paymentMethodsConfiguration/index.js
@@ -1,5 +1,6 @@
 const CardConfig = require('./card/cardConfig');
 const StoredCardConfig = require('./card/storedCardConfig');
+const BcmcConfig = require('./bcmc/bcmcConfig');
 const BoletoConfig = require('./boleto/boletoConfig');
 const GooglePayConfig = require('./googlePay/googlePayConfig');
 const KlarnaConfig = require('./klarna/klarnaConfig');
@@ -15,6 +16,7 @@ const { httpClient } = require('../../commons/httpClient');
 
 const cardConfig = new CardConfig(store, helpers).getConfig();
 const storedCardConfig = new StoredCardConfig(store, helpers).getConfig();
+const bcmcConfig = new BcmcConfig(store, helpers).getConfig();
 const boletoConfig = new BoletoConfig().getConfig();
 const googlePayConfig = new GooglePayConfig(helpers).getConfig();
 const klarnaConfig = new KlarnaConfig(
@@ -30,7 +32,7 @@ const giftCardsConfig = new GiftCardsConfig(store, httpClient).getConfig();
 
 const paymentMethodsConfiguration = {
   scheme: cardConfig,
-  bcmc: cardConfig,
+  bcmc: bcmcConfig,
   storedCard: storedCardConfig,
   boletobancario: boletoConfig,
   paywithgoogle: googlePayConfig,


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Being able to pay with payment methods that don't have a pay button and also are first in the list
- What existing problem does this pull request solve?
Not being able to pay with ideal or klarna when first in the list

## Tested scenarios
Description of tested scenarios:
- BCMC
- Cards
- iDEAL

**Fixed issue**:  SFI-988
