### PR TITLE
[SFI-1483] Removing the default value for ratepay id

### DIFF
--- a/metadata/site_import/meta/system-objecttype-extensions.xml
+++ b/metadata/site_import/meta/system-objecttype-extensions.xml
@@ -326,7 +326,6 @@
                 <mandatory-flag>false</mandatory-flag>
                 <externally-managed-flag>false</externally-managed-flag>
                 <min-length>0</min-length>
-                <default-value>oj9GsQ</default-value>
             </attribute-definition>
             <attribute-definition attribute-id="AdyenOneClickEnabled">
                 <display-name xml:lang="x-default">Store shopper details: one-click</display-name>


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
The ratepay script will run always since we prefill a dummy ratepay id in the metadata field. 
- What existing problem does this pull request solve?
By removing the dummy value, the rate pay script will trigger only if merchants populate a value for it in BM.

## Tested scenarios
Description of tested scenarios:
- RatePay value filling

**Fixed issue**:  SFI-1483
