### PR TITLE
[SFI-1306] Added endpoint for calculating product price in pdp

### DIFF
--- a/jest/__mocks__/dw/catalog/ProductMgr.js
+++ b/jest/__mocks__/dw/catalog/ProductMgr.js
@@ -1,0 +1,9 @@
+module.exports = {
+  getProduct: jest.fn(),
+  getVariant: jest.fn(),
+  getVariants: jest.fn(),
+  getVariationModel: jest.fn(),
+  getAvailabilityModel: jest.fn(),
+  getPriceModel: jest.fn(),
+  getPriceTable: jest.fn(),
+};

--- a/jest/sfccCartridgeMocks.js
+++ b/jest/sfccCartridgeMocks.js
@@ -25,6 +25,14 @@ jest.mock(
 );
 
 jest.mock(
+  '*/cartridge/scripts/helpers/pricing',
+  () => ({
+    getPromotionPrice: jest.fn(),
+  }),
+  { virtual: true },
+);
+
+jest.mock(
   '*/cartridge/adyen/scripts/expressPayments/createTemporaryBasket',
   () => jest.fn(),
   { virtual: true },

--- a/jest/sfccPathSetup.js
+++ b/jest/sfccPathSetup.js
@@ -501,6 +501,13 @@ jest.mock(
 );
 
 jest.mock(
+  '*/cartridge/adyen/scripts/expressPayments/calculatePrice',
+  () =>
+    require('../src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/calculatePrice'),
+  { virtual: true },
+);
+
+jest.mock(
   '*/cartridge/adyen/analytics/analyticsService',
   () =>
     require('../src/cartridges/int_adyen_SFRA/cartridge/adyen/analytics/analyticsService'),

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/commons/index.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/commons/index.js
@@ -65,3 +65,20 @@ module.exports.createTemporaryBasket = async function createTemporaryBasket() {
     },
   });
 };
+
+/**
+ * Makes an ajax call to the controller function calculatePrice
+ */
+module.exports.calculateProductPrice = async function calculateProductPrice(
+  productId,
+  quantity,
+) {
+  return httpClient({
+    method: 'POST',
+    url: window.productPriceCalculateUrl,
+    data: {
+      pid: productId,
+      quantity,
+    },
+  });
+};

--- a/src/cartridges/app_adyen_SFRA/cartridge/templates/default/adyen/adyenExpressMetadata.isml
+++ b/src/cartridges/app_adyen_SFRA/cartridge/templates/default/adyen/adyenExpressMetadata.isml
@@ -19,6 +19,7 @@
    window.showConfirmationAction = "${URLUtils.https('Adyen-ShowConfirmationPaymentFromComponent')}";
    window.returnUrl = "${URLUtils.https('Cart-Show')}";
    window.createTemporaryBasketUrl = "${URLUtils.https('Adyen-CreateTemporaryBasket')}";
+   window.productPriceCalculateUrl = "${URLUtils.https('Adyen-CalculatePrice')}";
    window.fractionDigits = "${AdyenHelper.getFractionDigits()}"
 
    window.expressMethodsOrder = "${AdyenConfigs.getExpressPaymentsOrder()}";

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/__tests__/calculatePrice.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/__tests__/calculatePrice.test.js
@@ -1,9 +1,4 @@
 /* eslint-disable global-require */
-
-jest.mock('dw/catalog/ProductMgr');
-jest.mock('*/cartridge/scripts/helpers/pricing');
-jest.mock('*/cartridge/adyen/logs/adyenCustomLogs');
-
 const ProductMgr = require('dw/catalog/ProductMgr');
 const priceHelper = require('*/cartridge/scripts/helpers/pricing');
 const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/__tests__/calculatePrice.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/__tests__/calculatePrice.test.js
@@ -1,0 +1,310 @@
+/* eslint-disable global-require */
+
+jest.mock('dw/catalog/ProductMgr');
+jest.mock('*/cartridge/scripts/helpers/pricing');
+jest.mock('*/cartridge/adyen/logs/adyenCustomLogs');
+
+const ProductMgr = require('dw/catalog/ProductMgr');
+const priceHelper = require('*/cartridge/scripts/helpers/pricing');
+const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
+
+const calculatePrice = require('../calculatePrice');
+
+describe('calculatePrice', () => {
+  let req;
+  let res;
+  let next;
+  let mockProduct;
+  let mockPriceModel;
+  let mockPriceTable;
+  let mockPrice;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    req = {
+      form: {
+        pid: 'test-product-id',
+        quantity: 2,
+      },
+    };
+
+    res = {
+      json: jest.fn(),
+    };
+
+    next = jest.fn();
+
+    mockPrice = {
+      value: 10.99,
+      currencyCode: 'USD',
+      multiply: jest.fn().mockReturnValue({
+        value: 21.98,
+        currencyCode: 'USD',
+      }),
+    };
+
+    mockPriceTable = {
+      quantities: [
+        { getValue: () => 1 },
+        { getValue: () => 5 },
+        { getValue: () => 10 },
+      ],
+      getQuantities: jest.fn().mockReturnValue([
+        { getValue: () => 1 },
+        { getValue: () => 5 },
+        { getValue: () => 10 },
+      ]),
+      getPrice: jest.fn().mockReturnValue(mockPrice),
+    };
+
+    mockPriceModel = {
+      getPrice: jest.fn().mockReturnValue(mockPrice),
+      getPriceTable: jest.fn().mockReturnValue(mockPriceTable),
+    };
+
+    mockProduct = {
+      master: false,
+      variationGroup: false,
+      bundle: false,
+      getPriceModel: jest.fn().mockReturnValue(mockPriceModel),
+      variationModel: {
+        variants: [],
+      },
+    };
+    ProductMgr.getProduct = jest.fn().mockReturnValue(mockProduct);
+    priceHelper.getPromotionPrice = jest.fn().mockReturnValue(null);
+  });
+
+  describe('validateProduct', () => {
+    it('should return error when pid is missing', () => {
+      req.form.pid = '';
+      calculatePrice(req, res, next);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: true,
+      });
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should return error when product is not found', () => {
+      ProductMgr.getProduct.mockReturnValue(null);   
+      calculatePrice(req, res, next);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: true,
+      });
+      expect(next).toHaveBeenCalled();
+    });
+  });
+
+  describe('getProductForPricing', () => {
+    it('should return original product when no variants', () => {
+      calculatePrice(req, res, next);
+      expect(mockProduct.getPriceModel).toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        totalAmount: {
+          value: 21.98,
+          currencyCode: 'USD',
+        },
+      });
+    });
+
+    it('should select available variant when product has variants', () => {
+      const mockVariant = {
+        ...mockProduct,
+        availabilityModel: { availability: 5 },
+        getPriceModel: jest.fn().mockReturnValue(mockPriceModel),
+      };
+      mockProduct.master = true;
+      mockProduct.variationModel.variants = [mockVariant];
+      calculatePrice(req, res, next);
+      expect(mockVariant.getPriceModel).toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        totalAmount: {
+          value: 21.98,
+          currencyCode: 'USD',
+        },
+      });
+    });
+
+    it('should select first variant when no available variants', () => {
+      const mockVariant = {
+        ...mockProduct,
+        availabilityModel: { availability: 0 },
+        getPriceModel: jest.fn().mockReturnValue(mockPriceModel),
+      };
+      mockProduct.master = true;
+      mockProduct.variationModel.variants = [mockVariant];
+      calculatePrice(req, res, next);
+      expect(mockVariant.getPriceModel).toHaveBeenCalled();
+    });
+  });
+
+  describe('calculateProductPrice', () => {
+    it('should use standard pricing when no tiered pricing', () => {
+      mockPriceTable.quantities = [{ getValue: () => 1 }];
+      mockPriceTable.getQuantities.mockReturnValue([{ getValue: () => 1 }]);
+      calculatePrice(req, res, next);
+      expect(mockPriceModel.getPrice).toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        totalAmount: {
+          value: 21.98,
+          currencyCode: 'USD',
+        },
+      });
+    });
+
+    it('should use tiered pricing when multiple quantity tiers exist', () => {
+      req.form.quantity = 7;
+      const tierPrice = {
+        value: 8.99,
+        currencyCode: 'USD',
+        multiply: jest.fn().mockReturnValue({
+          value: 62.93,
+          currencyCode: 'USD',
+        }),
+      };
+
+      const expectedQuantityTier = { getValue: () => 5 };
+      mockPriceTable.getQuantities.mockReturnValue([
+        { getValue: () => 1 },
+        expectedQuantityTier,
+        { getValue: () => 10 },
+      ]);
+      mockPriceTable.getPrice.mockReturnValue(tierPrice);
+      calculatePrice(req, res, next);
+      expect(mockPriceTable.getPrice).toHaveBeenCalledWith(expectedQuantityTier);
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        totalAmount: {
+          value: 62.93,
+          currencyCode: 'USD',
+        },
+      });
+    });
+
+    it('should fallback to standard pricing when no tier matches', () => {
+      mockPriceTable.quantities = [{ getValue: () => 1 }];
+      mockPriceTable.getQuantities.mockReturnValue([{ getValue: () => 1 }]);
+      calculatePrice(req, res, next);
+      expect(mockPriceModel.getPrice).toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        totalAmount: {
+          value: 21.98,
+          currencyCode: 'USD',
+        },
+      });
+    });
+  });
+
+  describe('getFinalUnitPrice', () => {
+    it('should use promotional price when available and lower', () => {
+      const promotionalPrice = {
+        value: 7.99,
+        currencyCode: 'USD',
+        available: true,
+        multiply: jest.fn().mockReturnValue({
+          value: 15.98,
+          currencyCode: 'USD',
+        }),
+      };
+      priceHelper.getPromotionPrice.mockReturnValue(promotionalPrice);
+      calculatePrice(req, res, next);
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        totalAmount: {
+          value: 15.98,
+          currencyCode: 'USD',
+        },
+      });
+    });
+
+    it('should use base price when promotional price is not available', () => {
+      const promotionalPrice = {
+        value: 7.99,
+        currencyCode: 'USD',
+        available: false,
+      };
+      priceHelper.getPromotionPrice.mockReturnValue(promotionalPrice);
+      calculatePrice(req, res, next);
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        totalAmount: {
+          value: 21.98,
+          currencyCode: 'USD',
+        },
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    it('should return error when price model is not available', () => {
+      mockProduct.getPriceModel.mockReturnValue(null);
+      calculatePrice(req, res, next);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: true,
+      });
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should return error when price is not available', () => {
+      mockPriceTable.quantities = [{ getValue: () => 1 }];
+      mockPriceTable.getQuantities.mockReturnValue([{ getValue: () => 1 }]);
+      mockPriceModel.getPrice.mockReturnValue(null);
+      calculatePrice(req, res, next);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: true,
+      });
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should handle exceptions and log errors', () => {
+      const error = new Error('Test error');
+      ProductMgr.getProduct.mockImplementation(() => {
+        throw error;
+      });
+      calculatePrice(req, res, next);
+      expect(AdyenLogs.error_log).toHaveBeenCalledWith(
+        'An error occurred while calculating the product price',
+        error,
+      );
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: true,
+      });
+      expect(next).toHaveBeenCalled();
+    });
+  });
+
+  describe('quantity handling', () => {
+    it('should default quantity to 1 when not provided', () => {
+      delete req.form.quantity;
+      calculatePrice(req, res, next);
+      expect(mockPrice.multiply).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('bundle products', () => {
+    it('should handle bundle products correctly', () => {
+      mockProduct.bundle = true;
+
+      calculatePrice(req, res, next);
+
+      expect(mockProduct.getPriceModel).toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        totalAmount: {
+          value: 21.98,
+          currencyCode: 'USD',
+        },
+      });
+    });
+  });
+});

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/calculatePrice.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/calculatePrice.js
@@ -1,0 +1,188 @@
+const ProductMgr = require('dw/catalog/ProductMgr');
+const priceHelper = require('*/cartridge/scripts/helpers/pricing');
+const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
+
+/**
+ * Validate product exists and is available
+ */
+function validateProduct(pid) {
+  if (!pid) {
+    return { error: true };
+  }
+
+  const product = ProductMgr.getProduct(pid);
+  if (!product) {
+    return { error: true };
+  }
+
+  return { product };
+}
+
+/**
+ * Check if product has variants
+ */
+function hasVariants(product) {
+  return (
+    (product.master || product.variationGroup) &&
+    product.variationModel.variants.length > 0
+  );
+}
+
+/**
+ * Find first available variant
+ */
+function findAvailableVariant(variants) {
+  for (let i = 0; i < variants.length; i++) {
+    const variant = variants[i];
+    if (variant.availabilityModel.availability > 0) {
+      return variant;
+    }
+  }
+  return variants[0];
+}
+
+/**
+ * Get appropriate product for pricing (handle variants)
+ */
+function getProductForPricing(product) {
+  if (hasVariants(product)) {
+    const [variants] = [product.variationModel.variants];
+    return findAvailableVariant(variants);
+  }
+  return product;
+}
+
+/**
+ * Check if product has tiered pricing
+ */
+function hasTieredPricing(priceTable) {
+  return (
+    priceTable && priceTable.quantities && priceTable.quantities.length > 1
+  );
+}
+
+/**
+ * Find quantity tier for given quantity
+ */
+function findQuantityTier(quantities, qty) {
+  let selectedQuantity = null;
+  for (let i = 0; i < quantities.length; i++) {
+    const tierQty = quantities[i].getValue();
+    if (qty >= tierQty) {
+      selectedQuantity = quantities[i];
+    }
+  }
+  return selectedQuantity;
+}
+
+/**
+ * Calculate price based on quantity (handle tiered pricing)
+ */
+function calculateProductPrice(priceModel, qty) {
+  const priceTable = priceModel.getPriceTable();
+
+  if (hasTieredPricing(priceTable)) {
+    const quantities = priceTable.getQuantities();
+    const selectedQuantity = findQuantityTier(quantities, qty);
+    return selectedQuantity
+      ? priceTable.getPrice(selectedQuantity)
+      : priceModel.getPrice();
+  }
+
+  return priceModel.getPrice();
+}
+
+/**
+ * Get final unit price including promotions
+ */
+function getFinalUnitPrice(product, basePrice) {
+  const promotionalPrice = priceHelper.getPromotionPrice(product, null, null);
+  return promotionalPrice &&
+    promotionalPrice.available &&
+    promotionalPrice.value < basePrice.value
+    ? promotionalPrice
+    : basePrice;
+}
+
+/**
+ * Handle price calculation response
+ */
+function sendPriceResponse(res, next, product, price, qty) {
+  const unitPrice = getFinalUnitPrice(product, price);
+  const totalAmount = unitPrice.multiply(qty);
+
+  res.json({
+    success: true,
+    totalAmount: {
+      value: totalAmount.value,
+      currencyCode: totalAmount.currencyCode,
+    },
+  });
+  return next();
+}
+
+/**
+ * Handle error response
+ */
+function sendErrorResponse(res, next) {
+  res.json({ success: false, error: true });
+  return next();
+}
+
+/**
+ * Process price calculation for validated product
+ */
+function processPriceCalculation(product, qty, res, next) {
+  const priceModel = product.getPriceModel();
+
+  if (!priceModel) {
+    AdyenLogs.error_log(
+      'Price model not available for product',
+      product.ID || 'unknown',
+    );
+    return sendErrorResponse(res, next);
+  }
+
+  const price = calculateProductPrice(priceModel, qty);
+
+  if (!price) {
+    AdyenLogs.error_log(
+      'Price not available for product',
+      product.ID || 'unknown',
+    );
+    return sendErrorResponse(res, next);
+  }
+
+  return sendPriceResponse(res, next, product, price, qty);
+}
+
+/**
+ * Calculate product total price based on product ID
+ */
+function calculatePrice(req, res, next) {
+  try {
+    const { pid, quantity = 1 } = req.form;
+
+    const validation = validateProduct(pid);
+    if (validation.error) {
+      AdyenLogs.error_log(
+        'Product validation failed',
+        pid ? 'Product not found' : 'Product ID is required',
+      );
+      return sendErrorResponse(res, next);
+    }
+
+    const product = getProductForPricing(validation.product);
+    const qty = parseInt(quantity, 10) || 1;
+
+    return processPriceCalculation(product, qty, res, next);
+  } catch (error) {
+    AdyenLogs.error_log(
+      'An error occurred while calculating the product price',
+      error,
+    );
+    return sendErrorResponse(res, next);
+  }
+}
+
+module.exports = calculatePrice;

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/index.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/index.js
@@ -22,6 +22,7 @@ const handleCheckoutReview = require('*/cartridge/adyen/scripts/expressPayments/
 const validatePaymentDataFromRequest = require('*/cartridge/adyen/utils/validatePaymentData');
 const createTemporaryBasket = require('*/cartridge/adyen/scripts/expressPayments/createTemporaryBasket');
 const saveExpressPaymentData = require('*/cartridge/adyen/scripts/expressPayments/paypal/saveExpressPaymentData');
+const calculatePrice = require('*/cartridge/adyen/scripts/expressPayments/calculatePrice');
 
 module.exports = {
   getCheckoutPaymentMethods,
@@ -48,4 +49,5 @@ module.exports = {
   createTemporaryBasket,
   getConnectedTerminals,
   saveExpressPaymentData,
+  calculatePrice,
 };

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/Adyen.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/Adyen.js
@@ -230,6 +230,13 @@ server.post(
   adyen.createTemporaryBasket,
 );
 
+server.post(
+  'CalculatePrice',
+  server.middleware.https,
+  csrf.validateRequest,
+  adyen.calculatePrice,
+);
+
 function getExternalPlatformVersion() {
   return EXTERNAL_PLATFORM_VERSION;
 }


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Loading the apple pay modale in pdp with product price immediately, instead of 0 amount which gets updated after couple of secs.
- What existing problem does this pull request solve?
Apple pay modale in PDP renders with product price.

## Tested scenarios
Description of tested scenarios:
- Apple pay transactions
- Products:
   - Standard
   - Tiered
   - Promotions
   - Bundles

**Fixed issue**:  SFI-1306
