### PR TITLE
[SFI-1496] Cancelling giftcard on paymentFromComponent failures

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/paymentFromComponent.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/paymentFromComponent.js
@@ -12,6 +12,9 @@ const AdyenConfigs = require('*/cartridge/adyen/utils/adyenConfigs');
 const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
 const GiftCardsHelper = require('*/cartridge/adyen/utils/giftCardsHelper');
 const setErrorType = require('*/cartridge/adyen/logs/setErrorType');
+const {
+  cancelPartialPaymentOrderHelper,
+} = require('*/cartridge/adyen/scripts/partialPayments/cancelPartialPaymentOrder');
 
 const expressMethods = [
   constants.PAYMENTMETHODS.APPLEPAY,
@@ -130,6 +133,13 @@ function handleCancellation(res, next, reqDataObj) {
     reqDataObj.orderToken,
   );
   failOrder(order);
+  const currentBasket = BasketMgr.getCurrentBasket();
+  const giftCardsAdded = currentBasket.custom?.adyenGiftCards
+    ? JSON.parse(currentBasket.custom.adyenGiftCards)
+    : null;
+  if (giftCardsAdded) {
+    cancelPartialPaymentOrderHelper(currentBasket);
+  }
   res.redirect(URLUtils.url('Checkout-Begin', 'stage', 'placeOrder'));
   return next();
 }

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/validatePaymentData.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/validatePaymentData.js
@@ -12,9 +12,14 @@ function validateBasketAmount(currentBasket) {
   }
 }
 
+// eslint-disable-next-line complexity
 function validatePaymentDataFromRequest(req, res, next) {
   try {
-    const { isExpressPdp } = req.form?.data ? JSON.parse(req.form.data) : null;
+    const requestData = req.form?.data ? JSON.parse(req.form.data) : null;
+    if (requestData?.cancelTransaction) {
+      return next();
+    }
+    const { isExpressPdp } = requestData || {};
     const currentBasket = isExpressPdp
       ? BasketMgr.getTemporaryBasket(session.privacy.temporaryBasketId)
       : BasketMgr.getCurrentBasket();


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Giftcards not being automatically cancelled on paymentFromComponent
- What existing problem does this pull request solve?
Cancels giftcards if paymentFromComponent fails

## Tested scenarios
Description of tested scenarios:
- PayPal + giftcards
- Klarna + giftcards

**Fixed issue**:  SFI-1496
