### PR TITLE
Fix setting proper shopper name for paypal shipping address

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/paypalExpress.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/paypalExpress.js
@@ -194,6 +194,15 @@ function getPaypalButtonConfig(paypalConfig) {
       $.spinner().stop();
     },
     onShopperDetails: async (shopperDetails, rawData, actions) => {
+      if (rawData.purchase_units?.length) {
+        const shopperName = rawData.purchase_units[0].shipping?.name?.full_name;
+        const [firstName, ...rest] = shopperName.split(' ');
+        shopperDetails.shippingAddress.shopperName = {
+          firstName: firstName || '',
+          lastName: rest && rest.length ? rest.join(' ') : '',
+        };
+      }
+      shopperDetails.billingAddress.shopperName = shopperDetails.shopperName;
       await saveShopperDetails(shopperDetails, actions);
     },
     onAdditionalDetails: (state) => {

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/paypal/handleCheckoutReview.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/paypal/handleCheckoutReview.js
@@ -7,7 +7,6 @@ const OrderModel = require('*/cartridge/models/order');
 const validationHelpers = require('*/cartridge/scripts/helpers/basketValidationHelpers');
 const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
 const AdyenHelper = require('*/cartridge/adyen/utils/adyenHelper');
-const paypalHelper = require('*/cartridge/adyen/utils/paypalHelper');
 
 /**
  * Sets Shipping and Billing address for the basket,
@@ -21,8 +20,6 @@ function updateCurrentBasket(currentBasket, req) {
   if (currentBasket.shipments?.length <= 1) {
     req.session.privacyCache.set('usingMultiShipping', false);
   }
-
-  paypalHelper.setBillingAndShippingAddress(currentBasket);
 
   const paymentInstrument = currentBasket.getPaymentInstruments()[0];
   Transaction.wrap(() => {

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/paypal/makeExpressPaymentDetailsCall.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/paypal/makeExpressPaymentDetailsCall.js
@@ -5,7 +5,6 @@ const BasketMgr = require('dw/order/BasketMgr');
 const adyenCheckout = require('*/cartridge/adyen/scripts/payments/adyenCheckout');
 const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
 const AdyenHelper = require('*/cartridge/adyen/utils/adyenHelper');
-const paypalHelper = require('*/cartridge/adyen/utils/paypalHelper');
 const constants = require('*/cartridge/adyen/config/constants');
 const hooksHelper = require('*/cartridge/scripts/helpers/hooks');
 
@@ -39,8 +38,6 @@ function makeExpressPaymentDetailsCall(req, res, next) {
       throw new Error('Basket products changed, cannot complete trasaction');
     }
 
-    paypalHelper.setBillingAndShippingAddress(currentBasket);
-
     const validationOrderStatus = hooksHelper(
       'app.validate.order',
       'validateOrder',
@@ -53,15 +50,18 @@ function makeExpressPaymentDetailsCall(req, res, next) {
     }
 
     // create order
-    const order = OrderMgr.createOrder(
-      currentBasket,
-      session.privacy.paypalExpressOrderNo,
-    );
+    let order = null;
+    Transaction.wrap(() => {
+      order = OrderMgr.createOrder(
+        currentBasket,
+        session.privacy.paypalExpressOrderNo,
+      );
+    });
+    if (!order) {
+      throw new Error('Order could not be created for paypal express');
+    }
 
     const response = adyenCheckout.doPaymentsDetailsCall(request.data);
-
-    // Setting the session variable to null after assigning the shopper data to basket level
-    session.privacy.shopperDetails = null;
 
     response.orderNo = order.orderNo;
     response.orderToken = order.orderToken;

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/paypal/saveShopperData.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/paypal/saveShopperData.js
@@ -1,10 +1,13 @@
 const URLUtils = require('dw/web/URLUtils');
+const BasketMgr = require('dw/order/BasketMgr');
 const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
+const paypalHelper = require('*/cartridge/adyen/utils/paypalHelper');
 
 function saveShopperData(req, res, next) {
   try {
     const shopperDetails = JSON.parse(req.form.shopperDetails);
-    session.privacy.shopperDetails = JSON.stringify(shopperDetails);
+    const currentBasket = BasketMgr.getCurrentBasket();
+    paypalHelper.setBillingAndShippingAddress(currentBasket, shopperDetails);
     res.json({ success: true });
     return next();
   } catch (error) {

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/__tests__/paypalHelper.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/__tests__/paypalHelper.test.js
@@ -133,6 +133,10 @@ describe('paypalHelper', () => {
           lastName: 'Doe'
         },
         billingAddress:{
+          shopperName:{
+            firstName: 'John',
+            lastName: 'Doe'
+          },
           street: '123 Main St',
           city: 'City',
           postalCode: '12345',
@@ -140,6 +144,10 @@ describe('paypalHelper', () => {
           country: 'United States',
         },
         shippingAddress:{
+          shopperName:{
+            firstName: 'John',
+            lastName: 'Doe'
+          },
           street: '123 Main St',
           city: 'City',
           postalCode: '12345',
@@ -149,20 +157,19 @@ describe('paypalHelper', () => {
         telephoneNumber: '+1234567890',
         shopperEmail: 'john@example.com'
       }
-      session.privacy.shopperDetails = JSON.stringify(shopperDetails);
     });
     afterEach(() => {
       jest.resetModules();
     });
     it('should update billing and shipping address for current basket', () => {
       const currentBasket = BasketMgr.getCurrentBasket();
-      paypalHelper.setBillingAndShippingAddress(currentBasket);
+      paypalHelper.setBillingAndShippingAddress(currentBasket, shopperDetails);
       expect(currentBasket.billingAddress.setFirstName).toHaveBeenCalledWith('John');
     })
     it('should set billing and shipping address if current basket has no billing Address', () => {
       const currentBasket = BasketMgr.getCurrentBasket();
       currentBasket.billingAddress= '';
-      paypalHelper.setBillingAndShippingAddress(currentBasket);
+      paypalHelper.setBillingAndShippingAddress(currentBasket, shopperDetails);
       expect(currentBasket.createBillingAddress).toHaveBeenCalled();
     })
     it('should set billing and shipping address if current basket has no shipping Address', () => {
@@ -181,7 +188,7 @@ describe('paypalHelper', () => {
       currentBasket.getDefaultShipment= jest.fn(() => ({
         createShippingAddress: createShippingAddress
       }));
-      paypalHelper.setBillingAndShippingAddress(currentBasket);
+      paypalHelper.setBillingAndShippingAddress(currentBasket, shopperDetails);
       expect(currentBasket.getDefaultShipment).toHaveBeenCalled();
       expect(createShippingAddress).toHaveBeenCalled();
     })

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/paypalHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/paypalHelper.js
@@ -142,9 +142,10 @@ function createPaypalUpdateOrderRequest(
 /**
  * sets Shipping and Billing address for the basket
  * @param {dw.order.Basket} currentBasket - the current basket
+ * @param {Object} shopperDetails - the shopper billing and shipping address details
  * @returns {undefined}
  */
-function setBillingAndShippingAddress(currentBasket) {
+function setBillingAndShippingAddress(currentBasket, shopperDetails) {
   let { billingAddress } = currentBasket;
   let { shippingAddress } = currentBasket.getDefaultShipment();
   Transaction.wrap(() => {
@@ -158,26 +159,34 @@ function setBillingAndShippingAddress(currentBasket) {
     }
   });
 
-  const shopperDetails = JSON.parse(session.privacy.shopperDetails);
-
   Transaction.wrap(() => {
-    billingAddress.setFirstName(shopperDetails.shopperName.firstName);
-    billingAddress.setLastName(shopperDetails.shopperName.lastName);
+    billingAddress.setFirstName(
+      shopperDetails.billingAddress.shopperName.firstName,
+    );
+    billingAddress.setLastName(
+      shopperDetails.billingAddress.shopperName.lastName,
+    );
     billingAddress.setAddress1(shopperDetails.billingAddress.street);
     billingAddress.setCity(shopperDetails.billingAddress.city);
     billingAddress.setPhone(shopperDetails.telephoneNumber);
     billingAddress.setPostalCode(shopperDetails.billingAddress.postalCode);
-    billingAddress.setStateCode(shopperDetails.billingAddress.stateOrProvince);
+    billingAddress.setStateCode(
+      shopperDetails.billingAddress.stateOrProvince || '',
+    );
     billingAddress.setCountryCode(shopperDetails.billingAddress.country);
 
-    shippingAddress.setFirstName(shopperDetails.shopperName.firstName);
-    shippingAddress.setLastName(shopperDetails.shopperName.lastName);
+    shippingAddress.setFirstName(
+      shopperDetails.shippingAddress.shopperName.firstName,
+    );
+    shippingAddress.setLastName(
+      shopperDetails.shippingAddress.shopperName.lastName,
+    );
     shippingAddress.setAddress1(shopperDetails.shippingAddress.street);
     shippingAddress.setCity(shopperDetails.shippingAddress.city);
     shippingAddress.setPhone(shopperDetails.telephoneNumber);
     shippingAddress.setPostalCode(shopperDetails.shippingAddress.postalCode);
     shippingAddress.setStateCode(
-      shopperDetails.shippingAddress.stateOrProvince,
+      shopperDetails.shippingAddress.stateOrProvince || '',
     );
     shippingAddress.setCountryCode(shopperDetails.shippingAddress.country);
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
If the shipping changes in the paypal modal, the shopper name should be set correctly
- What existing problem does this pull request solve?
Setting wrong shopper name

## Tested scenarios
Description of tested scenarios:
- PayPal express

**Fixed issue**:  SFI-1155