### PR TITLE
[SFI-1654] remove unused selected payment option input

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/templates/default/checkout/billing/paymentOptions.isml
+++ b/src/cartridges/app_adyen_SFRA/cartridge/templates/default/checkout/billing/paymentOptions.isml
@@ -17,10 +17,6 @@
 
 <iscomment> ### Custom Adyen cartridge start ### </iscomment>
 <fieldset>
-    <input type="hidden" class="form-control" id="selectedPaymentOption"
-           name="${pdict.forms.billingForm.paymentMethod.htmlName}"
-           value="paymentMethod">
-
     <isset name="creditFields" value="${pdict.forms.billingForm.creditCardFields}" scope="page"/>
     <iscomment> ### Custom Adyen cartridge end ### </iscomment>
 <div class="credit-card-selection-new" >


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Remove unused input
- What existing problem does this pull request solve?
Code clean up

## Tested scenarios
Description of tested scenarios:
- Render payment methods
- Card payments

**Fixed issue**:  SFI-1654
