### PR TITLE
Close googlepay modal after authorisation

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/__tests__/checkoutConfiguration.test.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/__tests__/checkoutConfiguration.test.js
@@ -204,7 +204,7 @@ describe('Checkout Configuration', () => {
         spy();
       });
       store.selectedMethod = 'paywithgoogle';
-      paywithgoogle.onSubmit({ data: {} });
+      paywithgoogle.onSubmit({ data: {} }, null, { resolve: jest.fn(), reject: jest.fn() });
       expect(spy).toBeCalledTimes(1);
       expect(submitButton.disabled).toBeFalsy();
     });

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/paymentMethodsConfiguration/googlePay/googlePayConfig.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/paymentMethodsConfiguration/googlePay/googlePayConfig.js
@@ -9,16 +9,12 @@ class GooglePayConfig {
   }
 
   onSubmit = (state, component, actions) => {
-    if (state.isValid) {
-      this.helpers.assignPaymentMethodValue();
-      document.querySelector('button[value="submit-payment"]').disabled = false;
-      document.querySelector('button[value="submit-payment"]').click();
-      actions.resolve({
-        resultCode: 'Pending',
-      });
-    } else {
-      actions.reject();
-    }
+    this.helpers.assignPaymentMethodValue();
+    document.querySelector('button[value="submit-payment"]').disabled = false;
+    document.querySelector('button[value="submit-payment"]').click();
+    actions.resolve({
+      resultCode: 'Pending',
+    });
   };
 
   getConfiguration = () => ({


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Close google pay modal when doing the payment
- What existing problem does this pull request solve?
Do not block the payment

## Tested scenarios
Description of tested scenarios:
- Google Pay

**Fixed issue**:  SFI-1261