### PR TITLE
[SFI-1464] Destroying previous instances of PayPal express component

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/express/shipping/expressPayments.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/express/shipping/expressPayments.js
@@ -142,7 +142,10 @@ async function renderPayPalButtonListener(e, response) {
   const paypalComponent = await paypal.getComponent();
 
   // This is a hack to destroy the previous paypal component as PayPal does not support multiple components on the same page
-  if (window.paypal) {
+  if (
+    window.paypal &&
+    typeof window.paypal.__internal_destroy__ === 'function'
+  ) {
     window.paypal.__internal_destroy__();
   }
 


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
PayPal does not support multiple components on the same page, and especially in SFRA5 the SDK throws errors most of the time.
- What existing problem does this pull request solve?
It destroys the previous instances of PayPal express when rendering on the shipping page

## Tested scenarios
Description of tested scenarios:
- PayPal on cart page
- PayPal on mini-cart page
- PayPal on PDP page

**Fixed issue**:  SFI-1464