### PR TITLE
Remove unused promise when rendering checkout components

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/__tests__/__snapshots__/renderPaymentMethod.test.js.snap
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/__tests__/__snapshots__/renderPaymentMethod.test.js.snap
@@ -3,7 +3,44 @@
 exports[`Render Payment Method should render payment method with shopper information fields 1`] = `
 <ul
   id="paymentMethodsList"
-/>
+>
+  <li
+    class="paymentMethod"
+  >
+    
+    
+    <input
+      id="rb_scheme"
+      name="brandCode"
+      type="radio"
+      value="scheme"
+    />
+    
+    
+    <img
+      class="paymentMethod_img"
+      src="/mocked_path/card.png"
+    />
+    
+    
+    <label
+      for="rb_scheme"
+      id="lb_scheme"
+    >
+      mocked_name
+    </label>
+    
+  
+    <p>
+      mocked_description
+    </p>
+    <div
+      class="additionalFields"
+      id="component_scheme"
+      style="display:none"
+    />
+  </li>
+</ul>
 `;
 
 exports[`Render Payment Method should render payment method with shopper information fields 2`] = `
@@ -18,7 +55,23 @@ exports[`Render Payment Method should render payment method with shopper informa
   "scheme": {
     "isValid": undefined,
     "node": {
-      "mount": [MockFunction],
+      "mount": [MockFunction] {
+        "calls": [
+          [
+            <div
+              class="additionalFields"
+              id="component_scheme"
+              style="display:none"
+            />,
+          ],
+        ],
+        "results": [
+          {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
     },
   },
 }

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/__tests__/checkoutConfiguration.test.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/__tests__/checkoutConfiguration.test.js
@@ -108,6 +108,7 @@ describe('Checkout Configuration', () => {
   });
   describe('PayPal', () => {
     it('handles onSubmit', () => {
+      const stateData = { foo: 'bar' };
       document.body.innerHTML = `
         <div id="lb_paypal">PayPal</div>
         <div id="adyenPaymentMethodName"></div>
@@ -115,9 +116,9 @@ describe('Checkout Configuration', () => {
       `;
       store.selectedMethod = 'paypal';
       store.componentsObj = { paypal: { stateData: { foo: 'bar' } } };
-      paypal.onSubmit({ data: {} });
+      paypal.onSubmit({ data: stateData });
       expect(document.getElementById('adyenStateData').value).toBe(
-        JSON.stringify(store.selectedPayment.stateData),
+        JSON.stringify(stateData),
       );
     });
 

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/index.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/index.js
@@ -43,6 +43,7 @@ async function registerRenderPaymentMethodListener() {
         (pm) => pm.type === GIFTCARD,
       );
     if (areGiftCardsEnabled) {
+      document.querySelector('#adyenGiftCards').style.display = 'block';
       await renderGiftCards(paymentMethodsResponse);
     }
     if (window.activeTerminalApiStores) {

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/paymentMethodsConfiguration/paypal/paypalConfig.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/paymentMethodsConfiguration/paypal/paypalConfig.js
@@ -10,7 +10,7 @@ class PaypalConfig {
   onSubmit = (state, component) => {
     this.helpers.assignPaymentMethodValue();
     document.querySelector('#adyenStateData').value = JSON.stringify(
-      this.store.selectedPayment.stateData,
+      state.data,
     );
     this.helpers.paymentFromComponent(state.data, component);
   };

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/renderPaymentMethod.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/renderPaymentMethod.js
@@ -165,7 +165,7 @@ function renderPaymentMethod(
     const paymentMethodsUI = document.querySelector('#paymentMethodsList');
     const paymentMethodID = getPaymentMethodID(isStored, paymentMethod);
     if (paymentMethodID === constants.GIFTCARD) {
-      return Promise.reject();
+      return false;
     }
 
     const isSchemeNotStored = paymentMethod.type === 'scheme' && !isStored;

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/renderPaymentMethod.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/renderPaymentMethod.js
@@ -160,6 +160,7 @@ function renderPaymentMethod(
   description = null,
   rerender = false,
 ) {
+  let canRender;
   try {
     const paymentMethodsUI = document.querySelector('#paymentMethodsList');
     const paymentMethodID = getPaymentMethodID(isStored, paymentMethod);
@@ -199,10 +200,11 @@ function renderPaymentMethod(
     handleInput(options);
     setValid(options);
 
-    return Promise.resolve();
+    canRender = true;
   } catch (err) {
-    return Promise.reject(err);
+    canRender = false;
   }
+  return canRender;
 }
 
 /**

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/renderPaymentMethod.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/renderPaymentMethod.js
@@ -144,16 +144,6 @@ function createListItem(rerender, paymentMethodID, liContents) {
   return li;
 }
 
-async function checkIfNodeIsAvailable(node) {
-  if (node?.isAvailable) {
-    const isNodeAvailable = await node.isAvailable();
-    if (!isNodeAvailable) {
-      return false;
-    }
-  }
-  return true;
-}
-
 /**
  * To avoid re-rendering components twice, unmounts existing components from payment methods list
  */
@@ -163,21 +153,18 @@ function clearPaymentMethodsContainer() {
   store.clearPaymentMethod();
 }
 
-async function renderPaymentMethod(
+function renderPaymentMethod(
   paymentMethod,
   isStored,
   path,
   description = null,
   rerender = false,
 ) {
-  let canRender;
   try {
     const paymentMethodsUI = document.querySelector('#paymentMethodsList');
-
     const paymentMethodID = getPaymentMethodID(isStored, paymentMethod);
-
     if (paymentMethodID === constants.GIFTCARD) {
-      return;
+      return Promise.reject();
     }
 
     const isSchemeNotStored = paymentMethod.type === 'scheme' && !isStored;
@@ -202,7 +189,6 @@ async function renderPaymentMethod(
 
     li.append(container);
 
-    await checkIfNodeIsAvailable(store.componentsObj[paymentMethodID]?.node);
     paymentMethodsUI.append(li);
     store.componentsObj[paymentMethodID]?.node?.mount(container);
 
@@ -212,13 +198,11 @@ async function renderPaymentMethod(
 
     handleInput(options);
     setValid(options);
-    canRender = true;
+
+    return Promise.resolve();
   } catch (err) {
-    // method not available
-    canRender = false;
+    return Promise.reject(err);
   }
-  // eslint-disable-next-line
-  return canRender;
 }
 
 /**

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/express/cart/expressPayments.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/express/cart/expressPayments.js
@@ -191,10 +191,10 @@ async function init() {
 }
 
 module.exports = {
-  init,
   renderExpressPaymentContainer,
   renderPayPalButton,
   renderApplePayButton,
   renderGooglePayButton,
   renderAmazonPayButton,
+  init,
 };

--- a/src/cartridges/app_adyen_SFRA/cartridge/templates/default/checkout/billing/adyenComponentForm.isml
+++ b/src/cartridges/app_adyen_SFRA/cartridge/templates/default/checkout/billing/adyenComponentForm.isml
@@ -80,38 +80,9 @@
      <input id="selectedIssuer" type="hidden" name="${adyenPaymentFields.issuer.htmlName}"/>
 
     <ul id="paymentMethodsList" class="payment-methods-container"></ul>
-    <div class="gift-card-separator adyen-checkout__content-separator adyen-checkout-ctp__separator">
-        ${Resource.msg('separator.giftCard', 'adyen', null)}
+    <div id="adyenGiftCards" style="display: none">
+        <isinclude template="checkout/billing/adyenGiftCards" />
     </div>
-    <div class="gift-card-selection">
-        <img id="headingImg" class="heading-img" />
-        <button id="giftCardAddButton" class="adyen-checkout__button adyen-checkout__button--secondary" type="button">
-            <span class="adyen-checkout__button__content">
-                <span class="adyen-checkout__button__text">
-                    ${Resource.msg('add.giftCard', 'adyen', null)}
-                </span>
-            </span>
-        </button>
-        <div id="giftCardSelectContainer" class="invisible">
-            <label  id="giftCardSelectWrapper" class="gift-card-select-wrapper">
-                <select id="giftCardSelect">
-                    <option value="null" selected="selected">${Resource.msg('select.giftCard', 'adyen', null)}</option>
-                </select>
-            </label>
-            <ul id="giftCardUl" class="list-cards invisible"></ul>
-            <div id="giftCardContainer"></div>
-        </div>
-        <div id="cancelGiftCardButton" class="invisible">
-            <button id="cancelGiftCardButtonStyling">
-                <img src="${URLUtils.staticURL('images/cancel.svg')}" alt="Cancel" />
-            </button>
-        </div>
-    </div>
-    <div id="giftCardsList" class="gift-cards-container"></div>
-    <div id="giftCardsCancelContainer" class="gift-cards-container-cancel invisible">
-        <a id="giftCardCancelButton">${Resource.msg('cancel.giftCard', 'adyen', null)}</a>
-    </div>
-    <div id="giftCardsInfoMessage"></div>
 
      <iscomment>
          Adyen RatePay Device Fingerprint Code

--- a/src/cartridges/app_adyen_SFRA/cartridge/templates/default/checkout/billing/adyenGiftCards.isml
+++ b/src/cartridges/app_adyen_SFRA/cartridge/templates/default/checkout/billing/adyenGiftCards.isml
@@ -1,0 +1,32 @@
+<div class="gift-card-separator adyen-checkout__content-separator adyen-checkout-ctp__separator">
+    ${Resource.msg('separator.giftCard', 'adyen', null)}
+</div>
+<div class="gift-card-selection">
+    <img id="headingImg" class="heading-img" />
+    <button id="giftCardAddButton" class="adyen-checkout__button adyen-checkout__button--secondary" type="button">
+        <span class="adyen-checkout__button__content">
+            <span class="adyen-checkout__button__text">
+                ${Resource.msg('add.giftCard', 'adyen', null)}
+            </span>
+        </span>
+    </button>
+    <div id="giftCardSelectContainer" class="invisible">
+        <label  id="giftCardSelectWrapper" class="gift-card-select-wrapper">
+            <select id="giftCardSelect">
+                <option value="null" selected="selected">${Resource.msg('select.giftCard', 'adyen', null)}</option>
+            </select>
+        </label>
+        <ul id="giftCardUl" class="list-cards invisible"></ul>
+        <div id="giftCardContainer"></div>
+    </div>
+    <div id="cancelGiftCardButton" class="invisible">
+        <button id="cancelGiftCardButtonStyling">
+            <img src="${URLUtils.staticURL('images/cancel.svg')}" alt="Cancel" />
+        </button>
+    </div>
+</div>
+<div id="giftCardsList" class="gift-cards-container"></div>
+<div id="giftCardsCancelContainer" class="gift-cards-container-cancel invisible">
+    <a id="giftCardCancelButton">${Resource.msg('cancel.giftCard', 'adyen', null)}</a>
+</div>
+<div id="giftCardsInfoMessage"></div>

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/getCheckoutExpressPaymentMethods.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/getCheckoutExpressPaymentMethods.js
@@ -44,6 +44,12 @@ function getCheckoutExpressPaymentMethods(req, res, next) {
           AdyenHelper.getCustomer(req.currentCustomer),
           countryCode,
           shopperEmail,
+          [
+            constants.PAYMENTMETHODS.APPLEPAY,
+            constants.PAYMENTMETHODS.AMAZONPAY,
+            constants.PAYMENTMETHODS.GOOGLEPAY,
+            constants.PAYMENTMETHODS.PAYPAL,
+          ],
         );
     req.session.privacyCache.set(
       `expressPaymentMethods_${countryCode}`,

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/adyenGetPaymentMethods.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/adyenGetPaymentMethods.js
@@ -27,7 +27,13 @@ const blockedPayments = require('*/cartridge/adyen/config/blockedPaymentMethods.
 const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
 
 // eslint-disable-next-line complexity
-function getMethods(paymentAmount, customer, countryCode, shopperEmail) {
+function getMethods(
+  paymentAmount,
+  customer,
+  countryCode,
+  shopperEmail,
+  allowedPaymentMethods,
+) {
   try {
     const paymentMethodsRequest = {
       merchantAccount: AdyenConfigs.getAdyenMerchantAccount(),
@@ -47,6 +53,10 @@ function getMethods(paymentAmount, customer, countryCode, shopperEmail) {
 
     if (shopperEmail) {
       paymentMethodsRequest.shopperEmail = shopperEmail;
+    }
+
+    if (allowedPaymentMethods) {
+      paymentMethodsRequest.allowedPaymentMethods = allowedPaymentMethods;
     }
 
     // check logged in shopper for oneClick


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
The isAvailable promise was blocking the rendering of some payment methods
- What existing problem does this pull request solve?
Rendering 

## Tested scenarios
Description of tested scenarios:
- CashApp and Amazon payrender

**Fixed issue**:  SFI-1232