### PR TITLE
Business Manager Orders:  PSP reference linking for partial payment orders

### DIFF
--- a/src/cartridges/bm_adyen/cartridge/templates/default/order/PaymentInstrumentInfo_Adyen_Component.isml
+++ b/src/cartridges/bm_adyen/cartridge/templates/default/order/PaymentInstrumentInfo_Adyen_Component.isml
@@ -12,6 +12,11 @@
 		var adyenAction = JSON.parse(paymentInstrument.custom.adyenAction);
 		var adyenPaymentMethod = paymentInstrument.custom.adyenPaymentMethod;
 	}
+	var mode : String = dw.system.Site.getCurrent().getCustomPreferenceValue("Adyen_Mode");
+	var urlPrefixType : String = 'test';
+	if (mode == 'LIVE') {
+		urlPrefixType = 'live';
+	}
 </isscript>
 <BR><BR>
 
@@ -26,22 +31,32 @@
 		</tr>
 	</thead>
 	<tbody>
-		<tr>
-		    <td class='infobox_title'>PSP reference</td>
-		    <td class='infobox_item'>
-		        <isscript>
-	                    var mode : String = dw.system.Site.getCurrent().getCustomPreferenceValue("Adyen_Mode");
-	                    var urlPrefixType : String = 'test';
-	                    if (mode == 'LIVE') {
-	                        urlPrefixType = 'live';
-	                    }
-			</isscript>
-			<A target='new' HREF='https://ca-${urlPrefixType}.adyen.com/ca/ca/accounts/showTx.shtml?pspReference=${order.custom.Adyen_pspReference}&txType=Payment'>
-			    <isprint value="${order.custom.Adyen_pspReference}">
-	                </A>
-	            </td>
-	        </tr>
-		<tr><td class='infobox_title'>Payment Method</td><td class='infobox_item'><isprint value="${order.custom.Adyen_paymentMethod}"></td></tr>
+		<isif condition="${order.getPaymentInstruments().size() > 1}">
+			<isloop items="${order.getPaymentInstruments()}" var="paymentInstrument" status="piStatus">
+				<tr>
+					<isif condition="${paymentInstrument.paymentTransaction.custom.Adyen_pspReference != null}">
+						<td class='infobox_title'>PSP reference</td>
+						<td class='infobox_item'>
+							<A target='new' HREF='https://ca-${urlPrefixType}.adyen.com/ca/ca/accounts/showTx.shtml?pspReference=${paymentInstrument.paymentTransaction.custom.Adyen_pspReference}&txType=Payment'>
+								<isprint value="${paymentInstrument.paymentTransaction.custom.Adyen_pspReference}">
+							</A>
+						</td>
+						<td class='infobox_item'><isprint value="${paymentInstrument.custom.adyenPaymentMethod}"></td>
+					</isif>
+				</tr>
+			</isloop>
+		<iselse/>
+			<tr>
+				<td class='infobox_title'>PSP reference</td>
+				<td class='infobox_item'>
+					<A target='new' HREF='https://ca-${urlPrefixType}.adyen.com/ca/ca/accounts/showTx.shtml?pspReference=${order.custom.Adyen_pspReference}&txType=Payment'>
+						<isprint value="${order.custom.Adyen_pspReference}">
+					</A>
+				</td>
+			</tr>
+			<tr><td class='infobox_title'>Payment Method</td><td class='infobox_item'><isprint value="${order.custom.Adyen_paymentMethod}"></td></tr>
+		</isif>
+		
 		<tr><td class='infobox_title'>Eventcode</td><td class='infobox_item'><isprint value="${order.custom.Adyen_eventCode}"></td></tr>
 		<isif condition="${adyenAdditionalPaymentData != null}">
 			<isloop items="${adyenAdditionalPaymentData}" var="additionalItem" status="loopstate">


### PR DESCRIPTION
Show both PSP reference links for partial payment orders

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
For partial payment orders, the PSP reference used for links in Business Manager was resolved from the order level, resulting in only the last transaction’s PSP reference being displayed and linked.

<img width="1264" height="1536" alt="Screenshot 2025-12-19 at 07 12 38" src="https://github.com/user-attachments/assets/792530d7-9070-434c-9944-193272e978f7" />

This change updates the PSP reference resolution to be transaction-based, so each payment transaction exposes its own PSP reference. This ensures correct linking for all payment instruments involved in a partial payment order.
<img width="1762" height="1492" alt="Screenshot 2025-12-19 at 08 01 03" src="https://github.com/user-attachments/assets/b529d426-d9ad-4704-a6f5-19e5a226c6bd" />

## Tested scenarios
- Credit Card + SVS partial payment order
- Verified that each transaction displays and links to its own PSP reference in Business Manager
- Verified no behavior change for single-payment orders

**Fixed issue**:  <!-- #-prefixed issue number -->
