### PR TITLE
[SFI-1532] remove payment method from donations request

### DIFF
--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/donations/__tests__/adyenGiving.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/donations/__tests__/adyenGiving.test.js
@@ -22,6 +22,17 @@ const createCampaignsResponse = (donation) => ({
   donationCampaigns: [{ id: 'mocked_campaignId', donation }],
 });
 
+const createRoundupCampaignsResponse = () =>
+  createCampaignsResponse({ type: 'roundup', maxRoundupAmount: 100 });
+
+const mockOrder = (
+  paymentTransactionCustom = createPaymentTransactionCustom(),
+) => {
+  const order = createOrder(paymentTransactionCustom);
+  OrderMgr.getOrder.mockReturnValue(order);
+  return order;
+};
+
 beforeEach(() => {
   adyenGiving = require('../adyenGiving');
   AdyenHelper = require('*/cartridge/adyen/utils/adyenHelper');
@@ -36,9 +47,7 @@ afterEach(() => {
 
 describe('donate', () => {
   it('should send a donation request without a payment method', () => {
-    OrderMgr.getOrder.mockReturnValueOnce(
-      createOrder(createPaymentTransactionCustom()),
-    );
+    mockOrder();
     AdyenHelper.executeCall
       .mockReturnValueOnce(createCampaignsResponse())
       .mockReturnValueOnce({ status: 'completed' });
@@ -75,36 +84,33 @@ describe('donate', () => {
     expect(AdyenHelper.executeCall).not.toHaveBeenCalled();
   });
 
-  it('should throw when no donation campaigns are available', () => {
-    OrderMgr.getOrder.mockReturnValue(
-      createOrder(createPaymentTransactionCustom()),
-    );
-
+  it('should throw when the campaigns call returns an error', () => {
+    mockOrder();
     AdyenHelper.executeCall.mockReturnValueOnce({ error: true });
+
     expect(() =>
       adyenGiving.donate('mocked_orderNo', donationAmount, 'mocked_orderToken'),
     ).toThrow('Donation campaigns are not available');
-
-    AdyenHelper.executeCall.mockReturnValueOnce({ donationCampaigns: [] });
-    expect(() =>
-      adyenGiving.donate('mocked_orderNo', donationAmount, 'mocked_orderToken'),
-    ).toThrow('Donation campaigns are not available');
-
-    expect(AdyenHelper.executeCall).toHaveBeenCalledTimes(2);
+    expect(AdyenHelper.executeCall).toHaveBeenCalledTimes(1);
   });
 
-  it('should validate the donation amount against the roundup amount', () => {
-    const roundupCampaign = createCampaignsResponse({
-      type: 'roundup',
-      maxRoundupAmount: 100,
-    });
+  it('should throw when no donation campaigns are returned', () => {
+    mockOrder();
+    AdyenHelper.executeCall.mockReturnValueOnce({ donationCampaigns: [] });
 
-    OrderMgr.getOrder.mockReturnValue(
-      createOrder(createPaymentTransactionCustom()),
-    );
+    expect(() =>
+      adyenGiving.donate('mocked_orderNo', donationAmount, 'mocked_orderToken'),
+    ).toThrow('Donation campaigns are not available');
+    expect(AdyenHelper.executeCall).toHaveBeenCalledTimes(1);
+  });
+
+  it('should throw when the donation amount does not match the roundup amount', () => {
+    mockOrder();
     AdyenHelper.getCurrencyValueForApi.mockReturnValue(1030);
+    AdyenHelper.executeCall.mockReturnValueOnce(
+      createRoundupCampaignsResponse(),
+    );
 
-    AdyenHelper.executeCall.mockReturnValueOnce(roundupCampaign);
     expect(() =>
       adyenGiving.donate(
         'mocked_orderNo',
@@ -113,39 +119,56 @@ describe('donate', () => {
       ),
     ).toThrow('Donation amount does not match the roundup amount');
     expect(AdyenHelper.executeCall).toHaveBeenCalledTimes(1);
+  });
 
+  it('should send the donation request when the roundup amount matches', () => {
+    mockOrder();
+    AdyenHelper.getCurrencyValueForApi.mockReturnValue(1030);
     AdyenHelper.executeCall
-      .mockReturnValueOnce(roundupCampaign)
+      .mockReturnValueOnce(createRoundupCampaignsResponse())
       .mockReturnValueOnce({ status: 'completed' });
+
     adyenGiving.donate(
       'mocked_orderNo',
       { value: '70', currency: 'EUR' },
       'mocked_orderToken',
     );
-    expect(AdyenHelper.executeCall.mock.calls[2][1]).not.toHaveProperty(
-      'paymentMethod',
-    );
+
+    const [service, requestObject] = AdyenHelper.executeCall.mock.calls[1];
+    expect(service).toBe('AdyenGiving');
+    expect(requestObject).not.toHaveProperty('paymentMethod');
+    expect(requestObject.amount).toEqual({ value: '70', currency: 'EUR' });
   });
 
-  it('should only clear the donation token when the donation is completed', () => {
-    const completedCustom = createPaymentTransactionCustom();
-    const completedOrder = createOrder(completedCustom);
-    OrderMgr.getOrder.mockReturnValueOnce(completedOrder);
+  it('should clear the donation token and store the amount when the donation is completed', () => {
+    const paymentTransactionCustom = createPaymentTransactionCustom();
+    const order = mockOrder(paymentTransactionCustom);
     AdyenHelper.executeCall
       .mockReturnValueOnce(createCampaignsResponse())
       .mockReturnValueOnce({ status: 'completed' });
+
     adyenGiving.donate('mocked_orderNo', donationAmount, 'mocked_orderToken');
-    expect(completedCustom.Adyen_donationToken).toBeNull();
-    expect(completedOrder.custom.Adyen_donationAmount).toBe(
+
+    expect(paymentTransactionCustom.Adyen_donationToken).toBeNull();
+    expect(order.custom.Adyen_donationAmount).toBe(
       JSON.stringify(donationAmount),
     );
+  });
 
-    const pendingCustom = createPaymentTransactionCustom();
-    OrderMgr.getOrder.mockReturnValueOnce(createOrder(pendingCustom));
+  it('should not clear the donation token when the donation is pending', () => {
+    const paymentTransactionCustom = createPaymentTransactionCustom();
+    const order = mockOrder(paymentTransactionCustom);
     AdyenHelper.executeCall
       .mockReturnValueOnce(createCampaignsResponse())
       .mockReturnValueOnce({ status: 'pending' });
+
     adyenGiving.donate('mocked_orderNo', donationAmount, 'mocked_orderToken');
-    expect(pendingCustom.Adyen_donationToken).toBe('mocked_donationToken');
+
+    expect(paymentTransactionCustom.Adyen_donationToken).toBe(
+      'mocked_donationToken',
+    );
+    expect(order.custom.Adyen_donationAmount).toBe(
+      JSON.stringify(donationAmount),
+    );
   });
 });

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/donations/__tests__/adyenGiving.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/donations/__tests__/adyenGiving.test.js
@@ -1,0 +1,151 @@
+/* eslint-disable global-require */
+let adyenGiving;
+let AdyenHelper;
+let OrderMgr;
+
+const donationAmount = { value: '1000', currency: 'EUR' };
+
+const createPaymentTransactionCustom = () => ({
+  Adyen_donationToken: 'mocked_donationToken',
+  Adyen_pspReference: 'mocked_pspReference',
+});
+
+const createOrder = (paymentTransactionCustom) => ({
+  custom: {},
+  getTotalGrossPrice: jest.fn(() => ({ value: 5000 })),
+  getPaymentInstruments: jest.fn(() => [
+    { paymentTransaction: { custom: paymentTransactionCustom } },
+  ]),
+});
+
+const createCampaignsResponse = (donation) => ({
+  donationCampaigns: [{ id: 'mocked_campaignId', donation }],
+});
+
+beforeEach(() => {
+  adyenGiving = require('../adyenGiving');
+  AdyenHelper = require('*/cartridge/adyen/utils/adyenHelper');
+  OrderMgr = require('dw/order/OrderMgr');
+  jest.clearAllMocks();
+  AdyenHelper.getCurrencyValueForApi.mockReturnValue(1000);
+});
+
+afterEach(() => {
+  jest.resetModules();
+});
+
+describe('donate', () => {
+  it('should send a donation request without a payment method', () => {
+    OrderMgr.getOrder.mockReturnValueOnce(
+      createOrder(createPaymentTransactionCustom()),
+    );
+    AdyenHelper.executeCall
+      .mockReturnValueOnce(createCampaignsResponse())
+      .mockReturnValueOnce({ status: 'completed' });
+
+    const response = adyenGiving.donate(
+      'mocked_orderNo',
+      donationAmount,
+      'mocked_orderToken',
+    );
+
+    expect(OrderMgr.getOrder).toHaveBeenCalledWith(
+      'mocked_orderNo',
+      'mocked_orderToken',
+    );
+
+    const [service, requestObject] = AdyenHelper.executeCall.mock.calls[1];
+    expect(service).toBe('AdyenGiving');
+    expect(requestObject).not.toHaveProperty('paymentMethod');
+    expect(requestObject).toEqual({
+      merchantAccount: 'mocked_merchant_account',
+      donationCampaignId: 'mocked_campaignId',
+      amount: donationAmount,
+      reference: 'mocked_merchant_account-mocked_orderNo',
+      donationOriginalPspReference: 'mocked_pspReference',
+      donationToken: 'mocked_donationToken',
+    });
+    expect(response).toEqual({ status: 'completed' });
+  });
+
+  it('should throw when the donation reference does not match the session order number', () => {
+    expect(() =>
+      adyenGiving.donate('other_orderNo', donationAmount, 'mocked_orderToken'),
+    ).toThrow('Donation reference is invalid');
+    expect(AdyenHelper.executeCall).not.toHaveBeenCalled();
+  });
+
+  it('should throw when no donation campaigns are available', () => {
+    OrderMgr.getOrder.mockReturnValue(
+      createOrder(createPaymentTransactionCustom()),
+    );
+
+    AdyenHelper.executeCall.mockReturnValueOnce({ error: true });
+    expect(() =>
+      adyenGiving.donate('mocked_orderNo', donationAmount, 'mocked_orderToken'),
+    ).toThrow('Donation campaigns are not available');
+
+    AdyenHelper.executeCall.mockReturnValueOnce({ donationCampaigns: [] });
+    expect(() =>
+      adyenGiving.donate('mocked_orderNo', donationAmount, 'mocked_orderToken'),
+    ).toThrow('Donation campaigns are not available');
+
+    expect(AdyenHelper.executeCall).toHaveBeenCalledTimes(2);
+  });
+
+  it('should validate the donation amount against the roundup amount', () => {
+    const roundupCampaign = createCampaignsResponse({
+      type: 'roundup',
+      maxRoundupAmount: 100,
+    });
+
+    OrderMgr.getOrder.mockReturnValue(
+      createOrder(createPaymentTransactionCustom()),
+    );
+    AdyenHelper.getCurrencyValueForApi.mockReturnValue(1030);
+
+    AdyenHelper.executeCall.mockReturnValueOnce(roundupCampaign);
+    expect(() =>
+      adyenGiving.donate(
+        'mocked_orderNo',
+        { value: '100', currency: 'EUR' },
+        'mocked_orderToken',
+      ),
+    ).toThrow('Donation amount does not match the roundup amount');
+    expect(AdyenHelper.executeCall).toHaveBeenCalledTimes(1);
+
+    AdyenHelper.executeCall
+      .mockReturnValueOnce(roundupCampaign)
+      .mockReturnValueOnce({ status: 'completed' });
+    adyenGiving.donate(
+      'mocked_orderNo',
+      { value: '70', currency: 'EUR' },
+      'mocked_orderToken',
+    );
+    expect(AdyenHelper.executeCall.mock.calls[2][1]).not.toHaveProperty(
+      'paymentMethod',
+    );
+  });
+
+  it('should only clear the donation token when the donation is completed', () => {
+    const completedCustom = createPaymentTransactionCustom();
+    const completedOrder = createOrder(completedCustom);
+    OrderMgr.getOrder.mockReturnValueOnce(completedOrder);
+    AdyenHelper.executeCall
+      .mockReturnValueOnce(createCampaignsResponse())
+      .mockReturnValueOnce({ status: 'completed' });
+    adyenGiving.donate('mocked_orderNo', donationAmount, 'mocked_orderToken');
+    expect(completedCustom.Adyen_donationToken).toBeNull();
+    expect(completedOrder.custom.Adyen_donationAmount).toBe(
+      JSON.stringify(donationAmount),
+    );
+
+    const pendingCustom = createPaymentTransactionCustom();
+    OrderMgr.getOrder.mockReturnValueOnce(createOrder(pendingCustom));
+    AdyenHelper.executeCall
+      .mockReturnValueOnce(createCampaignsResponse())
+      .mockReturnValueOnce({ status: 'pending' });
+    adyenGiving.donate('mocked_orderNo', donationAmount, 'mocked_orderToken');
+    expect(pendingCustom.Adyen_donationToken).toBe('mocked_donationToken');
+  });
+});

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/donations/adyenGiving.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/donations/adyenGiving.js
@@ -55,7 +55,6 @@ function donate(donationReference, donationAmount, orderToken) {
     throw new AdyenError('Donation reference is invalid');
   }
 
-  let paymentMethodVariant;
   const order = OrderMgr.getOrder(donationReference, orderToken);
   const orderAmount = AdyenHelper.getCurrencyValueForApi(
     order.getTotalGrossPrice(),
@@ -67,12 +66,6 @@ function donate(donationReference, donationAmount, orderToken) {
     paymentInstrument.paymentTransaction.custom.Adyen_donationToken;
   const originalReference =
     paymentInstrument.paymentTransaction.custom.Adyen_pspReference;
-  const paymentData = JSON.parse(
-    paymentInstrument.paymentTransaction.custom.Adyen_log,
-  );
-  paymentMethodVariant =
-    paymentData.paymentMethod?.type ||
-    paymentData.fullResponse?.paymentMethod?.type;
 
   const campaignsResponse = getActiveCampaigns();
   if (
@@ -85,20 +78,6 @@ function donate(donationReference, donationAmount, orderToken) {
   const donationCampaignId = donationCampaign.id;
   const donationCampaignType = donationCampaign.donation?.type;
 
-  // for iDeal donations, the payment method variant needs to be set to sepadirectdebit
-  if (paymentMethodVariant === constants.PAYMENTMETHODS.IDEAL) {
-    paymentMethodVariant = constants.PAYMENTMETHODS.SEPADIRECTDEBIT;
-  }
-  // for Apple Pay donations, the payment method variant needs to be the brand
-  if (
-    [
-      constants.PAYMENTMETHODS.APPLEPAY,
-      constants.PAYMENTMETHODS.GOOGLEPAY,
-      constants.PAYMENTMETHODS.PAYWITHGOOGLE,
-    ].includes(paymentMethodVariant)
-  ) {
-    paymentMethodVariant = constants.PAYMENTMETHODS.SCHEME;
-  }
   const requestObject = {
     merchantAccount: AdyenConfigs.getAdyenMerchantAccount(),
     donationCampaignId,
@@ -106,9 +85,6 @@ function donate(donationReference, donationAmount, orderToken) {
     reference: `${AdyenConfigs.getAdyenMerchantAccount()}-${donationReference}`,
     donationOriginalPspReference: originalReference,
     donationToken,
-    paymentMethod: {
-      type: paymentMethodVariant,
-    },
   };
 
   if (donationCampaignType === 'roundup') {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Remove obsolete payment method object
- What existing problem does this pull request solve?
Removing obsolete property from request

## Tested scenarios
Description of tested scenarios:
- Donations after redirect payments, APM and cards

**Fixed issue**:  SFI-1532
