### PR TITLE
SFRA 5, enabling PDP payment methods and confirmation page

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/index.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/index.js
@@ -70,6 +70,41 @@ function setAdyenInputValues() {
   }
 }
 
+function handleSfraRedirect(data) {
+  if (window.sfra6Compatibility) {
+    const redirect = $('<form>').appendTo(document.body).attr({
+      method: 'POST',
+      action: data.continueUrl,
+    });
+
+    $('<input>').appendTo(redirect).attr({
+      name: 'orderID',
+      value: data.orderID,
+    });
+
+    $('<input>').appendTo(redirect).attr({
+      name: 'orderToken',
+      value: data.orderToken,
+    });
+
+    redirect.submit();
+  } else {
+    let { continueUrl } = data;
+    const urlParams = {
+      ID: data.orderID,
+      token: data.orderToken,
+    };
+
+    continueUrl +=
+      (continueUrl.indexOf('?') !== -1 ? '&' : '?') +
+      Object.keys(urlParams)
+        .map((key) => `${key}=${encodeURIComponent(urlParams[key])}`)
+        .join('&');
+
+    window.location.href = continueUrl;
+  }
+}
+
 async function overridePlaceOrderRequest(url) {
   try {
     $('body').trigger('checkout:disableButton', '.next-step-button button');
@@ -89,22 +124,7 @@ async function overridePlaceOrderRequest(url) {
       window.orderToken = data.orderToken;
       actionHandler(data.adyenAction);
     } else {
-      const redirect = $('<form>').appendTo(document.body).attr({
-        method: 'POST',
-        action: data.continueUrl,
-      });
-
-      $('<input>').appendTo(redirect).attr({
-        name: 'orderID',
-        value: data.orderID,
-      });
-
-      $('<input>').appendTo(redirect).attr({
-        name: 'orderToken',
-        value: data.orderToken,
-      });
-
-      redirect.submit();
+      handleSfraRedirect(data);
     }
   } catch (err) {
     $('body').trigger('checkout:enableButton', '.next-step-button button');

--- a/src/cartridges/app_adyen_SFRA/cartridge/templates/default/checkout/billing/adyenComponentForm.isml
+++ b/src/cartridges/app_adyen_SFRA/cartridge/templates/default/checkout/billing/adyenComponentForm.isml
@@ -31,6 +31,7 @@
       window.cancelPartialPaymentOrderUrl = "${URLUtils.https('Adyen-CancelPartialPaymentOrder')}";
       window.fetchGiftCardsUrl = "${URLUtils.https('Adyen-fetchGiftCards')}";
       window.activeTerminalApiStores = '${pdict.AdyenConfigs.getAdyenActiveStoreId()}';
+      window.sfra6Compatibility = ${pdict.AdyenConfigs.getAdyenSFRA6Compatibility()};
       
       window.remainingAmountGiftCardResource = "${Resource.msg('remainingAmount.giftCard', 'adyen', null)}";
       window.discountedAmountGiftCardResource = "${Resource.msg('discountedAmount.giftCard', 'adyen', null)}";

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/Adyen.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/Adyen.js
@@ -110,10 +110,13 @@ server.post(
   adyen.getCheckoutPaymentMethods,
 );
 
+/**
+ * csrf.generateToken is used since SFRA5 doens't have a token in PDP
+ */
 server.post(
   'GetExpressPaymentMethods',
   server.middleware.https,
-  csrf.validateRequest,
+  csrf.generateToken,
   adyen.getCheckoutExpressPaymentMethods,
 );
 


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Enabling PDP payment methods and redirection to confirmation page in SFRA5.
- What existing problem does this pull request solve?
After a successful payment there was no redirection to confirmation page. 
PDP payment methods failed to load on PDP. 
Both issues were present only in SFRA5.

## Tested scenarios
Description of tested scenarios:
- Redirect pm
- PDP pm
- Card payments

**Fixed issue**:  SFI-1228
