### PR TITLE
fix(server): fixed syntax error to comply with salesforce commerce cloud code definition

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/webhooks/__tests__/notify.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/webhooks/__tests__/notify.test.js
@@ -9,7 +9,7 @@ beforeEach(() => {
   notify = adyen.notify;
   jest.clearAllMocks();
   req = {};
-  res = { render: jest.fn(), status: jest.fn(() => res)};
+  res = { render: jest.fn(), setStatusCode: jest.fn(), json: jest.fn()};
 });
 
 afterEach(() => {

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/webhooks/notify.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/webhooks/notify.js
@@ -22,8 +22,9 @@ function notify(req, res, next) {
   const hmacKey = AdyenConfigs.getAdyenHmacKey();
   const isHmacValid = handleHmacVerification(hmacKey, req);
   if (!status || !isHmacValid) {
-    res.status(403).render('/adyen/error');
-    return {};
+    res.setStatusCode(403);
+    res.render('/adyen/error');
+    return this.done(req, res);
   }
   Transaction.begin();
   const notificationResult = handleNotify.notify(req.form);
@@ -31,7 +32,8 @@ function notify(req, res, next) {
     Transaction.commit();
     res.render('/notify');
   } else {
-    res.status(403).render('/notifyError', {
+    res.setStatusCode(403);
+    res.render('/notifyError', {
       errorMessage: notificationResult.errorMessage,
     });
     Transaction.rollback();


### PR DESCRIPTION
## Summary
Following the cartridge upgrade for a customer leveraging Salesforce Commerce Cloud, we detected a server-side error in the logs after go-live, indicating a scripting failure.

<img width="1548" height="757" alt="Screenshot 2025-08-07 at 12 06 52 PM" src="https://github.com/user-attachments/assets/51dbb146-6799-41a2-b0a8-20d45ee56f11" />


## Tested scenarios

1. If the handle notification function returns an unsuccessful result.
2. If the authentication check for the notification webhook fails.

Reference to the SFRA repository:
1. storefront-reference-architecture/cartridges/modules/server/response.js [render](https://github.com/SalesforceCommerceCloud/storefront-reference-architecture/blob/1cb2b329fa281333403bb2681b939e727aee809a/cartridges/modules/server/response.js#L59) function definition;
2. storefront-reference-architecture/cartridges/modules/server/response.js [setStatusCode](https://github.com/SalesforceCommerceCloud/storefront-reference-architecture/blob/1cb2b329fa281333403bb2681b939e727aee809a/cartridges/modules/server/response.js#L162) function definition;

