### PR TITLE
Rendering only stored cards in end of checkout for logged-in users 

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGenericComponent.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGenericComponent.js
@@ -109,7 +109,10 @@ async function applyGiftCards() {
 
 function renderStoredPaymentMethod(imagePath) {
   return (pm) => {
-    if (pm.supportedShopperInteractions.includes('Ecommerce')) {
+    if (
+      pm.supportedShopperInteractions.includes('Ecommerce') &&
+      pm.type === constants.SCHEME
+    ) {
       renderPaymentMethod(pm, true, imagePath);
     }
   };


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Sometimes, besides than stored cards, other tokenized payment methods were being rendered in end of checkout, however they were not able to be utilized.
- What existing problem does this pull request solve?
Checks and renders only stored cards if available.


## Tested scenarios
Description of tested scenarios:
- Stored cards payments

**Fixed issue**:  SFI-1127
