### PR TITLE
fix: adding error messages for paypal express inside modale for v6

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_express/paymentMethods/paypal/paypal.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen_express/paymentMethods/paypal/paypal.js
@@ -127,8 +127,7 @@ class Paypal {
       const { shippingAddress } = data;
       const currentPaymentData = component.paymentData;
       if (!shippingAddress) {
-        actions.reject();
-        return;
+        return actions.reject();
       }
       const requestBody = {
         paymentMethodType: PAYPAL,
@@ -149,8 +148,9 @@ class Paypal {
         },
       });
       Paypal.updateComponent(response, component);
+      return null;
     } catch (e) {
-      actions.reject();
+      return actions.reject(data.errors.ADDRESS_ERROR);
     }
   }
 
@@ -158,23 +158,23 @@ class Paypal {
     try {
       const { selectedShippingOption } = data;
       if (!selectedShippingOption) {
-        actions.reject();
-      } else {
-        const response = await httpClient({
-          method: 'POST',
-          url: this.selectShippingMethodUrl,
-          data: {
-            data: JSON.stringify({
-              paymentMethodType: PAYPAL,
-              currentPaymentData: component.paymentData,
-              methodID: selectedShippingOption?.id,
-            }),
-          },
-        });
-        Paypal.updateComponent(response, component);
+        return actions.reject();
       }
+      const response = await httpClient({
+        method: 'POST',
+        url: this.selectShippingMethodUrl,
+        data: {
+          data: JSON.stringify({
+            paymentMethodType: PAYPAL,
+            currentPaymentData: component.paymentData,
+            methodID: selectedShippingOption?.id,
+          }),
+        },
+      });
+      Paypal.updateComponent(response, component);
+      return null;
     } catch (e) {
-      actions.reject();
+      return actions.reject(data.errors.METHOD_UNAVAILABLE);
     }
   }
 


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
PayPal SDK supports shopper friendly messages if `onShippingOptionsChange` or `onShippingAddressChange` fails. 
- What existing problem does this pull request solve?
It shows the supported shopper friendly messages in unhappy flows to the user.

## Tested scenarios
Description of tested scenarios:
- onShippingOptionsChange unhappy flow
- onShippingAddressChange unhappy flow

**Fixed issue**:  SFI-1158
