### PR TITLE
[SFI-1363] Post auth hook inside the cartrdige

### DIFF
--- a/jest/sfccPathSetup.js
+++ b/jest/sfccPathSetup.js
@@ -543,6 +543,13 @@ jest.mock(
 );
 
 jest.mock(
+  '*/cartridge/adyen/scripts/hooks/payment/postAuthorizationHandling',
+  () =>
+    require('../src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/hooks/payment/postAuthorizationHandling'),
+  { virtual: true },
+);
+
+jest.mock(
   '*/cartridge/adyen/utils/klarnaHelper',
   () =>
     require('../src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/klarnaHelper'),

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/hooks.json
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/hooks.json
@@ -23,6 +23,10 @@
 		{
 			"name": "app.payment.pre.auth",
 			"script": "./hooks/payment/preAuthorizationHandling"
+		},
+		{
+			"name": "app.payment.post.auth",
+			"script": "./hooks/payment/postAuthorizationHandling"
 		}
 	]
 }

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/hooks/payment/postAuthorizationHandling.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/hooks/payment/postAuthorizationHandling.js
@@ -1,0 +1,13 @@
+// Dummy implementation
+/**
+ * This function is to handle the post payment authorization customizations
+ * @param {Object} result - the payment response
+ */
+// eslint-disable-next-line
+function postAuthorization(result) {
+  return { error: false };
+}
+
+module.exports = {
+  postAuthorization,
+};

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/placeOrder.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout_services/placeOrder.js
@@ -162,16 +162,6 @@ function placeOrder(req, res, next) {
     }
     /* ### Custom Adyen cartridge end ### */
 
-    // Handle custom processing post authorization
-    var options = {
-        req: req,
-        res: res
-    };
-    var postAuthCustomizations = hooksHelper('app.post.auth', 'postAuthorization', handlePaymentResult, order, options, require('*/cartridge/scripts/hooks/postAuthorizationHandling').postAuthorization);
-    if (postAuthCustomizations && Object.prototype.hasOwnProperty.call(postAuthCustomizations, 'error')) {
-        res.json(postAuthCustomizations);
-        return next();
-    }
     if (handlePaymentResult.error) {
         res.json({
             error: true,


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Having the post auth hook as part of cartridge.
- What existing problem does this pull request solve?
Introduced a post auth hooks which triggers after `/payments` or `/payments/details` call.

## Tested scenarios
Description of tested scenarios:
- Card payments ( 3ds + no 3ds )
- Redirect
- Payment from Component

**Fixed issue**:  SFI-1363
