### PR TITLE
[SFI-1163] Added the case management handling in webhooks

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/config/constants.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/config/constants.js
@@ -147,6 +147,7 @@ module.exports = {
   POS_ABORT_REASON: {
     MERCHANT_ABORT: 'MerchantAbort',
   },
+  FRAUD_STATUS_AMBER: 'AMBER',
 
   MERCHANT_APPLICATION_NAME: 'adyen-salesforce-commerce-cloud',
   EXTERNAL_PLATFORM_NAME: 'SalesforceCommerceCloud',

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/webhooks/handleCustomObject.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/webhooks/handleCustomObject.js
@@ -130,7 +130,7 @@ function handle(customObj) {
         // Or if the payment method belongs to adyen payment processors
         const paymentInstruments = order.getPaymentInstruments();
         const webhookData = JSON.parse(customObj.custom.Adyen_log);
-        const fraudResultType = webhookData["additionalData.fraudResultType"];
+        const fraudResultType = webhookData['additionalData.fraudResultType'];
         for (const pi in paymentInstruments) {
           if (
             [
@@ -168,22 +168,28 @@ function handle(customObj) {
             );
           } else {
             // This if scenario can be true when shopper authorised a payment and then pressed the back button on browser
-            if (order.status.value === Order.ORDER_STATUS_FAILED && amountPaid === totalAmount) {
+            if (
+              order.status.value === Order.ORDER_STATUS_FAILED &&
+              amountPaid === totalAmount
+            ) {
               OrderMgr.undoFailOrder(order);
-              order.trackOrderChange('Authorisation webhook received for failed order, moving order status to CREATED');
+              order.trackOrderChange(
+                'Authorisation webhook received for failed order, moving order status to CREATED',
+              );
             }
             if (fraudResultType === constants.FRAUD_STATUS_AMBER) {
-              order.trackOrderChange('Order sent for manual review in Adyen Customer Area');
-            }
-            else {
+              order.trackOrderChange(
+                'Order sent for manual review in Adyen Customer Area',
+              );
+            } else {
               const placeOrderResult = placeOrder(order);
               if (!placeOrderResult.error) {
-				markOrderAsPaid(order);
-				AdyenLogs.info_log(
-					`Order ${order.orderNo} updated to status PAID.`,
-				);
-				result.SubmitOrder = true;
-			  }
+                markOrderAsPaid(order);
+                AdyenLogs.info_log(
+                  `Order ${order.orderNo} updated to status PAID.`,
+                );
+                result.SubmitOrder = true;
+              }
             }
           }
           order.custom.Adyen_eventCode = customObj.custom.eventCode;
@@ -254,7 +260,7 @@ function handle(customObj) {
         ) {
           const placeOrderResult = placeOrder(order);
           if (!placeOrderResult.error) {
-			markOrderAsPaid(order);
+            markOrderAsPaid(order);
             AdyenLogs.info_log(`Order ${order.orderNo} placed and closed`);
           }
         }
@@ -286,23 +292,25 @@ function handle(customObj) {
         }
         break;
       case 'MANUAL_REVIEW_ACCEPT':
-        order.trackOrderChange('Manual review is accepted in Adyen Customer Area, placing the order');
-		const placeOrderResult = placeOrder(order);
-		if (!placeOrderResult.error) {
-			markOrderAsPaid(order);
-			AdyenLogs.info_log(
-				`Order ${order.orderNo} updated to status PAID.`,
-			);
-			result.SubmitOrder = true;
-		}
-		break;
+        order.trackOrderChange(
+          'Manual review is accepted in Adyen Customer Area, placing the order',
+        );
+        const placeOrderResult = placeOrder(order);
+        if (!placeOrderResult.error) {
+          markOrderAsPaid(order);
+          AdyenLogs.info_log(`Order ${order.orderNo} updated to status PAID.`);
+          result.SubmitOrder = true;
+        }
+        break;
       case 'MANUAL_REVIEW_REJECT':
-        order.trackOrderChange('Manual review is not accepted in Adyen Customer Area, failing the order');
+        order.trackOrderChange(
+          'Manual review is not accepted in Adyen Customer Area, failing the order',
+        );
         order.setPaymentStatus(Order.PAYMENT_STATUS_NOTPAID);
         Transaction.wrap(() => {
           OrderMgr.failOrder(order, false);
         });
-		break;
+        break;
       default:
         AdyenLogs.info_log(
           `Order ${order.orderNo} received unhandled status ${customObj.custom.eventCode}`,

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/webhooks/handleCustomObject.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/webhooks/handleCustomObject.js
@@ -172,19 +172,19 @@ function handle(customObj) {
               OrderMgr.undoFailOrder(order);
               order.trackOrderChange('Authorisation webhook received for failed order, moving order status to CREATED');
             }
-			if (fraudResultType === 'AMBER'){
-				order.trackOrderChange('Order sent for manual review in Adyen Customer Area');
-			}
-			else{
-				const placeOrderResult = placeOrder(order);
-				if (!placeOrderResult.error) {
+            if (fraudResultType === constants.FRAUD_STATUS_AMBER) {
+              order.trackOrderChange('Order sent for manual review in Adyen Customer Area');
+            }
+            else {
+              const placeOrderResult = placeOrder(order);
+              if (!placeOrderResult.error) {
 				markOrderAsPaid(order);
 				AdyenLogs.info_log(
 					`Order ${order.orderNo} updated to status PAID.`,
 				);
 				result.SubmitOrder = true;
-				}
-			}
+			  }
+            }
           }
           order.custom.Adyen_eventCode = customObj.custom.eventCode;
           order.custom.Adyen_value = amountPaid.toString();

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/webhooks/handleNotify.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/webhooks/handleNotify.js
@@ -91,6 +91,8 @@ function notify(notificationData) {
       case 'OFFER_CLOSED':
       case 'PENDING':
       case 'CAPTURE':
+      case 'MANUAL_REVIEW_ACCEPT':
+      case 'MANUAL_REVIEW_REJECT':
       case 'DONATION':
         customObj.custom.updateStatus = 'PROCESS';
         AdyenLogs.info_log(


### PR DESCRIPTION

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Enabling case management webhooks in SFCC.
- What existing problem does this pull request solve?
It allows to process case management webhooks and update the order statuses accordingly.

## Tested scenarios
Description of tested scenarios:
- `AUTHORISATION`
- `MANUAL_REVIEW_ACCEPTED`
- `MANUAL_REVIEW_REJECTED`

**Fixed issue**:  SFI-1163
