### PR TITLE
[SFI-1529] Rerendering components with new amount in case of shipping methods change

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/index.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/index.js
@@ -294,6 +294,18 @@ function handlePaymentAction() {
       await overridePlaceOrderRequest(settings.url);
     }
   });
+
+  $(document).ajaxComplete(async (event, xhr, settings) => {
+    const isSelectShippingMethod =
+      settings.url &&
+      settings.url.includes('CheckoutShippingServices-SelectShippingMethod');
+    if (isSelectShippingMethod && xhr.status === 200) {
+      paymentMethodsResponse = await getPaymentMethods();
+      $('body').trigger('checkout:renderPaymentMethod', {
+        email: paymentMethodsResponse.shopperEmail,
+      });
+    }
+  });
 }
 
 function registerUpdateCheckoutView() {

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/paymentMethodsConfiguration/applePay/applePayConfig.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/paymentMethodsConfiguration/applePay/applePayConfig.js
@@ -1,8 +1,9 @@
 class ApplePayConfig {
-  constructor(helpers) {
+  constructor(helpers, amount) {
     this.showPayButton = true;
     this.buttonColor = 'black';
     this.helpers = helpers;
+    this.amount = amount;
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -33,6 +34,7 @@ class ApplePayConfig {
     return {
       showPayButton: this.showPayButton,
       buttonColor: this.buttonColor,
+      amount: this.amount,
       onAuthorized: this.onAuthorized,
       onSubmit: this.onSubmit,
     };

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/paymentMethodsConfiguration/index.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/paymentMethodsConfiguration/index.js
@@ -28,7 +28,7 @@ function getPaymentMethodsConfiguration(email, amount, AdyenPaymentMethods) {
   ).getConfig();
   const cashAppConfig = new CashAppConfig(helpers).getConfig();
   const upiConfig = new UpiConfig(helpers).getConfig();
-  const applePayConfig = new ApplePayConfig(helpers).getConfig();
+  const applePayConfig = new ApplePayConfig(helpers, amount).getConfig();
   const payPalConfig = new PayPalConfig(store, helpers).getConfig();
   const amazonPayConfig = new AmazonPayConfig(
     store,


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
In case of shipping method change, apple pay component does not reflect the new amount.
- What existing problem does this pull request solve?
Re-renders payment methods in case of shipping methods changes

## Tested scenarios
Description of tested scenarios:
- Apple Pay payments

**Fixed issue**:  SFI-1529
