### PR TITLE
[SFI-1439] Failure scenario not properly handled for giftcards and payments without action

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/partialPayments/cancelPartialPaymentOrder.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/partialPayments/cancelPartialPaymentOrder.js
@@ -11,33 +11,53 @@ const clearForms = require('*/cartridge/adyen/utils/clearForms');
 const setErrorType = require('*/cartridge/adyen/logs/setErrorType');
 const { AdyenError } = require('*/cartridge/adyen/logs/adyenError');
 
+/**
+ * Helper function to cancel partial payment order and refund gift cards
+ * @param {dw.order.Basket} basket - The current basket
+ * @returns {Object} Response from Adyen API
+ * @throws {AdyenError} If cancellation fails
+ */
+function cancelPartialPaymentOrderHelper(basket) {
+  if (!basket || !basket.custom.partialPaymentOrderData) {
+    return null;
+  }
+
+  const { order } = JSON.parse(basket.custom.partialPaymentOrderData);
+
+  const cancelOrderRequest = {
+    merchantAccount: AdyenConfigs.getAdyenMerchantAccount(),
+    order,
+  };
+
+  const response =
+    adyenCheckout.doCancelPartialPaymentOrderCall(cancelOrderRequest);
+
+  if (response.resultCode === constants.RESULTCODES.RECEIVED) {
+    Transaction.wrap(() => {
+      collections.forEach(basket.getPaymentInstruments(), (item) => {
+        if (item.custom.adyenPartialPaymentsOrder) {
+          basket.removePaymentInstrument(item);
+        }
+      });
+      clearForms.clearAdyenBasketData(basket);
+    });
+    session.privacy.giftCardResponse = null;
+    session.privacy.partialPaymentAmounts = null;
+    session.privacy.giftCardBalance = null;
+  } else {
+    throw new AdyenError(`received resultCode ${response.resultCode}`);
+  }
+
+  return response;
+}
+
 function cancelPartialPaymentOrder(req, res, next) {
   try {
     const currentBasket = BasketMgr.getCurrentBasket();
-    const { order } = JSON.parse(currentBasket.custom.partialPaymentOrderData);
+    const response = cancelPartialPaymentOrderHelper(currentBasket);
 
-    const cancelOrderRequest = {
-      merchantAccount: AdyenConfigs.getAdyenMerchantAccount(),
-      order,
-    };
-
-    const response =
-      adyenCheckout.doCancelPartialPaymentOrderCall(cancelOrderRequest);
-
-    if (response.resultCode === constants.RESULTCODES.RECEIVED) {
-      Transaction.wrap(() => {
-        collections.forEach(currentBasket.getPaymentInstruments(), (item) => {
-          if (item.custom.adyenPartialPaymentsOrder) {
-            currentBasket.removePaymentInstrument(item);
-          }
-        });
-        clearForms.clearAdyenBasketData(currentBasket);
-      });
-      session.privacy.giftCardResponse = null;
-      session.privacy.partialPaymentAmounts = null;
-      session.privacy.giftCardBalance = null;
-    } else {
-      throw new AdyenError(`received resultCode ${response.resultCode}`);
+    if (!response) {
+      throw new AdyenError('No partial payment order data found');
     }
 
     const amount = {
@@ -62,3 +82,5 @@ function cancelPartialPaymentOrder(req, res, next) {
 }
 
 module.exports = cancelPartialPaymentOrder;
+module.exports.cancelPartialPaymentOrderHelper =
+  cancelPartialPaymentOrderHelper;


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Fixing the failure scenario for giftcards in combination with a no 3ds card.
- What existing problem does this pull request solve?
Shopper is able to fix the wrong card data and continue paying with giftcards


## Tested scenarios
Description of tested scenarios:
- Giftcards + no 3DS cards

**Fixed issue**:  SFI-1439
