### PR TITLE
fix(SFI-1599): use basePrice for item amount in L2/L3 data and fix discount calculation

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/__tests__/adyenLevelTwoThreeData.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/__tests__/adyenLevelTwoThreeData.test.js
@@ -58,7 +58,7 @@ describe('getLineItems (Enhanced Scheme Data)', () => {
     });
 
     expect(result).toEqual({
-      'enhancedSchemeData.totalTaxAmount': 10,
+      'enhancedSchemeData.totalTaxAmount': 20,
       'enhancedSchemeData.customerReference': 'cust-9999',
       'enhancedSchemeData.itemDetailLine1.unitPrice': '50',
       'enhancedSchemeData.itemDetailLine1.totalAmount': 100,

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/__tests__/adyenLevelTwoThreeData.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/__tests__/adyenLevelTwoThreeData.test.js
@@ -17,7 +17,9 @@ jest.mock('*/cartridge/adyen/utils/lineItemHelper', () => ({
   isProductLineItem: jest.fn(() => false),
 }));
 
-const { getLineItems } = require('*/cartridge/adyen/scripts/payments/adyenLevelTwoThreeData');
+const {
+  getLineItems,
+} = require('*/cartridge/adyen/scripts/payments/adyenLevelTwoThreeData');
 const AdyenHelper = require('*/cartridge/adyen/utils/adyenHelper');
 
 describe('getLineItems (Enhanced Scheme Data)', () => {
@@ -26,7 +28,7 @@ describe('getLineItems (Enhanced Scheme Data)', () => {
     productID: 'SW1234567890X',
     quantityValue: 2,
     adjustedNetPrice: 100,
-	getAdjustedTax: 20,
+    getAdjustedTax: 20,
   };
 
   const createMockOrderOrBasket = (customerData = {}) => ({
@@ -49,17 +51,21 @@ describe('getLineItems (Enhanced Scheme Data)', () => {
 
   it('should return enhanced line item fields with tax, description, and commodity code', () => {
     const result = getLineItems({
-      Order: createMockOrderOrBasket({ registered: true, customerNo: 'cust-9999' }),
+      Order: createMockOrderOrBasket({
+        registered: true,
+        customerNo: 'cust-9999',
+      }),
     });
 
     expect(result).toEqual({
-      'enhancedSchemeData.totalTaxAmount': 10, 
+      'enhancedSchemeData.totalTaxAmount': 10,
       'enhancedSchemeData.customerReference': 'cust-9999',
-      'enhancedSchemeData.itemDetailLine1.unitPrice': '50', 
-      'enhancedSchemeData.itemDetailLine1.totalAmount': 100, 
+      'enhancedSchemeData.itemDetailLine1.unitPrice': '50',
+      'enhancedSchemeData.itemDetailLine1.totalAmount': 100,
       'enhancedSchemeData.itemDetailLine1.quantity': 2,
       'enhancedSchemeData.itemDetailLine1.unitOfMeasure': 'EAC',
-      'enhancedSchemeData.itemDetailLine1.commodityCode': 'mocked_comodity_code',
+      'enhancedSchemeData.itemDetailLine1.commodityCode':
+        'mocked_comodity_code',
       'enhancedSchemeData.itemDetailLine1.description': 'Super Widget',
       'enhancedSchemeData.itemDetailLine1.productCode': 'SW1234567890',
     });
@@ -68,10 +74,15 @@ describe('getLineItems (Enhanced Scheme Data)', () => {
   it('should truncate customerReference to 25 characters', () => {
     const longCustomerNo = 'very-long-customer-number-1234567890';
     const result = getLineItems({
-      Order: createMockOrderOrBasket({ registered: true, customerNo: longCustomerNo }),
+      Order: createMockOrderOrBasket({
+        registered: true,
+        customerNo: longCustomerNo,
+      }),
     });
 
-    expect(result['enhancedSchemeData.customerReference'].length).toBeLessThanOrEqual(25);
+    expect(
+      result['enhancedSchemeData.customerReference'].length,
+    ).toBeLessThanOrEqual(25);
   });
 
   it('should return null when no Order or Basket is passed', () => {
@@ -96,13 +107,15 @@ describe('getLineItems (Enhanced Scheme Data)', () => {
           toArray: () => [],
         }),
         getCustomer: () => ({
-          getID: () => null
+          getID: () => null,
         }),
         getCustomerNo: () => null,
       },
     });
 
-    expect(result['enhancedSchemeData.customerReference']).toBe('no-unique-ref');
+    expect(result['enhancedSchemeData.customerReference']).toBe(
+      'no-unique-ref',
+    );
   });
 
   it('should include discount amount when product has basePrice > adjustedPrice', () => {
@@ -110,17 +123,20 @@ describe('getLineItems (Enhanced Scheme Data)', () => {
     lineItemHelper.isProductLineItem.mockReturnValueOnce(true);
 
     AdyenHelper.getCurrencyValueForApi = jest.fn(() => ({
-      divide: jest.fn(() => ({
-        value: { toFixed: () => '10' },
-      })),
+      value: { toFixed: () => '20' },
     }));
 
+    // qty=2, basePrice=60/unit (line=120), adjustedPrice=100 (line total).
+    // Expected total line discount = 60*2 - 100 = 20.
     const discountedLineItem = {
       ...mockLineItem,
       basePrice: {
-        value: 120,
-        subtract: jest.fn((adjustedPrice) => ({
-          value: 20,
+        value: 60,
+        multiply: jest.fn(() => ({
+          value: 120,
+          subtract: jest.fn(() => ({
+            value: 20,
+          })),
         })),
       },
       adjustedPrice: {
@@ -145,8 +161,12 @@ describe('getLineItems (Enhanced Scheme Data)', () => {
       },
     });
 
-    expect(result['enhancedSchemeData.itemDetailLine1.discountAmount']).toBe('10');
+    // Total line discount (not per-unit). Adyen formula:
+    // totalAmount = quantity * unitPrice - discountAmount => 100 = 2 * 60 - 20
+    expect(result['enhancedSchemeData.itemDetailLine1.discountAmount']).toBe(
+      '20',
+    );
+    expect(result['enhancedSchemeData.itemDetailLine1.unitPrice']).toBe('60');
+    expect(result['enhancedSchemeData.itemDetailLine1.totalAmount']).toBe(100);
   });
-
-  
 });

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/adyenLevelTwoThreeData.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/adyenLevelTwoThreeData.js
@@ -33,12 +33,12 @@ function getShopperReference(orderOrBasket) {
   return orderNo || customer.getID() || 'no-unique-ref';
 }
 
-function getDiscountAmount(lineItem) {
+function getDiscountAmount(lineItem, quantity) {
   if (!LineItemHelper.isProductLineItem(lineItem)) return null;
   const { basePrice, adjustedPrice } = lineItem;
   if (!basePrice || !adjustedPrice) return null;
   // Total line discount = (per-unit basePrice * quantity) - adjustedPrice line total.
-  const baseTotal = basePrice.multiply(LineItemHelper.getQuantity(lineItem));
+  const baseTotal = basePrice.multiply(quantity);
   if (baseTotal.value <= adjustedPrice.value) return null;
   return AdyenHelper.getCurrencyValueForApi(
     baseTotal.subtract(adjustedPrice),
@@ -95,13 +95,13 @@ function processLineItem(acc, lineItem, index) {
   const description = LineItemHelper.getDescription(lineItem);
   const id = LineItemHelper.getId(lineItem);
   const quantity = LineItemHelper.getQuantity(lineItem);
+  const quantityNum = parseFloat(quantity) || 1;
   const lineAmount = LineItemHelper.getItemAmount(lineItem);
-  const vatAmount = LineItemHelper.getVatAmount(lineItem).divide(quantity);
-  const discountAmount = getDiscountAmount(lineItem);
+  const vatAmount = LineItemHelper.getVatAmount(lineItem);
+  const discountAmount = getDiscountAmount(lineItem, quantityNum);
   const commodityCode = AdyenConfigs.getAdyenLevel23CommodityCode();
   // Derive unitPrice from totalAmount = quantity * unitPrice - discountAmount.
   const totalAmount = parseFloat(lineAmount.value.toFixed());
-  const quantityNum = parseFloat(quantity);
   const discount = discountAmount ? parseFloat(discountAmount) : 0;
   const unitPrice = ((totalAmount + discount) / quantityNum).toFixed();
   const currentLineItem = buildEnhancedSchemeDataFields(

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/adyenLevelTwoThreeData.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/adyenLevelTwoThreeData.js
@@ -33,18 +33,16 @@ function getShopperReference(orderOrBasket) {
   return orderNo || customer.getID() || 'no-unique-ref';
 }
 
-function getDiscountAmount(lineItem, quantity) {
-  if (LineItemHelper.isProductLineItem(lineItem)) {
-    const { basePrice } = lineItem;
-    const { adjustedPrice } = lineItem;
-    if (basePrice && adjustedPrice && basePrice.value > adjustedPrice.value) {
-      const discountPerUnit = AdyenHelper.getCurrencyValueForApi(
-        basePrice.subtract(adjustedPrice),
-      ).divide(quantity);
-      return discountPerUnit.value.toFixed();
-    }
-  }
-  return null;
+function getDiscountAmount(lineItem) {
+  if (!LineItemHelper.isProductLineItem(lineItem)) return null;
+  const { basePrice, adjustedPrice } = lineItem;
+  if (!basePrice || !adjustedPrice) return null;
+  // Total line discount = (per-unit basePrice * quantity) - adjustedPrice line total.
+  const baseTotal = basePrice.multiply(LineItemHelper.getQuantity(lineItem));
+  if (baseTotal.value <= adjustedPrice.value) return null;
+  return AdyenHelper.getCurrencyValueForApi(
+    baseTotal.subtract(adjustedPrice),
+  ).value.toFixed();
 }
 
 function collectShippingLineItems(shipments) {
@@ -60,7 +58,7 @@ function collectShippingLineItems(shipments) {
 
 function buildEnhancedSchemeDataFields(
   index,
-  itemAmount,
+  unitPrice,
   quantity,
   totalAmount,
   commodityCode,
@@ -69,8 +67,7 @@ function buildEnhancedSchemeDataFields(
   discountAmount,
 ) {
   return {
-    [`enhancedSchemeData.itemDetailLine${index + 1}.unitPrice`]:
-      itemAmount.value.toFixed(),
+    [`enhancedSchemeData.itemDetailLine${index + 1}.unitPrice`]: unitPrice,
     [`enhancedSchemeData.itemDetailLine${index + 1}.totalAmount`]: totalAmount,
     [`enhancedSchemeData.itemDetailLine${index + 1}.quantity`]: quantity,
     [`enhancedSchemeData.itemDetailLine${index + 1}.unitOfMeasure`]: 'EAC',
@@ -98,17 +95,18 @@ function processLineItem(acc, lineItem, index) {
   const description = LineItemHelper.getDescription(lineItem);
   const id = LineItemHelper.getId(lineItem);
   const quantity = LineItemHelper.getQuantity(lineItem);
-  const itemAmount = LineItemHelper.getItemAmount(lineItem).divide(quantity);
+  const lineAmount = LineItemHelper.getItemAmount(lineItem);
   const vatAmount = LineItemHelper.getVatAmount(lineItem).divide(quantity);
-  const discountAmount = getDiscountAmount(lineItem, quantity);
+  const discountAmount = getDiscountAmount(lineItem);
   const commodityCode = AdyenConfigs.getAdyenLevel23CommodityCode();
-  const unitPrice = parseFloat(itemAmount.value.toFixed());
+  // Derive unitPrice from totalAmount = quantity * unitPrice - discountAmount.
+  const totalAmount = parseFloat(lineAmount.value.toFixed());
   const quantityNum = parseFloat(quantity);
   const discount = discountAmount ? parseFloat(discountAmount) : 0;
-  const totalAmount = quantityNum * unitPrice - discount;
+  const unitPrice = ((totalAmount + discount) / quantityNum).toFixed();
   const currentLineItem = buildEnhancedSchemeDataFields(
     index,
-    itemAmount,
+    unitPrice,
     quantity,
     totalAmount,
     commodityCode,


### PR DESCRIPTION


<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
  - use basePrice for item amount in L2/L3 data and fix discount calculation
 
- What existing problem does this pull request solve?
  - [getDiscountAmount](cci:1://file:///Users/shani/workspace/adyen-salesforce-commerce-cloud/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/adyenLevelTwoThreeData.js:35:0-45:1) now returns the **total line discount** using `(basePrice * quantity) - adjustedPrice`, so it is correct for any quantity.
  - [processLineItem](cci:1://file:///Users/shani/workspace/adyen-salesforce-commerce-cloud/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/adyenLevelTwoThreeData.js:100:0-131:1) now uses the adjusted line total (from [getItemAmount](cci:1://file:///Users/shani/workspace/adyen-salesforce-commerce-cloud/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/lineItemHelper.js:88:2-99:3)) as `totalAmount` and derives `unitPrice = (totalAmount + discountAmount) / quantity`, guaranteeing the Adyen formula always holds.

## Tested scenarios
Description of tested scenarios:
 - 3DS and no 3DS card flow

**Fixed issue**:  #SFI-1599
