### PR TITLE
POS renders separately on checkout page

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/__tests__/renderGenericComponent.test.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/__tests__/renderGenericComponent.test.js
@@ -4,8 +4,10 @@
 jest.mock('../../commons');
 jest.mock('../../../../../store');
 
-const { renderGenericComponent, setInstallments, renderPosTerminals } = require('../renderGenericComponent');
-const { applyGiftCards, setGiftCardContainerVisibility, renderGiftCardLogo, isCartModified } = require('../giftcards/index');
+const { renderGenericComponent, setInstallments } = require('../renderGenericComponent');
+const { renderPosTerminals } = require('../pos');
+
+const { applyGiftCards, renderGiftCardLogo, isCartModified } = require('../giftcards/index');
 const { getPaymentMethods } = require('../../commons');
 const { fetchGiftCards } = require('../../commons');
 const store = require('../../../../../store');

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/index.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/index.js
@@ -14,6 +14,7 @@ const { httpClient } = require('../commons/httpClient');
 const { getPaymentMethods } = require('../commons');
 const { GIFTCARD } = require('../constants');
 const { renderGiftCards } = require('./giftcards');
+const { addStores } = require('./pos');
 
 function setAdyenInputValues() {
   const customMethods = {};
@@ -44,6 +45,9 @@ function renderPaymentMethod() {
       );
     if (areGiftCardsEnabled) {
       await renderGiftCards(paymentMethodsResponse);
+    }
+    if (window.activeTerminalApiStores) {
+      addStores(window.activeTerminalApiStores);
     }
   });
 }

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/pos/index.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/pos/index.js
@@ -1,0 +1,76 @@
+const { getConnectedTerminals } = require('../../commons');
+
+function addPosTerminals(terminals) {
+  const ddTerminals = document.createElement('select');
+  ddTerminals.id = 'terminalList';
+  Object.keys(terminals).forEach((t) => {
+    const option = document.createElement('option');
+    option.value = terminals[t];
+    option.text = terminals[t];
+    ddTerminals.appendChild(option);
+  });
+  document.querySelector('#adyenPosTerminals').append(ddTerminals);
+}
+
+function renderPosTerminals(adyenConnectedTerminals) {
+  const removeChilds = () => {
+    const posTerminals = document.querySelector('#adyenPosTerminals');
+    while (posTerminals.firstChild) {
+      posTerminals.removeChild(posTerminals.firstChild);
+    }
+  };
+  if (adyenConnectedTerminals) {
+    removeChilds();
+    addPosTerminals(adyenConnectedTerminals);
+  }
+}
+
+function addStores(stores) {
+  const storeDropdown = document.createElement('select');
+  storeDropdown.id = 'storeList';
+
+  const placeholderOption = document.createElement('option');
+  placeholderOption.value = '';
+  placeholderOption.text = 'Select a store';
+  placeholderOption.disabled = true;
+  placeholderOption.selected = true;
+  storeDropdown.appendChild(placeholderOption);
+
+  const storeArray = typeof stores === 'string' ? stores.split(',') : stores;
+
+  storeArray.forEach((terminalStore) => {
+    const option = document.createElement('option');
+    option.value = terminalStore.trim();
+    option.text = terminalStore.trim();
+    storeDropdown.appendChild(option);
+  });
+  const storeDropdownContainer = document.querySelector('#adyenPosStores');
+  if (storeDropdownContainer) {
+    const existingDropdown = storeDropdownContainer.querySelector('#storeList');
+    if (existingDropdown) {
+      storeDropdownContainer.removeChild(existingDropdown);
+    }
+    storeDropdownContainer.append(storeDropdown);
+  }
+  storeDropdown.addEventListener('change', async () => {
+    const terminalDropdownContainer =
+      document.querySelector('#adyenPosTerminals');
+    const existingTerminalDropdown =
+      terminalDropdownContainer.querySelector('#terminalList');
+    if (existingTerminalDropdown) {
+      terminalDropdownContainer.removeChild(existingTerminalDropdown); // Clear old terminal list
+    }
+    const data = await getConnectedTerminals();
+    const parsedResponse = JSON.parse(data.response);
+    const { uniqueTerminalIds } = parsedResponse;
+    if (uniqueTerminalIds) {
+      renderPosTerminals(uniqueTerminalIds);
+      document.querySelector('button[value="submit-payment"]').disabled = false;
+    }
+  });
+}
+
+module.exports = {
+  addStores,
+  renderPosTerminals,
+};

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGenericComponent.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_checkout/renderGenericComponent.js
@@ -2,20 +2,7 @@
 const store = require('../../../../store');
 const { renderPaymentMethod } = require('./renderPaymentMethod');
 const helpers = require('./helpers');
-const { getConnectedTerminals } = require('../commons');
 const constants = require('../constants');
-
-function addPosTerminals(terminals) {
-  const ddTerminals = document.createElement('select');
-  ddTerminals.id = 'terminalList';
-  Object.keys(terminals).forEach((t) => {
-    const option = document.createElement('option');
-    option.value = terminals[t];
-    option.text = terminals[t];
-    ddTerminals.appendChild(option);
-  });
-  document.querySelector('#adyenPosTerminals').append(ddTerminals);
-}
 
 function setCheckoutConfiguration(checkoutOptions) {
   const setField = (key, val) => val && { [key]: val };
@@ -73,64 +60,6 @@ async function renderPaymentMethods(
     // eslint-disable-next-line
     await renderPaymentMethod(pm, false, imagePath, adyenDescriptions[pm.type]);
   }
-}
-
-function renderPosTerminals(adyenConnectedTerminals) {
-  const removeChilds = () => {
-    const posTerminals = document.querySelector('#adyenPosTerminals');
-    while (posTerminals.firstChild) {
-      posTerminals.removeChild(posTerminals.firstChild);
-    }
-  };
-  if (adyenConnectedTerminals) {
-    removeChilds();
-    addPosTerminals(adyenConnectedTerminals);
-  }
-}
-
-function addStores(stores) {
-  const storeDropdown = document.createElement('select');
-  storeDropdown.id = 'storeList';
-
-  const placeholderOption = document.createElement('option');
-  placeholderOption.value = '';
-  placeholderOption.text = 'Select a store';
-  placeholderOption.disabled = true;
-  placeholderOption.selected = true;
-  storeDropdown.appendChild(placeholderOption);
-
-  const storeArray = typeof stores === 'string' ? stores.split(',') : stores;
-
-  storeArray.forEach((terminalStore) => {
-    const option = document.createElement('option');
-    option.value = terminalStore.trim();
-    option.text = terminalStore.trim();
-    storeDropdown.appendChild(option);
-  });
-  const storeDropdownContainer = document.querySelector('#adyenPosStores');
-  if (storeDropdownContainer) {
-    const existingDropdown = storeDropdownContainer.querySelector('#storeList');
-    if (existingDropdown) {
-      storeDropdownContainer.removeChild(existingDropdown);
-    }
-    storeDropdownContainer.append(storeDropdown);
-  }
-  storeDropdown.addEventListener('change', async () => {
-    const terminalDropdownContainer =
-      document.querySelector('#adyenPosTerminals');
-    const existingTerminalDropdown =
-      terminalDropdownContainer.querySelector('#terminalList');
-    if (existingTerminalDropdown) {
-      terminalDropdownContainer.removeChild(existingTerminalDropdown); // Clear old terminal list
-    }
-    const data = await getConnectedTerminals();
-    const parsedResponse = JSON.parse(data.response);
-    const { uniqueTerminalIds } = parsedResponse;
-    if (uniqueTerminalIds) {
-      renderPosTerminals(uniqueTerminalIds);
-      document.querySelector('button[value="submit-payment"]').disabled = false;
-    }
-  });
 }
 
 function setAmazonPayConfig(adyenPaymentMethods) {
@@ -238,10 +167,6 @@ export async function initializeCheckout(paymentMethodsResponse) {
     helpers.displaySelectedMethod(firstPaymentMethod.value);
   }
 
-  if (window.activeTerminalApiStores) {
-    addStores(window.activeTerminalApiStores);
-  }
-
   helpers.createShowConfirmationForm(
     window.ShowConfirmationPaymentFromComponent,
   );
@@ -265,7 +190,5 @@ module.exports = {
   setAmazonPayConfig,
   renderStoredPaymentMethods,
   renderPaymentMethods,
-  renderPosTerminals,
   resolveUnmount,
-  addStores,
 };


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Rendering POS component is done separately, not requiring a /paymentsMethod call.
- What existing problem does this pull request solve?
It allows using POS even without need for setup of other payment methods.

## Tested scenarios
Description of tested scenarios:
- POS payments
- End of checkout payments

**Fixed issue**:  SFI-1153
