### PR TITLE
Apple Pay shipping cost mismatch 

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
@@ -84,7 +84,7 @@ let adyenHelperObj = {
    * @param {dw.order.Shipment} shipment - a shipment of the current basket
    * @returns {{currencyCode: String, value: String}} - Shipping Cost including taxes
    */
-  getShippingCost(shippingMethod) {
+  getShippingCost(shippingMethod, shipment) {
     const shipmentShippingModel = ShippingMgr.getShipmentShippingModel(shipment);
     let shippingCost = shipmentShippingModel.getShippingCost(shippingMethod).getAmount();
     collections.forEach(shipment.getProductLineItems(), (lineItem) => {
@@ -166,7 +166,7 @@ let adyenHelperObj = {
           shippingMethod,
           shipment,
         );
-        const shippingCost = adyenHelperObj.getShippingCost(shippingMethod);
+        const shippingCost = adyenHelperObj.getShippingCost(shippingMethod, shipment);
         const shipmentUUID = adyenHelperObj.getShipmentUUID(shipment);
         filteredMethods.push({
           ...shippingMethodModel,


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
In gross sites, the shipping cost line item for Apple Pay Express was not matching SFCC shipping cost.
- What existing problem does this pull request solve?
It makes sure that the shipping cost line item for apple pay express matches the shipping cost of SFCC.

## Tested scenarios
Description of tested scenarios:
- Apple Pay Express
- PayPal Express

**Fixed issue**:  SFI-1140
