### PR TITLE
[SFI-1536] Extend L2/L3 data support to applepay and googlepay payment methods

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/config/constants.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/config/constants.js
@@ -64,7 +64,7 @@ module.exports = {
     'clearpay',
   ],
 
-  L23_PAYMENT_METHODS: ['applepay', 'googlepay', 'scheme'],
+  L23_PAYMENT_METHODS: ['applepay', 'googlepay', 'paywithgoogle', 'scheme'],
 
   SERVICE: {
     PAYMENT: 'AdyenPayment',

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/config/constants.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/config/constants.js
@@ -64,6 +64,8 @@ module.exports = {
     'clearpay',
   ],
 
+  L23_PAYMENT_METHODS: ['applepay', 'googlepay', 'scheme'],
+
   SERVICE: {
     PAYMENT: 'AdyenPayment',
     PAYMENT_LINKS: 'AdyenPaymentLinks',

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/__tests__/adyenCheckout.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/__tests__/adyenCheckout.test.js
@@ -1,5 +1,8 @@
 const adyenCheckout = require('../adyenCheckout');
 const Logger = require('../../../../../../../../jest/__mocks__/dw/system/Logger');
+const AdyenConfigs = require('*/cartridge/adyen/utils/adyenConfigs');
+const AdyenHelper = require('*/cartridge/adyen/utils/adyenHelper');
+const adyenLevelTwoThreeData = require('*/cartridge/adyen/scripts/payments/adyenLevelTwoThreeData');
 
 describe('AdyenCheckout', () => {
     it('should not error when cached gift card amount and actual amount match', () => {
@@ -94,5 +97,88 @@ describe('AdyenCheckout', () => {
         };
         const testFn = () => {adyenCheckout.createPaymentRequest(args)};
         expect(testFn).toThrow("Cart has been edited after applying a gift card");
+    })
+
+    describe('L2/3 Data filtering with L23_PAYMENT_METHODS', () => {
+        let getLineItemsSpy;
+        const l23MockData = { 'enhancedSchemeData.totalTaxAmount': 10 };
+
+        function createArgs() {
+            return {
+                Order: {
+                    custom: {},
+                    setPaymentStatus: jest.fn(),
+                    setExportStatus: jest.fn(),
+                    getOrderNo: jest.fn(),
+                    getOrderToken: jest.fn(),
+                    getCustomerEmail: jest.fn(),
+                    getBillingAddress: jest.fn(),
+                    getDefaultShipment: jest.fn(),
+                    paymentInstrument: {
+                        custom: {
+                            adyenPaymentData: "{}",
+                        },
+                        paymentTransaction: {
+                            amount: {
+                                value: 1000,
+                                currencyCode: "EUR"
+                            }
+                        }
+                    },
+                },
+            };
+        }
+
+        beforeEach(() => {
+            getLineItemsSpy = jest.spyOn(adyenLevelTwoThreeData, 'getLineItems')
+                .mockReturnValue(l23MockData);
+            AdyenConfigs.getAdyenLevel23DataEnabled.mockReturnValue(true);
+        });
+
+        afterEach(() => {
+            getLineItemsSpy.mockRestore();
+            AdyenConfigs.getAdyenLevel23DataEnabled.mockReturnValue(false);
+            AdyenHelper.createAdyenRequestObject.mockReturnValue({
+                paymentMethod: { type: 'scheme' },
+            });
+        });
+
+        it('should add L2/3 data for scheme payment method', () => {
+            AdyenHelper.createAdyenRequestObject.mockReturnValue({
+                paymentMethod: { type: 'scheme' },
+            });
+            adyenCheckout.createPaymentRequest(createArgs());
+            expect(getLineItemsSpy).toHaveBeenCalled();
+        });
+
+        it('should add L2/3 data for applepay payment method', () => {
+            AdyenHelper.createAdyenRequestObject.mockReturnValue({
+                paymentMethod: { type: 'applepay' },
+            });
+            adyenCheckout.createPaymentRequest(createArgs());
+            expect(getLineItemsSpy).toHaveBeenCalled();
+        });
+
+        it('should add L2/3 data for googlepay payment method', () => {
+            AdyenHelper.createAdyenRequestObject.mockReturnValue({
+                paymentMethod: { type: 'googlepay' },
+            });
+            adyenCheckout.createPaymentRequest(createArgs());
+            expect(getLineItemsSpy).toHaveBeenCalled();
+        });
+
+        it('should not add L2/3 data for non-L23 payment method', () => {
+            AdyenHelper.createAdyenRequestObject.mockReturnValue({
+                paymentMethod: { type: 'ideal' },
+            });
+            adyenCheckout.createPaymentRequest(createArgs());
+            expect(getLineItemsSpy).not.toHaveBeenCalled();
+        });
+
+        it('should not add L2/3 data when Level23Data is disabled', () => {
+            AdyenConfigs.getAdyenLevel23DataEnabled.mockReturnValue(false);
+            adyenCheckout.createPaymentRequest(createArgs());
+            expect(getLineItemsSpy).not.toHaveBeenCalled();
+        });
     })
 })

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/adyenCheckout.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/adyenCheckout.js
@@ -163,7 +163,9 @@ function createPaymentRequest(args) {
   // L2/3 Data
   if (
     AdyenConfigs.getAdyenLevel23DataEnabled() &&
-    paymentMethodType.indexOf('scheme') > -1
+    constants.L23_PAYMENT_METHODS.some(
+      (pm) => paymentMethodType.indexOf(pm) > -1,
+    )
   ) {
     paymentRequest.additionalData = {
       ...paymentRequest.additionalData,


### PR DESCRIPTION

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
- Support L2/L3 enhanced scheme data for `applepay` and `googlepay` payment methods.
- What existing problem does this pull request solve?
- - Previously, L2/L3 enhanced scheme data was only attached to `scheme` (card) payments. This change extends L2/L3 data support to also include `applepay` and `googlepay` payment methods.


## Tested scenarios
Description of tested scenarios:
L2/L3 data for cards, applepay and googlepay

**Fixed issue**: #SFI-1536
