### PR TITLE
fix: prevent skipping of the first product line item in array

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/lineItemHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/lineItemHelper.js
@@ -130,7 +130,7 @@ const __LineItemHelper = {
     const lineItems = [];
     // eslint-disable-next-line no-restricted-syntax
     for (const item in allLineItems) {
-      if (item) {
+      if (item != null) {
         const lineItem = allLineItems[item];
         if (this.isValidLineItem(lineItem)) {
           lineItems.push(lineItem);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
This fixes https://github.com/Adyen/adyen-salesforce-commerce-cloud/issues/1321 by changing the truthy check to a null check because the first item of an array with index 0 was getting skipped.


## Tested scenarios
Description of tested scenarios:
Ordering with Paypal and Ratepay

**Fixed issue**:  <!-- #-1321 -->
