### PR TITLE
Setting payment instrument fields for paymentFromComponent based on stateData

### DIFF
--- a/jest/sfccCartridgeMocks.js
+++ b/jest/sfccCartridgeMocks.js
@@ -266,6 +266,7 @@ jest.mock(
   '*/cartridge/adyen/utils/adyenHelper',
   () => ({
     savePaymentDetails: jest.fn(),
+    setPaymentInstrumentFields: jest.fn(),
     getAdyenHash: jest.fn(() => 'mocked_hash'),
     getLoadingContext: jest.fn(() => 'mocked_loading_context'),
     getCurrencyValueForApi: jest.fn(() => ({

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/config/constants.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/config/constants.js
@@ -38,6 +38,7 @@ module.exports = {
     PAYPAL: 'paypal',
     GOOGLEPAY: 'googlepay',
     SCHEME: 'scheme',
+    GIFTCARD: 'giftcard',
   },
 
   CAN_SKIP_SUMMARY_PAGE: ['applepay', 'cashapp', 'upi', 'googlepay'],

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/config/constants.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/config/constants.js
@@ -37,6 +37,7 @@ module.exports = {
     AMAZONPAY: 'amazonpay',
     PAYPAL: 'paypal',
     GOOGLEPAY: 'googlepay',
+    SCHEME: 'scheme',
   },
 
   CAN_SKIP_SUMMARY_PAGE: ['applepay', 'cashapp', 'upi', 'googlepay'],

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/paypal/makeExpressPaymentDetailsCall.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/paypal/makeExpressPaymentDetailsCall.js
@@ -5,20 +5,7 @@ const BasketMgr = require('dw/order/BasketMgr');
 const adyenCheckout = require('*/cartridge/adyen/scripts/payments/adyenCheckout');
 const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
 const AdyenHelper = require('*/cartridge/adyen/utils/adyenHelper');
-const constants = require('*/cartridge/adyen/config/constants');
 const hooksHelper = require('*/cartridge/scripts/helpers/hooks');
-
-function setPaymentInstrumentFields(paymentInstrument, response) {
-  paymentInstrument.custom.adyenPaymentMethod =
-    AdyenHelper.getAdyenComponentType(response.paymentMethod.type);
-  paymentInstrument.custom[`${constants.OMS_NAMESPACE}__Adyen_Payment_Method`] =
-    AdyenHelper.getAdyenComponentType(response.paymentMethod.type);
-  paymentInstrument.custom.Adyen_Payment_Method_Variant =
-    response.paymentMethod.type.toLowerCase();
-  paymentInstrument.custom[
-    `${constants.OMS_NAMESPACE}__Adyen_Payment_Method_Variant`
-  ] = response.paymentMethod.type.toLowerCase();
-}
 
 /*
  * Makes a payment details call to Adyen to confirm the current status of a payment.
@@ -65,13 +52,9 @@ function makeExpressPaymentDetailsCall(req, res, next) {
 
     response.orderNo = order.orderNo;
     response.orderToken = order.orderToken;
-    const paymentInstrument = order.getPaymentInstruments(
-      AdyenHelper.getOrderMainPaymentInstrumentType(order),
-    )[0];
     // Storing the paypal express response to make use of show confirmation logic
     Transaction.wrap(() => {
       order.custom.Adyen_paypalExpressResponse = JSON.stringify(response);
-      setPaymentInstrumentFields(paymentInstrument, response);
     });
     res.json({ orderNo: response.orderNo, orderToken: response.orderToken });
     return next();

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/paypal/makeExpressPaymentsCall.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/paypal/makeExpressPaymentsCall.js
@@ -40,6 +40,8 @@ function makeExpressPaymentsCall(req, res, next) {
       null,
       paymentInstrument,
     );
+    // Set payment instrument fields
+    AdyenHelper.setPaymentInstrumentFields(paymentInstrument, paymentRequest);
     paymentRequest.amount = {
       currency: paymentInstrument.paymentTransaction.amount.currencyCode,
       value: AdyenHelper.getCurrencyValueForApi(

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/adyenCheckout.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/adyenCheckout.js
@@ -151,6 +151,8 @@ function createPaymentRequest(args) {
       paymentInstrument,
       order.getCustomerEmail(),
     );
+    // Set payment instrument fields
+    AdyenHelper.setPaymentInstrumentFields(paymentInstrument, paymentRequest);
 
     const paymentMethodType = paymentRequest.paymentMethod.type;
     paymentRequest = AdyenHelper.add3DS2Data(paymentRequest);

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/paymentFromComponent.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/paymentFromComponent.js
@@ -198,16 +198,6 @@ function paymentFromComponent(req, res, next) {
       paymentInstrument.custom.adyenPartialPaymentsOrder =
         session.privacy.partialPaymentData;
     }
-    paymentInstrument.custom.adyenPaymentMethod =
-      AdyenHelper.getAdyenComponentType(req.form.paymentMethod);
-    paymentInstrument.custom[
-      `${constants.OMS_NAMESPACE}__Adyen_Payment_Method`
-    ] = AdyenHelper.getAdyenComponentType(req.form.paymentMethod);
-    paymentInstrument.custom.Adyen_Payment_Method_Variant =
-      req.form.paymentMethod.toLowerCase();
-    paymentInstrument.custom[
-      `${constants.OMS_NAMESPACE}__Adyen_Payment_Method_Variant`
-    ] = req.form.paymentMethod.toLowerCase();
   });
 
   handleExpressPayment(reqDataObj, currentBasket);

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
@@ -564,14 +564,15 @@ const adyenHelperObj = {
   },
 
   setPaymentInstrumentFields(paymentInstrument, stateData) {
+	if (!(paymentInstrument instanceof dw.order.OrderPaymentInstrument)) {
+		return null;
+	}
     const paymentMethodType = stateData.paymentMethod.type;
 	// Currently this doesn't set the fields for cards and giftcards, they are handled by other flow
     if (
       [constants.SCHEME, constants.ACTIONTYPES.GIFTCARD].indexOf(paymentMethodType) ===
       -1
     ) {
-      AdyenLogs.fatal_log('going inside the setPaymentInstrumentFields');
-      Transaction.wrap(() => {
         paymentInstrument.custom.adyenPaymentMethod =
           adyenHelperObj.getAdyenComponentType(stateData.paymentMethod.type);
         paymentInstrument.custom[
@@ -582,7 +583,6 @@ const adyenHelperObj = {
         paymentInstrument.custom[
           `${constants.OMS_NAMESPACE}__Adyen_Payment_Method_Variant`
         ] = stateData.paymentMethod.type.toLowerCase();
-      });
     }
   },
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
@@ -570,7 +570,7 @@ const adyenHelperObj = {
     const paymentMethodType = stateData.paymentMethod.type;
 	// Currently this doesn't set the fields for cards and giftcards, they are handled by other flow
     if (
-      [constants.SCHEME, constants.ACTIONTYPES.GIFTCARD].indexOf(paymentMethodType) ===
+      [constants.PAYMENTMETHODS.SCHEME, constants.PAYMENTMETHODS.GIFTCARD].indexOf(paymentMethodType) ===
       -1
     ) {
         paymentInstrument.custom.adyenPaymentMethod =


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Payment instrument fields for payment method are set based on state data from the component same as they are passed to `/payments` call
- What existing problem does this pull request solve?
Removing the possibility of the fields to be saved as HTML translated tags.

## Tested scenarios
Description of tested scenarios:
- Card payments
- PaymentFromComponent payments
- Zero auth payments
- Giftcard payments
- Express payments

**Fixed issue**:  SFI-1170
