### PR TITLE
Improving the way on how signature is cleaned

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/clearForms.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/clearForms.js
@@ -55,7 +55,6 @@ function clearAdyenBasketData(basket) {
 function clearPaymentTransactionData(paymentInstrument) {
   Transaction.wrap(() => {
     paymentInstrument.paymentTransaction.custom.Adyen_authResult = null;
-    paymentInstrument.paymentTransaction.custom.Adyen_merchantSig = null;
   });
 }
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/webhooks/handleCustomObject.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/webhooks/handleCustomObject.js
@@ -153,6 +153,7 @@ function handle(customObj) {
             // Move adyen log request to order payment transaction
             paymentInstruments[pi].paymentTransaction.custom.Adyen_log =
               customObj.custom.Adyen_log;
+            paymentInstruments[pi].paymentTransaction.custom.Adyen_merchantSig = null;
           }
         }
         if (customObj.custom.success === 'true') {


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Moving signature cleaning logic to webhooks processing.
- What existing problem does this pull request solve?
Making sure signature is always available during redirect back for some payment methods.

## Tested scenarios
Description of tested scenarios:
- Redirect payment methods

**Fixed issue**:  SFI-1405
