### PR TITLE
[SFI-1421] SFRA 5 place order button is not clickable for payment methods requiring a review page.

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/CheckoutServices.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/CheckoutServices.js
@@ -4,9 +4,12 @@ server.extend(module.superModule);
 
 const placeOrder = require('*/cartridge/controllers/middlewares/checkout_services/placeOrder');
 const submitCustomer = require('*/cartridge/controllers/middlewares/checkout_services/submitCustomer');
+const AdyenConfigs = require('*/cartridge/adyen/utils/adyenConfigs');
 
 server.prepend('PlaceOrder', server.middleware.https, placeOrder);
 
-server.prepend('SubmitCustomer', server.middleware.https, submitCustomer);
+if (AdyenConfigs.getAdyenSFRA6Compatibility() === true) {
+  server.prepend('SubmitCustomer', server.middleware.https, submitCustomer);
+}
 
 module.exports = server.exports();


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Place order button is not clickable for payment methods requiring a review page in SFRA 5.
- What existing problem does this pull request solve?
It prepends `SubmitCustomer` controller only for SFRA 6, 7 as that was the root cause of the issue.

## Tested scenarios
Description of tested scenarios:
- SFRA 5, 6, 7

**Fixed issue**:  SFI-1421
