### PR TITLE
Paypal express shipping methods supports excluded address rules

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/__tests__/shippingMethods.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/__tests__/shippingMethods.test.js
@@ -55,6 +55,15 @@ describe('Shipping methods', () => {
         }
       }),
       updateTotals: jest.fn(),
+	  getShipments: jest.fn(() => ({
+		toArray: jest.fn(() => [
+		  {
+			shippingAddress: {
+			  getCountryCode: jest.fn(() => ({ value: 'NL' })),
+			},
+		  },
+		]),
+	  })),
     };
     BasketMgr.getCurrentBasket.mockReturnValueOnce(currentBasket);
     callGetShippingMethods(req, res, next);


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
When default shipping method is being excluded by a rule, Adyen-ShippingMethods returns 500 since `selected = false` for each available shipping method.
- What existing problem does this pull request solve?
Enables paypal express when rules are activated for a shipping method. 

## Tested scenarios
Description of tested scenarios:
- PayPal express payment with exclusion rule for a country

**Fixed issue**:  SFI-1158