### PR TITLE
fix[SFI-1584]: paypal gross pricing and shipping method selection improvements

### DIFF
--- a/jest/__mocks__/dw/order/TaxMgr.js
+++ b/jest/__mocks__/dw/order/TaxMgr.js
@@ -1,3 +1,5 @@
 export const getTaxJurisdictionID = jest.fn();
 export const getTaxRate = jest.fn();
 export const TAX_POLICY_GROSS = 0;
+export const TAX_POLICY_NET = 1;
+export let taxationPolicy = TAX_POLICY_NET; // default to net; override per test

--- a/src/cartridges/app_adyen_SFRA/cartridge/templates/default/adyen/adyenExpressMetadata.isml
+++ b/src/cartridges/app_adyen_SFRA/cartridge/templates/default/adyen/adyenExpressMetadata.isml
@@ -11,7 +11,7 @@
    window.areCartExpressPaymentsEnabled = "${AdyenConfigs.areExpressPaymentsEnabled()}";
    window.areExpressPaymentsEnabledOnPdp = "${AdyenConfigs.areExpressPaymentsEnabledOnPdp()}";
    window.areExpressPaymentsEnabledOnShipping = "${AdyenConfigs.areExpressPaymentsEnabledOnShipping()}";
-   window.sfra6Compatibility = ${pdict.AdyenConfigs.getAdyenSFRA6Compatibility()}; 
+   window.sfra6Compatibility = ${AdyenConfigs.getAdyenSFRA6Compatibility()};
 
    window.getExpressPaymentMethodsURL = "${URLUtils.https('Adyen-GetExpressPaymentMethods')}";
    window.shippingMethodsUrl = "${URLUtils.https('Adyen-ShippingMethods')}";

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/shippingMethods.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/shippingMethods.js
@@ -61,8 +61,12 @@ function callGetShippingMethods(req, res, next) {
         shipment,
         address,
       );
+      const selectedMethod = methods.find((method) => method.selected);
       Transaction.wrap(() => {
-        shippingHelper.selectShippingMethod(shipment);
+        shippingHelper.selectShippingMethod(
+          shipment,
+          selectedMethod?.ID || null,
+        );
         basketCalculationHelpers.calculateTotals(currentBasket);
       });
       if (methods && methods.length > 0) {

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/__tests__/paypalHelper.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/__tests__/paypalHelper.test.js
@@ -5,25 +5,34 @@ jest.mock('*/cartridge/adyen/utils/adyenHelper', () => {
   return {
     getCurrencyValueForApi: jest.fn(() => {
       return {
-        value: 1000
-      }
-    })
-  }
-})
+        value: 1000,
+      };
+    }),
+  };
+});
+jest.mock('dw/order/TaxMgr', () => ({
+  TAX_POLICY_GROSS: 0,
+  TAX_POLICY_NET: 1,
+  taxationPolicy: 1, // net by default; override per test
+}));
+const TaxMgr = require('dw/order/TaxMgr');
 
-const paypalHelper = require('../paypalHelper')
+const paypalHelper = require('../paypalHelper');
 const Money = require('dw/value/Money');
-const { createBillingAddress } = require("../../../../../../../jest/__mocks__/dw/order/BasketMgr");
+const AdyenHelper = require('*/cartridge/adyen/utils/adyenHelper');
+const {
+  createBillingAddress,
+} = require('../../../../../../../jest/__mocks__/dw/order/BasketMgr');
 describe('paypalHelper', () => {
   describe('getLineItems', () => {
-    let args,lineItem, result
+    let args, lineItem, result;
     beforeEach(() => {
       jest.clearAllMocks();
       args = (item) => ({
         Order: {
-          getAllLineItems: jest.fn(() => ([item]))
-        }
-      })
+          getAllLineItems: jest.fn(() => [item]),
+        },
+      });
 
       lineItem = {
         productName: 'test',
@@ -32,7 +41,7 @@ describe('paypalHelper', () => {
         getAdjustedTax: '1000',
         adjustedNetPrice: '10000',
         category: 'PHYSICAL_GOODS',
-      }
+      };
 
       result = {
         quantity: '1',
@@ -40,102 +49,248 @@ describe('paypalHelper', () => {
         itemCategory: 'PHYSICAL_GOODS',
         sku: '123',
         amountExcludingTax: '10000',
-        taxAmount: '1000'
-      }
-    })
+        taxAmount: '1000',
+      };
+    });
 
     afterEach(() => {
       jest.resetModules();
     });
 
     it('should return lineItems for paypal', () => {
-      const paypalLineItems = paypalHelper.getLineItems(args(lineItem))
-      expect(paypalLineItems[0]).toStrictEqual(result)
-    })
+      const paypalLineItems = paypalHelper.getLineItems(args(lineItem));
+      expect(paypalLineItems[0]).toStrictEqual(result);
+    });
 
     it('should return lineItems for paypal with default itemCategory when category is not as per paypal', () => {
-      const paypalLineItems = paypalHelper.getLineItems(args({...lineItem, category: 'TEST_GOODS'}))
+      const paypalLineItems = paypalHelper.getLineItems(
+        args({ ...lineItem, category: 'TEST_GOODS' }),
+      );
       expect(paypalLineItems[0]).toStrictEqual({
         quantity: '1',
         description: 'test',
         sku: '123',
         amountExcludingTax: '10000',
-        taxAmount: '1000'
-      })
-    })
+        taxAmount: '1000',
+      });
+    });
 
     it('should return no lineItems for paypal if order or basket is not defined', () => {
-
-      const paypalLineItems = paypalHelper.getLineItems({})
-      expect(paypalLineItems).toBeNull()
-    })
-  })
+      const paypalLineItems = paypalHelper.getLineItems({});
+      expect(paypalLineItems).toBeNull();
+    });
+  });
   describe('createPaypalUpdateOrderRequest', () => {
-    let pspReference, currentBasket, currentShippingMethods, paymentData, result;
+    let pspReference,
+      currentBasket,
+      currentShippingMethods,
+      paymentData,
+      result;
     beforeEach(() => {
       jest.clearAllMocks();
       pspReference = 'test';
       paymentData = 'test';
-      currentShippingMethods = [{
-        ID: '001',
-        displayName: 'test',
-        shippingCost: {
-          currencyCode: 'USD',
-          value: '10.00',
+      currentShippingMethods = [
+        {
+          ID: '001',
+          displayName: 'test',
+          shippingCost: {
+            currencyCode: 'USD',
+            value: '10.00',
+          },
+          selected: true,
         },
-        selected: true,
-      }]
+      ];
       currentBasket = {
         currencyCode: 'USD',
-      }
+        getTotalGrossPrice: jest.fn(() => ({ value: 1000 })),
+      };
 
       result = {
         pspReference: 'test',
         paymentData: 'test',
         amount: {
           currency: 'USD',
-          value: 1000
+          value: 1000,
         },
         taxTotal: {
           amount: {
             currency: 'USD',
-            value: 1000
-          }
-        },
-        deliveryMethods:[{
-          reference: '001',
-          description: 'test',
-          type: 'Shipping',
-          amount: {
-            currency: 'USD',
             value: 1000,
           },
-          selected: true,
-        }],
-      }
-
-    })
+        },
+        deliveryMethods: [
+          {
+            reference: '001',
+            description: 'test',
+            type: 'Shipping',
+            amount: {
+              currency: 'USD',
+              value: 1000,
+            },
+            selected: true,
+          },
+        ],
+      };
+    });
 
     it('should return UpdateOrderRequest object for paypal', () => {
-      Money.mockReturnValue(() => {return {value: 10, currency: 'TEST'}})
-      const paypalUpdateOrderRequest = paypalHelper.createPaypalUpdateOrderRequest(pspReference, currentBasket, currentShippingMethods, paymentData)
-      expect(paypalUpdateOrderRequest).toStrictEqual(result)
-    })
-  })
+      Money.mockReturnValue(() => {
+        return { value: 10, currency: 'TEST' };
+      });
+      const paypalUpdateOrderRequest =
+        paypalHelper.createPaypalUpdateOrderRequest(
+          pspReference,
+          currentBasket,
+          currentShippingMethods,
+          paymentData,
+        );
+      expect(paypalUpdateOrderRequest).toStrictEqual(result);
+    });
+
+    it('on a gross-price site should subtract shipping tax from taxTotal', () => {
+      TaxMgr.taxationPolicy = TaxMgr.TAX_POLICY_GROSS;
+
+      currentBasket = {
+        currencyCode: 'USD',
+        getTotalGrossPrice: jest.fn(() => ({ value: 122 })),
+        totalTax: { value: 12 },
+        shippingTotalTax: { value: 2 },
+      };
+
+      currentShippingMethods = [
+        {
+          ID: '001',
+          displayName: 'Ground',
+          shippingCost: { currencyCode: 'USD', value: 12 },
+          selected: true,
+        },
+        {
+          ID: '002',
+          displayName: 'Express',
+          shippingCost: { currencyCode: 'USD', value: 24 },
+          selected: false,
+        },
+      ];
+
+      AdyenHelper.getCurrencyValueForApi = jest.fn((money) => ({
+        value: money.value ?? money,
+      }));
+
+      const result = paypalHelper.createPaypalUpdateOrderRequest(
+        pspReference,
+        currentBasket,
+        currentShippingMethods,
+        paymentData,
+      );
+
+      // On gross sites, taxTotal should be totalTax - shippingTotalTax (12 - 2 = 10)
+      expect(result.taxTotal.amount.value).toBe(10);
+
+      // All methods use catalog pricing
+      expect(Money).toHaveBeenCalledWith(12, 'USD');
+      expect(Money).toHaveBeenCalledWith(24, 'USD');
+    });
+
+    it('on a net-price site should not modify taxTotal', () => {
+      TaxMgr.taxationPolicy = TaxMgr.TAX_POLICY_NET;
+
+      currentBasket = {
+        currencyCode: 'USD',
+        getTotalGrossPrice: jest.fn(() => ({ value: 120 })),
+        totalTax: { value: 10 },
+        shippingTotalTax: { value: 0 },
+      };
+
+      currentShippingMethods = [
+        {
+          ID: '001',
+          displayName: 'Ground',
+          shippingCost: { currencyCode: 'USD', value: 10 },
+          selected: true,
+        },
+        {
+          ID: '002',
+          displayName: 'Express',
+          shippingCost: { currencyCode: 'USD', value: 20 },
+          selected: false,
+        },
+      ];
+
+      AdyenHelper.getCurrencyValueForApi = jest.fn((money) => ({
+        value: money.value ?? money,
+      }));
+
+      const result = paypalHelper.createPaypalUpdateOrderRequest(
+        pspReference,
+        currentBasket,
+        currentShippingMethods,
+        paymentData,
+      );
+
+      // On net sites, taxTotal equals totalTax unchanged
+      expect(result.taxTotal.amount.value).toBe(10);
+
+      // All methods use catalog pricing
+      expect(Money).toHaveBeenCalledWith(10, 'USD');
+      expect(Money).toHaveBeenCalledWith(20, 'USD');
+    });
+
+    it('should ensure at least one delivery method is selected when none are marked', () => {
+      TaxMgr.taxationPolicy = TaxMgr.TAX_POLICY_NET;
+
+      currentBasket = {
+        currencyCode: 'USD',
+        getTotalGrossPrice: jest.fn(() => ({ value: 110 })),
+        totalTax: { value: 10 },
+        shippingTotalTax: { value: 0 },
+      };
+
+      currentShippingMethods = [
+        {
+          ID: '001',
+          displayName: 'Ground',
+          shippingCost: { currencyCode: 'USD', value: 10 },
+          selected: false,
+        },
+        {
+          ID: '002',
+          displayName: 'Express',
+          shippingCost: { currencyCode: 'USD', value: 20 },
+          selected: false,
+        },
+      ];
+
+      AdyenHelper.getCurrencyValueForApi = jest.fn((money) => ({
+        value: money.value ?? money,
+      }));
+
+      const result = paypalHelper.createPaypalUpdateOrderRequest(
+        pspReference,
+        currentBasket,
+        currentShippingMethods,
+        paymentData,
+      );
+
+      // First method should be auto-selected
+      expect(result.deliveryMethods[0].selected).toBe(true);
+      expect(result.deliveryMethods[1].selected).toBe(false);
+    });
+  });
   describe('setBillingAndShippingAddress', () => {
     let shopperDetails, billingAddress, shippingAddress;
     beforeEach(() => {
       jest.clearAllMocks();
       billingAddress = require('../../../../../../../jest/__mocks__/dw/order/BasketMgr');
       shopperDetails = {
-        shopperName:{
+        shopperName: {
           firstName: 'John',
-          lastName: 'Doe'
+          lastName: 'Doe',
         },
-        billingAddress:{
-          shopperName:{
+        billingAddress: {
+          shopperName: {
             firstName: 'John',
-            lastName: 'Doe'
+            lastName: 'Doe',
           },
           street: '123 Main St',
           city: 'City',
@@ -143,10 +298,10 @@ describe('paypalHelper', () => {
           stateOrProvince: 'State',
           country: 'United States',
         },
-        shippingAddress:{
-          shopperName:{
+        shippingAddress: {
+          shopperName: {
             firstName: 'John',
-            lastName: 'Doe'
+            lastName: 'Doe',
           },
           street: '123 Main St',
           city: 'City',
@@ -155,8 +310,8 @@ describe('paypalHelper', () => {
           country: 'United States',
         },
         telephoneNumber: '+1234567890',
-        shopperEmail: 'john@example.com'
-      }
+        shopperEmail: 'john@example.com',
+      };
     });
     afterEach(() => {
       jest.resetModules();
@@ -164,14 +319,16 @@ describe('paypalHelper', () => {
     it('should update billing and shipping address for current basket', () => {
       const currentBasket = BasketMgr.getCurrentBasket();
       paypalHelper.setBillingAndShippingAddress(currentBasket, shopperDetails);
-      expect(currentBasket.billingAddress.setFirstName).toHaveBeenCalledWith('John');
-    })
+      expect(currentBasket.billingAddress.setFirstName).toHaveBeenCalledWith(
+        'John',
+      );
+    });
     it('should set billing and shipping address if current basket has no billing Address', () => {
       const currentBasket = BasketMgr.getCurrentBasket();
-      currentBasket.billingAddress= '';
+      currentBasket.billingAddress = '';
       paypalHelper.setBillingAndShippingAddress(currentBasket, shopperDetails);
       expect(currentBasket.createBillingAddress).toHaveBeenCalled();
-    })
+    });
     it('should set billing and shipping address if current basket has no shipping Address', () => {
       const currentBasket = BasketMgr.getCurrentBasket();
       const createShippingAddress = jest.fn(() => ({
@@ -185,13 +342,12 @@ describe('paypalHelper', () => {
         setPhone: jest.fn(),
         setStateCode: jest.fn(),
       }));
-      currentBasket.getDefaultShipment= jest.fn(() => ({
-        createShippingAddress: createShippingAddress
+      currentBasket.getDefaultShipment = jest.fn(() => ({
+        createShippingAddress: createShippingAddress,
       }));
       paypalHelper.setBillingAndShippingAddress(currentBasket, shopperDetails);
       expect(currentBasket.getDefaultShipment).toHaveBeenCalled();
       expect(createShippingAddress).toHaveBeenCalled();
-    })
-  })
-})
-
+    });
+  });
+});

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
@@ -44,23 +44,23 @@ const COHelpers = require('*/cartridge/scripts/checkout/checkoutHelpers');
 const adyenHelperObj = {
   // Create the service config used to make calls to the Adyen Checkout API (used for all services)
   getService(service, reqMethod = 'POST') {
-       const adyenService = LocalServiceRegistry.createService(service, {
-        createRequest(svc, args) {
-          svc.setRequestMethod(reqMethod);
-          if (args) {
-            return args;
-          }
-          return null;
-        },
-        parseResponse(svc, client) {
-          return client;
-        },
-        filterLogMessage(msg) {
-          return msg;
-        },
-      });
-      AdyenLogs.info_log(`Successfully retrieve service with name ${service}`);
-      return adyenService;
+    const adyenService = LocalServiceRegistry.createService(service, {
+      createRequest(svc, args) {
+        svc.setRequestMethod(reqMethod);
+        if (args) {
+          return args;
+        }
+        return null;
+      },
+      parseResponse(svc, client) {
+        return client;
+      },
+      filterLogMessage(msg) {
+        return msg;
+      },
+    });
+    AdyenLogs.info_log(`Successfully retrieve service with name ${service}`);
+    return adyenService;
   },
 
   // returns SFCC customer object based on currentCustomer object
@@ -75,10 +75,13 @@ const adyenHelperObj = {
   },
 
   /**
-   * Returns shippingCost including taxes for a specific Shipment / ShippingMethod pair including the product level shipping cost if any
-   * @param {dw.order.ShippingMethod} shippingMethod - the default shipment of the current basket
-   * @param {dw.order.Shipment} shipment - a shipment of the current basket
-   * @returns {{currencyCode: String, value: String}} - Shipping Cost including taxes
+   * Returns shippingCost for a specific Shipment / ShippingMethod pair including
+   * the product level shipping cost if any.
+   * On gross-price sites the amount includes tax (per SFCC ShippingCost.getAmount()
+   * semantics); on net-price sites the amount excludes tax.
+   * @param {dw.order.ShippingMethod} shippingMethod
+   * @param {dw.order.Shipment} shipment
+   * @returns {{currencyCode: String, value: String}}
    */
   getShippingCost(shippingMethod, shipment) {
     const shipmentShippingModel =
@@ -94,9 +97,9 @@ const adyenHelperObj = {
         shippingMethod,
       )
         ? productShippingModel
-          .getShippingCost(shippingMethod)
-          .getAmount()
-          .multiply(productQuantity)
+            .getShippingCost(shippingMethod)
+            .getAmount()
+            .multiply(productQuantity)
         : new Money(0, product.getPriceModel().getPrice().getCurrencyCode());
       shippingCost = shippingCost.add(productShippingCost);
     });
@@ -302,16 +305,20 @@ const adyenHelperObj = {
       return false;
     }
 
-    const paymentInstruments = order.getPaymentInstruments(adyenHelperObj.getOrderMainPaymentInstrumentType(order));
+    const paymentInstruments = order.getPaymentInstruments(
+      adyenHelperObj.getOrderMainPaymentInstrumentType(order),
+    );
 
     if (!paymentInstruments.length) {
-        return false;
+      return false;
     }
 
     const paymentInstrument = paymentInstruments[0];
 
-    return AdyenConfigs.getAdyenGivingEnabled() &&
-           !!paymentInstrument.paymentTransaction.custom.Adyen_donationToken;
+    return (
+      AdyenConfigs.getAdyenGivingEnabled() &&
+      !!paymentInstrument.paymentTransaction.custom.Adyen_donationToken
+    );
   },
 
   // gets the ID for ratePay using the custom preference and the encoded session ID
@@ -345,9 +352,9 @@ const adyenHelperObj = {
   },
 
   isPayPalExpress(paymentMethod) {
-    return paymentMethod.type === 'paypal' &&
-      paymentMethod.subtype === 'express';
-
+    return (
+      paymentMethod.type === 'paypal' && paymentMethod.subtype === 'express'
+    );
   },
 
   // Get stored card token of customer saved card based on matched cardUUID
@@ -711,7 +718,8 @@ const adyenHelperObj = {
         result.additionalData.paymentMethod;
       order.custom.Adyen_paymentMethod = result.additionalData.paymentMethod;
     } else if (result.paymentMethod) {
-      paymentInstrument.paymentTransaction.custom.Adyen_paymentMethod = result.paymentMethod.type;
+      paymentInstrument.paymentTransaction.custom.Adyen_paymentMethod =
+        result.paymentMethod.type;
       order.custom.Adyen_paymentMethod = result.paymentMethod.type;
     }
 
@@ -977,7 +985,9 @@ const adyenHelperObj = {
 
     const resultObject = callResult.object;
     if (!resultObject || !resultObject.getText()) {
-      throw new AdyenError(`No correct response from ${serviceType} service call`);
+      throw new AdyenError(
+        `No correct response from ${serviceType} service call`,
+      );
     }
     return JSON.parse(resultObject.getText());
   },
@@ -995,7 +1005,7 @@ const adyenHelperObj = {
     } else {
       return COHelpers.createOrder(currentBasket);
     }
-  }
+  },
 };
 
 module.exports = adyenHelperObj;

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/paypalHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/paypalHelper.js
@@ -117,18 +117,20 @@ function createPaypalUpdateOrderRequest(
   // On gross sites, shipping costs already include tax, so we must subtract
   // the shipping tax from totalTax to prevent double-counting.
   // On net sites, shipping costs exclude tax, so totalTax is passed unchanged.
-  const totalTax = isGrossSite
-    ? {
-        currency: currentBasket.currencyCode,
-        value:
-          AdyenHelper.getCurrencyValueForApi(currentBasket.totalTax).value -
-          AdyenHelper.getCurrencyValueForApi(currentBasket.shippingTotalTax)
-            .value,
-      }
-    : {
-        currency: currentBasket.currencyCode,
-        value: AdyenHelper.getCurrencyValueForApi(currentBasket.totalTax).value,
-      };
+  let totalTaxValue;
+  if (isGrossSite) {
+    totalTaxValue =
+      AdyenHelper.getCurrencyValueForApi(currentBasket.totalTax).value -
+      AdyenHelper.getCurrencyValueForApi(currentBasket.shippingTotalTax).value;
+  } else {
+    totalTaxValue = AdyenHelper.getCurrencyValueForApi(
+      currentBasket.totalTax,
+    ).value;
+  }
+  const totalTax = {
+    currency: currentBasket.currencyCode,
+    value: totalTaxValue,
+  };
 
   // All delivery methods use the catalog shipping cost (gross on gross-price sites,
   // net on net-price sites). The selected method is determined by the shipment's

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/paypalHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/paypalHelper.js
@@ -20,6 +20,7 @@
  */
 const Money = require('dw/value/Money');
 const Transaction = require('dw/system/Transaction');
+const TaxMgr = require('dw/order/TaxMgr');
 const LineItemHelper = require('*/cartridge/adyen/utils/lineItemHelper');
 const AdyenHelper = require('*/cartridge/adyen/utils/adyenHelper');
 
@@ -58,7 +59,8 @@ function getLineItems({ Order: order, Basket: basket }, isExpress) {
       lineItemObject.amountExcludingTax = itemAmount.getValue().toFixed();
       // For paypal express tax amount could change based on shipping Address
       // so the tax amount in lineItem is excluded in the initial /Payments call.
-      // The final tax would be passed as tax_total in /paypalUpdateOrder call.
+      // The final tax is passed as tax_total in /paypalUpdateOrder. On gross-price sites,
+      // shipping tax is subtracted from tax_total to prevent double-counting.
       if (!isExpress) {
         lineItemObject.taxAmount = vatAmount.getValue().toFixed();
       }
@@ -102,21 +104,38 @@ function createPaypalUpdateOrderRequest(
   currentShippingMethods,
   paymentData,
 ) {
+  const isGrossSite = TaxMgr.taxationPolicy === TaxMgr.TAX_POLICY_GROSS;
+
   const totalGrossPrice = {
     currency: currentBasket.currencyCode,
-    value: AdyenHelper.getCurrencyValueForApi(currentBasket.totalGrossPrice)
-      .value,
+    value: AdyenHelper.getCurrencyValueForApi(
+      currentBasket.getTotalGrossPrice(),
+    ).value,
   };
 
-  const totalTax = {
-    currency: currentBasket.currencyCode,
-    value: AdyenHelper.getCurrencyValueForApi(currentBasket.totalTax).value,
-  };
+  // Validation rule: Original Amount + Shipping + Tax = New Amount
+  // On gross sites, shipping costs already include tax, so we must subtract
+  // the shipping tax from totalTax to prevent double-counting.
+  // On net sites, shipping costs exclude tax, so totalTax is passed unchanged.
+  const totalTax = isGrossSite
+    ? {
+        currency: currentBasket.currencyCode,
+        value:
+          AdyenHelper.getCurrencyValueForApi(currentBasket.totalTax).value -
+          AdyenHelper.getCurrencyValueForApi(currentBasket.shippingTotalTax)
+            .value,
+      }
+    : {
+        currency: currentBasket.currencyCode,
+        value: AdyenHelper.getCurrencyValueForApi(currentBasket.totalTax).value,
+      };
 
+  // All delivery methods use the catalog shipping cost (gross on gross-price sites,
+  // net on net-price sites). The selected method is determined by the shipment's
+  // current shipping method, which is applied in shippingMethods.js before calling this function.
   const deliveryMethods = currentShippingMethods.map((shippingMethod) => {
     const { currencyCode, value } = shippingMethod.shippingCost;
     const isSelected = shippingMethod.selected;
-
     return {
       reference: shippingMethod.ID,
       description: shippingMethod.displayName,
@@ -124,9 +143,7 @@ function createPaypalUpdateOrderRequest(
       amount: {
         currency: currencyCode,
         value: AdyenHelper.getCurrencyValueForApi(
-          isSelected
-            ? currentBasket.adjustedShippingTotalNetPrice
-            : new Money(value, currencyCode),
+          new Money(value, currencyCode),
         ).value,
       },
       selected: isSelected,
@@ -137,9 +154,6 @@ function createPaypalUpdateOrderRequest(
   const anySelected = deliveryMethods.some((method) => method.selected);
   if (!anySelected && deliveryMethods.length > 0) {
     deliveryMethods[0].selected = true;
-    deliveryMethods[0].amount.value = AdyenHelper.getCurrencyValueForApi(
-      currentBasket.adjustedShippingTotalNetPrice,
-    ).value;
   }
 
   return {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
  - PayPal validates that `Original Amount + Shipping + Tax = New Amount`
  - On gross-price sites, shipping costs returned by [getShippingCost()](cci:1://file:///Users/shani/workspace/adyen-salesforce-commerce-cloud/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js:76:2-109:3) already include tax
   - Previously, we were passing both gross shipping amounts AND the full `totalTax`, causing validation failures or incorrect pricing display in the PayPal lightbox
- What existing problem does this pull request solve?
  - Added `TaxMgr.taxationPolicy` detection to identify gross vs net sites
  - On gross sites: `totalTax = basket.totalTax - basket.shippingTotalTax`
  - On net sites: `totalTax = basket.totalTax` (unchanged)
  - Simplified delivery methods to use catalog pricing uniformly (removed selected/unselected price distinction)
  - Added clarifying comments explaining the validation logic

## Tested scenarios
Description of tested scenarios:
- Gross-price site: Shipping tax correctly subtracted from `taxTotal`
- Net-price site: `taxTotal` passed unchanged, behavior unaffected
- Auto-selection: First method selected when none are marked

**Fixed issue**: SFI-1584
