### PR TITLE
Remove quotes from adyen payment method custom field

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/__tests__/adyenHelper.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/__tests__/adyenHelper.test.js
@@ -38,8 +38,8 @@ describe('savePaymentDetails', () => {
   it('should set Adyen_paymentMethod from paymentMethod', () => {
     result.paymentMethod = { type: 'mc' };
     savePaymentDetails(paymentInstrument, order, result);
-    expect(paymentInstrument.paymentTransaction.custom.Adyen_paymentMethod).toBe(JSON.stringify('mc'));
-    expect(order.custom.Adyen_paymentMethod).toBe(JSON.stringify('mc'));
+    expect(paymentInstrument.paymentTransaction.custom.Adyen_paymentMethod).toBe('mc');
+    expect(order.custom.Adyen_paymentMethod).toBe('mc');
   });
 
   it('should set the credit card token if not already exists', () => {

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
@@ -695,11 +695,8 @@ const adyenHelperObj = {
         result.additionalData.paymentMethod;
       order.custom.Adyen_paymentMethod = result.additionalData.paymentMethod;
     } else if (result.paymentMethod) {
-      paymentInstrument.paymentTransaction.custom.Adyen_paymentMethod =
-        JSON.stringify(result.paymentMethod.type);
-      order.custom.Adyen_paymentMethod = JSON.stringify(
-        result.paymentMethod.type,
-      );
+      paymentInstrument.paymentTransaction.custom.Adyen_paymentMethod = result.paymentMethod.type;
+      order.custom.Adyen_paymentMethod = result.paymentMethod.type;
     }
 
     // For authenticated shoppers we are setting the token on other place already


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
No need for quotes as part of payment method type
- What existing problem does this pull request solve?
Show proper payment method variant in business manager

## Tested scenarios
Description of tested scenarios:
- Paypal
- iDEAL
- Cards

**Fixed issue**:  SFI-1184