### PR TITLE
[SFI-1380] Show adyen as a payment option in CSC

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/hooks.json
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/hooks.json
@@ -27,6 +27,10 @@
 		{
 			"name": "app.payment.post.auth",
 			"script": "./hooks/payment/postAuthorizationHandling"
-		}
-	]
+		},
+        {
+          "name": "dw.ocapi.shop.basket.payment_methods.modifyGETResponse",
+          "script": "./hooks/payment/applicablePaymentMethods"
+        }
+    ]
 }

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/hooks/payment/applicablePaymentMethods.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/hooks/payment/applicablePaymentMethods.js
@@ -1,0 +1,10 @@
+function modifyGETResponse(paymentMethodsResult) {
+  if (request.clientId === 'dw.csc') {
+    paymentMethodsResult.applicablePaymentMethods =
+      paymentMethodsResult.applicablePaymentMethods
+        .toArray()
+        .filter((paymentMethod) => paymentMethod.id === 'AdyenComponent');
+  }
+}
+
+exports.modifyGETResponse = modifyGETResponse;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Override payment methods hook to show AdyenComponent as payment in CSC
- What existing problem does this pull request solve?
Making payments in CSC using Adyen

## Tested scenarios
Description of tested scenarios:
- Render adyen payment method in CSC

**Fixed issue**:  SFI-396
