### PR TITLE
Adding the new card types and moving the config to a json file

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/config/card-type-mapping.json
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/config/card-type-mapping.json
@@ -1,0 +1,28 @@
+{
+	"visa": "Visa",
+	"visa_applepay": "Visa",
+	"mc": "Mastercard",
+	"mc_applepay": "Mastercard",
+	"amex": "Amex",
+	"amex_applepay": "Amex",
+	"discover": "Discover",
+	"discover_applepay": "Discover",
+	"maestro": "Maestro",
+	"maestrouk": "Maestro",
+	"maestro_applepay": "Maestro",
+	"diners": "Diners",
+	"diners_applepay": "Diners",
+	"bcmc": "Bancontact",
+	"jcb": "JCB",
+	"jcb_applepay": "JCB",
+	"cup": "CUP",
+	"cartebancaire": "Carte Bancaire",
+	"cartebancaire_applepay": "Carte Bancaire",
+	"star": "Star",
+	"star_applepay": "Star",
+	"nyce": "Nyce",
+	"nyce_applepay": "Nyce",
+	"accel": "Accel",
+	"accel_applepay": "Accel"
+  }
+  

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
@@ -664,7 +664,7 @@ let adyenHelperObj = {
 
   // gets the Adyen card type name based on the SFCC card type name
   getSfccCardType(cardType) {
-	const cardTypeMapping = require('*/cartridge/adyen/config/card-type-mapping.json');
+    const cardTypeMapping = require('*/cartridge/adyen/config/card-type-mapping.json');
     if (empty(cardType)) {
         throw new Error('cardType argument is not passed to getSfccCardType function');
     }

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
@@ -664,56 +664,13 @@ let adyenHelperObj = {
 
   // gets the Adyen card type name based on the SFCC card type name
   getSfccCardType(cardType) {
-    if (!empty(cardType)) {
-      switch (cardType) {
-        case 'visa':
-        case 'visa_applepay':
-          cardType = 'Visa';
-          break;
-        case 'mc':
-        case 'mc_applepay':
-          cardType = 'Mastercard';
-          break;
-        case 'amex':
-        case 'amex_applepay':
-          cardType = 'Amex';
-          break;
-        case 'discover':
-        case 'discover_applepay':
-          cardType = 'Discover';
-          break;
-        case 'maestro':
-        case 'maestrouk':
-        case 'maestro_applepay':
-          cardType = 'Maestro';
-          break;
-        case 'diners':
-        case 'diners_applepay':
-          cardType = 'Diners';
-          break;
-        case 'bcmc':
-          cardType = 'Bancontact';
-          break;
-        case 'jcb':
-        case 'jcb_applepay':
-          cardType = 'JCB';
-          break;
-        case 'cup':
-          cardType = 'CUP';
-          break;
-        case 'cartebancaire':
-        case 'cartebancaire_applepay':
-          cardType = 'Carte Bancaire';
-          break;
-        default:
-          cardType = '';
-          break;
-      }
-      return cardType;
+	const cardTypeMapping = require('*/cartridge/adyen/config/card-type-mapping.json');
+	AdyenLogs.fatal_log(`entering card type ${cardType}`);
+    if (empty(cardType)) {
+        throw new Error('cardType argument is not passed to getSfccCardType function');
     }
-    throw new Error(
-      'cardType argument is not passed to getSfccCardType function',
-    );
+	AdyenLogs.fatal_log(`card type mapping ${cardTypeMapping[cardType]}`);
+    return cardTypeMapping[cardType] || '';
   },
 
   // saves the payment details in the paymentInstrument's custom object

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
@@ -665,11 +665,9 @@ let adyenHelperObj = {
   // gets the Adyen card type name based on the SFCC card type name
   getSfccCardType(cardType) {
 	const cardTypeMapping = require('*/cartridge/adyen/config/card-type-mapping.json');
-	AdyenLogs.fatal_log(`entering card type ${cardType}`);
     if (empty(cardType)) {
         throw new Error('cardType argument is not passed to getSfccCardType function');
     }
-	AdyenLogs.fatal_log(`card type mapping ${cardTypeMapping[cardType]}`);
     return cardTypeMapping[cardType] || '';
   },
 


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Supporting more card types and moving the configuration to a json file.
- What existing problem does this pull request solve?
It allows merchants to use Accel, Star and Nyce cards.

## Tested scenarios
Description of tested scenarios:
- Star payment
- Nyce payment

**Fixed issue**:  SFI-1144