### PR TITLE
[SFI-1268] Remove sending duplicate confirmation email

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/__tests__/placeOrder.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/__tests__/placeOrder.test.js
@@ -34,10 +34,8 @@ describe('Checkout Services', () => {
   });
   it('should not process payment and return json response at end of file when there is no action', () => {
     session.privacy.orderNo = null;
-    const COHelpers = require('*/cartridge/scripts/checkout/checkoutHelpers');
     adyenHelpers.handlePayments.mockImplementationOnce(() => ({error: false}));
     placeOrder.call({ emit: jest.fn() }, req, res, jest.fn());
-    expect(COHelpers.sendConfirmationEmail).toBeCalledTimes(1);
     expect(res.json.mock.calls).toMatchSnapshot();
   });
   it('should attempt to cache orderNumber after order creation', () => {

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/placeOrder.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/placeOrder.js
@@ -218,10 +218,6 @@ function placeOrder(req, res, next) {
         });
     }
 
-    if (order.getCustomerEmail()) {
-        COHelpers.sendConfirmationEmail(order, req.locale.id);
-    }
-
     clearForms.clearForms();
     if (mainPaymentInstrument) {
         clearForms.clearPaymentTransactionData(mainPaymentInstrument);


### PR DESCRIPTION


<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Sending the confirmation email only through webhooks handlers
- What existing problem does this pull request solve?
Sending duplicate confirmation emails

## Tested scenarios
Description of tested scenarios:
- Card payments

**Fixed issue**:  SFI-1268
