### PR TITLE
fix(SFI-1657): handle empty installments configuration

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/paymentMethodsConfiguration/card/cardConfig.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/paymentMethodsConfiguration/card/cardConfig.js
@@ -21,9 +21,13 @@ class CardConfig {
     if (installmentLocales.indexOf(window.Configuration?.locale) < 0) {
       return;
     }
-    const installments = JSON.parse(
-      window.installments?.replace(/&quot;/g, '"'),
-    );
+    let installments;
+    try {
+      installments = JSON.parse(window.installments?.replace(/&quot;/g, '"'));
+    } catch (e) {
+      // Malformed or empty installments value; skip installments config.
+      return;
+    }
     if (installments?.length && this.amount) {
       const installmentOptions = {};
       installments.forEach((installment) => {

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout/__tests__/begin.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout/__tests__/begin.test.js
@@ -41,6 +41,15 @@ describe('Begin', () => {
     expect(viewData.adyen.installments).toBe('[]');
   });
 
+  it('should set installments to an empty array string when enabled but not configured', () => {
+    const AdyenConfigs = require('*/cartridge/adyen/utils/adyenConfigs');
+    AdyenConfigs.getAdyenInstallmentsEnabled.mockImplementationOnce(() => true);
+    AdyenConfigs.getCreditCardInstallments.mockImplementationOnce(() => null);
+    begin(req, res, jest.fn());
+    const viewData = res.setViewData.mock.calls[0][0];
+    expect(viewData.adyen.installments).toBe('[]');
+  });
+
   it('should not attempt to restore cart when no order number is cached', () =>{
     begin(req, res, jest.fn());
     expect(res.setViewData.mock.calls).toMatchSnapshot();

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout/__tests__/begin.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout/__tests__/begin.test.js
@@ -33,6 +33,14 @@ describe('Begin', () => {
     expect(res.setViewData.mock.calls).toMatchSnapshot();
   });
 
+  it('should set installments to an empty array string when disabled', () => {
+    const AdyenConfigs = require('*/cartridge/adyen/utils/adyenConfigs');
+    AdyenConfigs.getAdyenInstallmentsEnabled.mockImplementationOnce(() => false);
+    begin(req, res, jest.fn());
+    const viewData = res.setViewData.mock.calls[0][0];
+    expect(viewData.adyen.installments).toBe('[]');
+  });
+
   it('should not attempt to restore cart when no order number is cached', () =>{
     begin(req, res, jest.fn());
     expect(res.setViewData.mock.calls).toMatchSnapshot();

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout/begin.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout/begin.js
@@ -43,7 +43,7 @@ function getAdyenViewData() {
   const environment = AdyenHelper.getCheckoutEnvironment();
   const installments = AdyenConfigs.getAdyenInstallmentsEnabled()
     ? AdyenConfigs.getCreditCardInstallments()
-    : {};
+    : '[]';
   const adyenClientKey = AdyenConfigs.getAdyenClientKey();
   const googleMerchantID = AdyenConfigs.getGoogleMerchantID();
   const merchantAccount = AdyenConfigs.getAdyenMerchantAccount();

--- a/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout/begin.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/controllers/middlewares/checkout/begin.js
@@ -42,7 +42,7 @@ function getAdyenViewData() {
   const clientKey = AdyenConfigs.getAdyenClientKey();
   const environment = AdyenHelper.getCheckoutEnvironment();
   const installments = AdyenConfigs.getAdyenInstallmentsEnabled()
-    ? AdyenConfigs.getCreditCardInstallments()
+    ? AdyenConfigs.getCreditCardInstallments() || '[]'
     : '[]';
   const adyenClientKey = AdyenConfigs.getAdyenClientKey();
   const googleMerchantID = AdyenConfigs.getGoogleMerchantID();


### PR DESCRIPTION
## Description

Fixes a critical checkout regression where **no payment methods render** for the
installment locales (`pt_BR`, `ja_JP`, `tr_TR`, `es_MX`) whenever credit card
installments are **disabled** in the Business Manager.

### Root cause

When installments are disabled, `getAdyenViewData()` in `begin.js` returned a JS
object (`{}`) for `installments`. The billing ISML renders this into a
single-quoted string literal (`window.installments = '${pdict.adyen.installments}'`),
so the object stringifies to `[object Object]`, producing
`window.installments = '[object Object]'`.

For the installment locales, `cardConfig.js` calls
`JSON.parse(window.installments...)` without any error handling. Parsing
`[object Object]` throws a `SyntaxError`, which propagates up through
`getConfig()` and takes down the entire payment-methods configuration — so
nothing renders. Non-installment locales are unaffected because
`setInstallments()` returns early before the parse.

This was introduced when the installments logic moved into `cardConfig.js`
during the adyen-web v6 modernization, which dropped the previous swallowing
`try/catch`.

## Changes

- **`begin.js`** — return a valid empty-array JSON string (`'[]'`) instead of an
  object in the disabled branch, so `window.installments` parses to `[]` and is
  safely skipped.
- **`cardConfig.js`** — wrap the `JSON.parse` in a `try/catch`. On any
  malformed/empty/undefined value, bail out of `setInstallments()` without
  throwing so `getConfig()` always returns a valid config. This also covers the
  enabled-but-empty-preference edge case (`JSON.parse('')`).

## Test

- [x] Unit test asserting `installments === '[]'` when installments are disabled.
- [x] Manual test with installments disabled, verify payment methods render for `pt_BR`, `ja_JP`, `tr_TR`, `es_MX`.
- [x] Manual test with installments enabled, verify installment options still render correctly for those locales.

**Fixed issue**:  #SFI-1657
