### PR TITLE
[SFI-1425] Adding the bm toggle for paypal express on pdp

### DIFF
--- a/src/cartridges/bm_adyen/cartridge/static/default/js/adyenSettings.js
+++ b/src/cartridges/bm_adyen/cartridge/static/default/js/adyenSettings.js
@@ -56,6 +56,11 @@ const expressPaymentMethods = [
         checked: window.isPayPalExpressEnabled,
       },
       {
+        name: 'PayPalExpress_Pdp_Enabled',
+        text: 'Product details page',
+        checked: window.isPayPalExpressOnPdpEnabled,
+      },
+      {
         name: 'PayPalExpress_ReviewPage_Enabled',
         text: 'Order review page',
         checked: window.isPayPalExpressReviewPageEnabled,

--- a/src/cartridges/bm_adyen/cartridge/templates/default/adyenSettings/settingCards/epmSettings.isml
+++ b/src/cartridges/bm_adyen/cartridge/templates/default/adyenSettings/settingCards/epmSettings.isml
@@ -13,6 +13,7 @@
     window.isGooglePayExpressOnPdpEnabled = ${AdyenConfigs.isGooglePayExpressOnPdpEnabled() || false};
     window.isAmazonPayEnabled = ${AdyenConfigs.isAmazonPayExpressEnabled() || false};
     window.isPayPalExpressEnabled = ${AdyenConfigs.isPayPalExpressEnabled() || false};
+    window.isPayPalExpressOnPdpEnabled = ${AdyenConfigs.isPayPalExpressOnPdpEnabled() || false};
     window.isPayPalExpressReviewPageEnabled = ${AdyenConfigs.isPayPalExpressReviewPageEnabled() || false};
     window.expressMethodsOrder = "${AdyenConfigs.getExpressPaymentsOrder()}";
 </script>


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Adding a toggle for enabling disabling paypal express on PDP.
- What existing problem does this pull request solve?
It allows enabling/disabling paypal express on pdp from Adyen settings config page.


## Tested scenarios
Description of tested scenarios:
- PayPal express PDP enablement/disablement

**Fixed issue**:  SFI-1425
