### PR TITLE
[SFI-1613] Upgrade to v72

### DIFF
--- a/jest/__mocks__/dw/system/Status.js
+++ b/jest/__mocks__/dw/system/Status.js
@@ -1,0 +1,10 @@
+function Status(status, code, message) {
+  this.status = status;
+  this.code = code;
+  this.message = message;
+}
+
+Status.OK = 0;
+Status.ERROR = 1;
+
+module.exports = Status;

--- a/jest/sfccPathSetup.js
+++ b/jest/sfccPathSetup.js
@@ -318,6 +318,13 @@ jest.mock(
   { virtual: true },
 );
 
+jest.mock(
+  '*/cartridge/adyen/utils/checkoutRequestSanitizer',
+  () =>
+    require('../src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/checkoutRequestSanitizer'),
+  { virtual: true },
+);
+
 // controllers/middlewares/checkout_services subclasses
 jest.mock(
   '*/cartridge/controllers/middlewares/checkout_services/placeOrder',

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/config/constants.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/config/constants.js
@@ -169,6 +169,6 @@ module.exports = {
     '/.well-known/apple-developer-merchantid-domain-association',
 
   CHECKOUT_COMPONENT_VERSION: '6.35.0',
-  CHECKOUT_API_VERSION: 'v71',
+  CHECKOUT_API_VERSION: 'v72',
   VERSION: '26.2.0',
 };

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/hooks/payment/__tests__/authorizeCSC.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/hooks/payment/__tests__/authorizeCSC.test.js
@@ -45,10 +45,10 @@ describe('authorizeCSC payment link request', () => {
     expect(getSentBillingAddress().stateOrProvince).toBe('NH');
   });
 
-  it('omits stateOrProvince entirely when the billing address has no stateCode', () => {
+  it('falls back to N/A when the billing address has no stateCode', () => {
     authorize(buildOrder(null), buildOrderPaymentInstrument());
 
-    expect('stateOrProvince' in getSentBillingAddress()).toBe(false);
+    expect(getSentBillingAddress().stateOrProvince).toBe('N/A');
   });
 
   it('keeps the N/A fallbacks for the other billing address fields', () => {

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/hooks/payment/__tests__/authorizeCSC.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/hooks/payment/__tests__/authorizeCSC.test.js
@@ -1,0 +1,68 @@
+const { authorize } = require('../authorizeCSC');
+const AdyenHelper = require('*/cartridge/adyen/utils/adyenHelper');
+
+const buildOrder = (stateCode) => ({
+  orderNo: '00001202',
+  custom: {},
+  customerLocaleID: 'en_US',
+  getCustomerNo: () => 'mocked_customerNo',
+  getCustomerEmail: () => 'shopper@example.com',
+  addNote: jest.fn(),
+  getBillingAddress: () => ({
+    address1: 'Simon Carmiggeltstraat 6',
+    city: 'Amsterdam',
+    postalCode: '1011DJ',
+    countryCode: { value: 'nl' },
+    stateCode,
+  }),
+});
+
+const buildOrderPaymentInstrument = () => ({
+  getPaymentTransaction: () => ({
+    amount: { currencyCode: 'EUR' },
+    getPaymentProcessor: () => ({ getID: () => 'Adyen_Component' }),
+  }),
+});
+
+const getSentBillingAddress = () =>
+  AdyenHelper.executeCall.mock.calls[0][1].billingAddress;
+
+describe('authorizeCSC payment link request', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.request.clientId = 'dw.csc';
+    AdyenHelper.executeCall.mockReturnValue({
+      url: 'https://test.adyen.link/PL123',
+    });
+    AdyenHelper.getCurrencyValueForApi.mockReturnValue({
+      getValueOrNull: () => 1000,
+    });
+  });
+
+  it('includes stateOrProvince when the billing address has a stateCode', () => {
+    authorize(buildOrder('NH'), buildOrderPaymentInstrument());
+
+    expect(getSentBillingAddress().stateOrProvince).toBe('NH');
+  });
+
+  it('omits stateOrProvince entirely when the billing address has no stateCode', () => {
+    authorize(buildOrder(null), buildOrderPaymentInstrument());
+
+    expect('stateOrProvince' in getSentBillingAddress()).toBe(false);
+  });
+
+  it('keeps the N/A fallbacks for the other billing address fields', () => {
+    const order = buildOrder('NH');
+    const billingAddress = order.getBillingAddress();
+    order.getBillingAddress = () => ({
+      ...billingAddress,
+      city: null,
+      postalCode: null,
+    });
+
+    authorize(order, buildOrderPaymentInstrument());
+
+    expect(getSentBillingAddress().city).toBe('N/A');
+    expect(getSentBillingAddress().postalCode).toBe('N/A');
+  });
+});

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/hooks/payment/authorizeCSC.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/hooks/payment/authorizeCSC.js
@@ -57,9 +57,9 @@ function buildPaymentLinkRequest(
     country: billingCountry,
     houseNumberOrName: billingHouseNumberOrName,
     postalCode: billingAddress.postalCode ? billingAddress.postalCode : 'N/A',
-    stateOrProvince: billingAddress.stateCode
-      ? billingAddress.stateCode
-      : 'N/A',
+    ...(billingAddress.stateCode && {
+      stateOrProvince: billingAddress.stateCode,
+    }),
     street: billingStreet,
   };
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/hooks/payment/authorizeCSC.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/hooks/payment/authorizeCSC.js
@@ -57,9 +57,9 @@ function buildPaymentLinkRequest(
     country: billingCountry,
     houseNumberOrName: billingHouseNumberOrName,
     postalCode: billingAddress.postalCode ? billingAddress.postalCode : 'N/A',
-    ...(billingAddress.stateCode && {
-      stateOrProvince: billingAddress.stateCode,
-    }),
+    stateOrProvince: billingAddress.stateCode
+      ? billingAddress.stateCode
+      : 'N/A',
     street: billingStreet,
   };
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/__tests__/adyenCheckout.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/__tests__/adyenCheckout.test.js
@@ -101,7 +101,24 @@ describe('AdyenCheckout', () => {
 
     describe('L2/3 Data filtering with L23_PAYMENT_METHODS', () => {
         let getLineItemsSpy;
-        const l23MockData = { 'enhancedSchemeData.totalTaxAmount': 10 };
+        const l23MockData = {
+            levelTwoThree: {
+                customerReferenceNumber: 'cust-1',
+                totalTaxAmount: 10,
+                itemDetailLines: [
+                    {
+                        unitPrice: 50,
+                        totalAmount: 100,
+                        quantity: 2,
+                        unitOfMeasure: 'EAC',
+                    },
+                ],
+            },
+        };
+
+        function getSentPaymentRequest() {
+            return AdyenHelper.createShopperObject.mock.calls[0][0].paymentRequest;
+        }
 
         function createArgs() {
             return {
@@ -114,6 +131,7 @@ describe('AdyenCheckout', () => {
                     getCustomerEmail: jest.fn(),
                     getBillingAddress: jest.fn(),
                     getDefaultShipment: jest.fn(),
+                    getProductLineItems: jest.fn(() => ({ toArray: () => [] })),
                     paymentInstrument: {
                         custom: {
                             adyenPaymentData: "{}",
@@ -133,11 +151,13 @@ describe('AdyenCheckout', () => {
             getLineItemsSpy = jest.spyOn(adyenLevelTwoThreeData, 'getLineItems')
                 .mockReturnValue(l23MockData);
             AdyenConfigs.getAdyenLevel23DataEnabled.mockReturnValue(true);
+            AdyenHelper.createShopperObject.mockClear();
         });
 
         afterEach(() => {
             getLineItemsSpy.mockRestore();
             AdyenConfigs.getAdyenLevel23DataEnabled.mockReturnValue(false);
+            AdyenConfigs.getAdyenBasketFieldsEnabled.mockReturnValue(false);
             AdyenHelper.createAdyenRequestObject.mockReturnValue({
                 paymentMethod: { type: 'scheme' },
             });
@@ -149,6 +169,58 @@ describe('AdyenCheckout', () => {
             });
             adyenCheckout.createPaymentRequest(createArgs());
             expect(getLineItemsSpy).toHaveBeenCalled();
+        });
+
+        it('should send L2/3 data as enhancedSchemeData, not in additionalData', () => {
+            AdyenHelper.createAdyenRequestObject.mockReturnValue({
+                paymentMethod: { type: 'scheme' },
+            });
+            adyenCheckout.createPaymentRequest(createArgs());
+            const paymentRequest = getSentPaymentRequest();
+            expect(paymentRequest.enhancedSchemeData).toEqual(l23MockData);
+            expect(paymentRequest.additionalData).toBeUndefined();
+        });
+
+        it('should not add enhancedSchemeData when there are no itemDetailLines', () => {
+            getLineItemsSpy.mockReturnValue({
+                levelTwoThree: {
+                    customerReferenceNumber: 'cust-1',
+                    totalTaxAmount: 0,
+                    itemDetailLines: [],
+                },
+            });
+            AdyenHelper.createAdyenRequestObject.mockReturnValue({
+                paymentMethod: { type: 'scheme' },
+            });
+            adyenCheckout.createPaymentRequest(createArgs());
+            expect(getSentPaymentRequest().enhancedSchemeData).toBeUndefined();
+        });
+
+        it('should not add enhancedSchemeData when getLineItems returns null', () => {
+            getLineItemsSpy.mockReturnValue(null);
+            AdyenHelper.createAdyenRequestObject.mockReturnValue({
+                paymentMethod: { type: 'scheme' },
+            });
+            adyenCheckout.createPaymentRequest(createArgs());
+            expect(getSentPaymentRequest().enhancedSchemeData).toBeUndefined();
+        });
+
+        it('should keep enhancedSchemeData out of a populated additionalData', () => {
+            AdyenConfigs.getAdyenBasketFieldsEnabled.mockReturnValue(true);
+            AdyenHelper.createAdyenRequestObject.mockReturnValue({
+                paymentMethod: { type: 'scheme' },
+                additionalData: { 'openinvoicedata.numberOfLines': '1' },
+            });
+
+            adyenCheckout.createPaymentRequest(createArgs());
+
+            const paymentRequest = getSentPaymentRequest();
+            expect(paymentRequest.enhancedSchemeData).toEqual(l23MockData);
+            expect(
+                Object.keys(paymentRequest.additionalData).every(
+                    (key) => key.indexOf('enhancedSchemeData') !== 0,
+                ),
+            ).toBe(true);
         });
 
         it('should add L2/3 data for applepay payment method', () => {

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/__tests__/adyenLevelTwoThreeData.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/__tests__/adyenLevelTwoThreeData.test.js
@@ -23,6 +23,10 @@ const {
 const AdyenHelper = require('*/cartridge/adyen/utils/adyenHelper');
 
 describe('getLineItems (Enhanced Scheme Data)', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   const mockLineItem = {
     productName: 'Super Widget',
     productID: 'SW1234567890X',
@@ -49,7 +53,7 @@ describe('getLineItems (Enhanced Scheme Data)', () => {
     getCustomerNo: () => customerData.customerNo || null,
   });
 
-  it('should return enhanced line item fields with tax, description, and commodity code', () => {
+  it('should return enhanced scheme data with tax, description, and commodity code', () => {
     const result = getLineItems({
       Order: createMockOrderOrBasket({
         registered: true,
@@ -58,20 +62,25 @@ describe('getLineItems (Enhanced Scheme Data)', () => {
     });
 
     expect(result).toEqual({
-      'enhancedSchemeData.totalTaxAmount': 20,
-      'enhancedSchemeData.customerReference': 'cust-9999',
-      'enhancedSchemeData.itemDetailLine1.unitPrice': '50',
-      'enhancedSchemeData.itemDetailLine1.totalAmount': 100,
-      'enhancedSchemeData.itemDetailLine1.quantity': 2,
-      'enhancedSchemeData.itemDetailLine1.unitOfMeasure': 'EAC',
-      'enhancedSchemeData.itemDetailLine1.commodityCode':
-        'mocked_comodity_code',
-      'enhancedSchemeData.itemDetailLine1.description': 'Super Widget',
-      'enhancedSchemeData.itemDetailLine1.productCode': 'SW1234567890',
+      levelTwoThree: {
+        customerReferenceNumber: 'cust-9999',
+        totalTaxAmount: 20,
+        itemDetailLines: [
+          {
+            unitPrice: 50,
+            totalAmount: 100,
+            quantity: 2,
+            unitOfMeasure: 'EAC',
+            commodityCode: 'mocked_comodity_code',
+            description: 'Super Widget',
+            productCode: 'SW1234567890',
+          },
+        ],
+      },
     });
   });
 
-  it('should truncate customerReference to 25 characters', () => {
+  it('should truncate customerReferenceNumber to 25 characters', () => {
     const longCustomerNo = 'very-long-customer-number-1234567890';
     const result = getLineItems({
       Order: createMockOrderOrBasket({
@@ -81,7 +90,7 @@ describe('getLineItems (Enhanced Scheme Data)', () => {
     });
 
     expect(
-      result['enhancedSchemeData.customerReference'].length,
+      result.levelTwoThree.customerReferenceNumber.length,
     ).toBeLessThanOrEqual(25);
   });
 
@@ -94,7 +103,7 @@ describe('getLineItems (Enhanced Scheme Data)', () => {
       Basket: createMockOrderOrBasket({ customerId: 'anon-user' }),
     });
 
-    expect(result['enhancedSchemeData.customerReference']).toBe('anon-user');
+    expect(result.levelTwoThree.customerReferenceNumber).toBe('anon-user');
   });
 
   it('should use default "no-unique-ref" if no customer ID or profile available', () => {
@@ -113,18 +122,82 @@ describe('getLineItems (Enhanced Scheme Data)', () => {
       },
     });
 
-    expect(result['enhancedSchemeData.customerReference']).toBe(
-      'no-unique-ref',
+    expect(result.levelTwoThree.customerReferenceNumber).toBe('no-unique-ref');
+  });
+
+  it('should append shipping line items to itemDetailLines', () => {
+    const shippingLineItem = {
+      productName: 'Ground shipping',
+      productID: 'SHIP001',
+      quantityValue: 1,
+      adjustedNetPrice: 10,
+      getAdjustedTax: 2,
+    };
+    const orderOrBasket = createMockOrderOrBasket();
+    orderOrBasket.getShipments = () => ({
+      toArray: () => [
+        { getShippingLineItems: () => ({ toArray: () => [shippingLineItem] }) },
+      ],
+    });
+
+    const result = getLineItems({ Order: orderOrBasket });
+
+    expect(result.levelTwoThree.itemDetailLines).toHaveLength(2);
+    expect(result.levelTwoThree.itemDetailLines[1]).toEqual(
+      expect.objectContaining({
+        description: 'Ground shipping',
+        productCode: 'SHIP001',
+        totalAmount: 10,
+        unitPrice: 10,
+        quantity: 1,
+      }),
     );
+    expect(result.levelTwoThree.totalTaxAmount).toBe(22);
+  });
+
+  it('should fall back to a quantity of 1 when the quantity is not numeric', () => {
+    const orderOrBasket = createMockOrderOrBasket();
+    orderOrBasket.getProductLineItems = () => ({
+      toArray: () => [{ ...mockLineItem, quantityValue: null }],
+    });
+
+    const result = getLineItems({ Order: orderOrBasket });
+
+    expect(result.levelTwoThree.itemDetailLines[0].quantity).toBe(1);
+    expect(result.levelTwoThree.itemDetailLines[0].unitPrice).toBe(100);
+  });
+
+  it('should omit discountAmount when the line has no price reduction', () => {
+    const lineItemHelper = require('*/cartridge/adyen/utils/lineItemHelper');
+    lineItemHelper.isProductLineItem.mockReturnValueOnce(true);
+
+    const undiscountedLineItem = {
+      ...mockLineItem,
+      basePrice: {
+        value: 50,
+        multiply: jest.fn(() => ({ value: 100 })),
+      },
+      adjustedPrice: { value: 100 },
+    };
+    const orderOrBasket = createMockOrderOrBasket();
+    orderOrBasket.getProductLineItems = () => ({
+      toArray: () => [undiscountedLineItem],
+    });
+
+    const result = getLineItems({ Order: orderOrBasket });
+
+    expect(
+      'discountAmount' in result.levelTwoThree.itemDetailLines[0],
+    ).toBe(false);
   });
 
   it('should include discount amount when product has basePrice > adjustedPrice', () => {
     const lineItemHelper = require('*/cartridge/adyen/utils/lineItemHelper');
     lineItemHelper.isProductLineItem.mockReturnValueOnce(true);
 
-    AdyenHelper.getCurrencyValueForApi = jest.fn(() => ({
+    jest.spyOn(AdyenHelper, 'getCurrencyValueForApi').mockReturnValue({
       value: { toFixed: () => '20' },
-    }));
+    });
 
     // qty=2, basePrice=60/unit (line=120), adjustedPrice=100 (line total).
     // Expected total line discount = 60*2 - 100 = 20.
@@ -163,10 +236,9 @@ describe('getLineItems (Enhanced Scheme Data)', () => {
 
     // Total line discount (not per-unit). Adyen formula:
     // totalAmount = quantity * unitPrice - discountAmount => 100 = 2 * 60 - 20
-    expect(result['enhancedSchemeData.itemDetailLine1.discountAmount']).toBe(
-      '20',
-    );
-    expect(result['enhancedSchemeData.itemDetailLine1.unitPrice']).toBe('60');
-    expect(result['enhancedSchemeData.itemDetailLine1.totalAmount']).toBe(100);
+    const [itemDetailLine] = result.levelTwoThree.itemDetailLines;
+    expect(itemDetailLine.discountAmount).toBe(20);
+    expect(itemDetailLine.unitPrice).toBe(60);
+    expect(itemDetailLine.totalAmount).toBe(100);
   });
 });

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/adyenCheckout.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/adyenCheckout.js
@@ -167,10 +167,10 @@ function createPaymentRequest(args) {
       (pm) => paymentMethodType.indexOf(pm) > -1,
     )
   ) {
-    paymentRequest.additionalData = {
-      ...paymentRequest.additionalData,
-      ...adyenLevelTwoThreeData.getLineItems(args),
-    };
+    const enhancedSchemeData = adyenLevelTwoThreeData.getLineItems(args);
+    if (enhancedSchemeData?.levelTwoThree?.itemDetailLines?.length > 0) {
+      paymentRequest.enhancedSchemeData = enhancedSchemeData;
+    }
   }
 
   // Add installments

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/adyenLevelTwoThreeData.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/payments/adyenLevelTwoThreeData.js
@@ -40,9 +40,11 @@ function getDiscountAmount(lineItem, quantity) {
   // Total line discount = (per-unit basePrice * quantity) - adjustedPrice line total.
   const baseTotal = basePrice.multiply(quantity);
   if (baseTotal.value <= adjustedPrice.value) return null;
-  return AdyenHelper.getCurrencyValueForApi(
-    baseTotal.subtract(adjustedPrice),
-  ).value.toFixed();
+  return parseFloat(
+    AdyenHelper.getCurrencyValueForApi(
+      baseTotal.subtract(adjustedPrice),
+    ).value.toFixed(),
+  );
 }
 
 function collectShippingLineItems(shipments) {
@@ -56,8 +58,7 @@ function collectShippingLineItems(shipments) {
   return shippingLineItems;
 }
 
-function buildEnhancedSchemeDataFields(
-  index,
+function buildItemDetailLine(
   unitPrice,
   quantity,
   totalAmount,
@@ -67,61 +68,47 @@ function buildEnhancedSchemeDataFields(
   discountAmount,
 ) {
   return {
-    [`enhancedSchemeData.itemDetailLine${index + 1}.unitPrice`]: unitPrice,
-    [`enhancedSchemeData.itemDetailLine${index + 1}.totalAmount`]: totalAmount,
-    [`enhancedSchemeData.itemDetailLine${index + 1}.quantity`]: quantity,
-    [`enhancedSchemeData.itemDetailLine${index + 1}.unitOfMeasure`]: 'EAC',
-    ...(commodityCode && {
-      [`enhancedSchemeData.itemDetailLine${index + 1}.commodityCode`]:
-        commodityCode,
-    }),
+    unitPrice,
+    totalAmount,
+    quantity,
+    unitOfMeasure: 'EAC',
+    ...(commodityCode && { commodityCode }),
     ...(description && {
-      [`enhancedSchemeData.itemDetailLine${index + 1}.description`]:
-        // eslint-disable-next-line no-control-regex
-        description.substring(0, 26).replace(/[^\x00-\x7F]/g, ''),
+      // eslint-disable-next-line no-control-regex
+      description: description.substring(0, 26).replace(/[^\x00-\x7F]/g, ''),
     }),
-    ...(id && {
-      [`enhancedSchemeData.itemDetailLine${index + 1}.productCode`]:
-        id.substring(0, 12),
-    }),
-    ...(discountAmount && {
-      [`enhancedSchemeData.itemDetailLine${index + 1}.discountAmount`]:
-        discountAmount,
-    }),
+    ...(id && { productCode: id.substring(0, 12) }),
+    ...(discountAmount && { discountAmount }),
   };
 }
 
-function processLineItem(acc, lineItem, index) {
+function processLineItem(acc, lineItem) {
   const description = LineItemHelper.getDescription(lineItem);
   const id = LineItemHelper.getId(lineItem);
-  const quantity = LineItemHelper.getQuantity(lineItem);
-  const quantityNum = parseFloat(quantity) || 1;
+  const quantity = parseFloat(LineItemHelper.getQuantity(lineItem)) || 1;
   const lineAmount = LineItemHelper.getItemAmount(lineItem);
   const vatAmount = LineItemHelper.getVatAmount(lineItem);
-  const discountAmount = getDiscountAmount(lineItem, quantityNum);
+  const discountAmount = getDiscountAmount(lineItem, quantity);
   const commodityCode = AdyenConfigs.getAdyenLevel23CommodityCode();
   // Derive unitPrice from totalAmount = quantity * unitPrice - discountAmount.
   const totalAmount = parseFloat(lineAmount.value.toFixed());
-  const discount = discountAmount ? parseFloat(discountAmount) : 0;
-  const unitPrice = ((totalAmount + discount) / quantityNum).toFixed();
-  const currentLineItem = buildEnhancedSchemeDataFields(
-    index,
-    unitPrice,
-    quantity,
-    totalAmount,
-    commodityCode,
-    description,
-    id,
-    discountAmount,
+  const unitPrice = parseFloat(
+    ((totalAmount + (discountAmount || 0)) / quantity).toFixed(),
   );
 
-  return {
-    ...acc,
-    ...currentLineItem,
-    'enhancedSchemeData.totalTaxAmount':
-      acc['enhancedSchemeData.totalTaxAmount'] +
-      parseFloat(vatAmount.value.toFixed()),
-  };
+  acc.itemDetailLines.push(
+    buildItemDetailLine(
+      unitPrice,
+      quantity,
+      totalAmount,
+      commodityCode,
+      description,
+      id,
+      discountAmount,
+    ),
+  );
+  acc.totalTaxAmount += parseFloat(vatAmount.value.toFixed());
+  return acc;
 }
 
 function getLineItems({ Order: order, Basket: basket }) {
@@ -133,13 +120,13 @@ function getLineItems({ Order: order, Basket: basket }) {
   const allLineItems = productLineItems.concat(shippingLineItems);
   const shopperReference = getShopperReference(orderOrBasket);
 
-  return allLineItems.reduce(
-    (acc, lineItem, index) => processLineItem(acc, lineItem, index),
-    {
-      'enhancedSchemeData.totalTaxAmount': 0.0,
-      'enhancedSchemeData.customerReference': shopperReference.substring(0, 25),
-    },
-  );
+  return {
+    levelTwoThree: allLineItems.reduce(processLineItem, {
+      customerReferenceNumber: shopperReference.substring(0, 25),
+      totalTaxAmount: 0.0,
+      itemDetailLines: [],
+    }),
+  };
 }
 
 module.exports.getLineItems = getLineItems;

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/__tests__/adyenHelper.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/__tests__/adyenHelper.test.js
@@ -162,3 +162,183 @@ describe('getCheckoutEnvironment', () => {
     expect(result).toBe('live-nea');
   });
 });
+
+describe('executeCall', () => {
+  const adyenHelper = require('../adyenHelper');
+  const constants = require('*/cartridge/adyen/config/constants');
+  let service;
+  let callResult;
+
+  const getSentBody = (nthCall = 0) =>
+    JSON.parse(service.call.mock.calls[nthCall][0]);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const adyenConfigs = require('*/cartridge/adyen/utils/adyenConfigs');
+    adyenConfigs.getAdyenEnvironment.mockReturnValue('TEST');
+    callResult = {
+      isOk: jest.fn(() => true),
+      object: { getText: jest.fn(() => '{"resultCode":"Authorised"}') },
+      getError: jest.fn(() => 500),
+      getStatus: jest.fn(() => 'ERROR'),
+      getErrorMessage: jest.fn(() => ''),
+      getMsg: jest.fn(() => ''),
+    };
+    service = {
+      getURL: jest.fn(
+        () => 'https://checkout-test.adyen.com/[CHECKOUT_API_VERSION]/payments',
+      ),
+      setURL: jest.fn(),
+      addHeader: jest.fn(),
+      call: jest.fn(() => callResult),
+    };
+    jest.spyOn(adyenHelper, 'getService').mockReturnValue(service);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('sends the sanitized request body', () => {
+    adyenHelper.executeCall(constants.SERVICE.PAYMENT, {
+      reference: '00001202',
+      shopperIP: 'i'.repeat(80),
+      shopperEmail: '  shopper@example.com  ',
+    });
+
+    expect(getSentBody().shopperIP).toBe('i'.repeat(50));
+    expect(getSentBody().shopperEmail).toBe('shopper@example.com');
+  });
+
+  it('does not mutate the request object it was given', () => {
+    const requestObject = { shopperIP: 'i'.repeat(80) };
+
+    adyenHelper.executeCall(constants.SERVICE.PAYMENT, requestObject);
+
+    expect(requestObject.shopperIP).toBe('i'.repeat(80));
+  });
+
+  it('sanitizes once and re-sends the identical body on every retry', () => {
+    callResult.isOk.mockReturnValue(false);
+
+    expect(() =>
+      adyenHelper.executeCall(constants.SERVICE.PAYMENT, {
+        shopperIP: 'i'.repeat(80),
+      }),
+    ).toThrow();
+
+    expect(service.call).toHaveBeenCalledTimes(constants.MAX_API_RETRIES);
+    const [firstBody] = service.call.mock.calls[0];
+    service.call.mock.calls.forEach(([body]) => expect(body).toBe(firstBody));
+  });
+
+  it('substitutes the checkout API version placeholder', () => {
+    adyenHelper.executeCall(constants.SERVICE.PAYMENT, {});
+
+    expect(service.setURL).toHaveBeenCalledWith(
+      `https://checkout-test.adyen.com/${constants.CHECKOUT_API_VERSION}/payments`,
+    );
+  });
+});
+
+describe('createAddressObjects', () => {
+  const { createAddressObjects } = require('../adyenHelper');
+
+  const buildAddress = (stateCode) => ({
+    address1: 'Simon Carmiggeltstraat 6',
+    city: 'Amsterdam',
+    postalCode: '1011DJ',
+    countryCode: { value: 'nl' },
+    stateCode,
+  });
+
+  const buildOrder = (shippingStateCode, billingStateCode) => ({
+    defaultShipment: { shippingAddress: buildAddress(shippingStateCode) },
+    getBillingAddress: () => buildAddress(billingStateCode),
+  });
+
+  it('includes stateOrProvince when the address has a stateCode', () => {
+    const paymentRequest = createAddressObjects(
+      buildOrder('NH', 'ZH'),
+      'scheme',
+      {},
+    );
+
+    expect(paymentRequest.deliveryAddress.stateOrProvince).toBe('NH');
+    expect(paymentRequest.billingAddress.stateOrProvince).toBe('ZH');
+  });
+
+  it('omits stateOrProvince entirely when the address has no stateCode', () => {
+    const paymentRequest = createAddressObjects(
+      buildOrder(null, undefined),
+      'scheme',
+      {},
+    );
+
+    expect('stateOrProvince' in paymentRequest.deliveryAddress).toBe(false);
+    expect('stateOrProvince' in paymentRequest.billingAddress).toBe(false);
+  });
+
+  it('never falls back to the N/A literal for stateOrProvince', () => {
+    const paymentRequest = createAddressObjects(
+      buildOrder('', ''),
+      'scheme',
+      {},
+    );
+
+    expect(JSON.stringify(paymentRequest)).not.toContain('stateOrProvince');
+  });
+
+  it('keeps the N/A fallbacks for the other address fields', () => {
+    const order = buildOrder('NH', 'ZH');
+    order.defaultShipment.shippingAddress.address1 = null;
+    order.defaultShipment.shippingAddress.city = null;
+
+    const paymentRequest = createAddressObjects(order, 'scheme', {});
+
+    expect(paymentRequest.deliveryAddress.street).toBe('N/A');
+    expect(paymentRequest.deliveryAddress.city).toBe('N/A');
+  });
+});
+
+describe('validateStateData', () => {
+  const { validateStateData } = require('../adyenHelper');
+
+  it('strips conversionId, which v72 removed from the request', () => {
+    const { stateData, invalidFields } = validateStateData({
+      paymentMethod: { type: 'scheme' },
+      conversionId: 'abc',
+    });
+
+    expect(stateData.conversionId).toBeUndefined();
+    expect(invalidFields).toContain('conversionId');
+  });
+
+  it('keeps a component-supplied deliveryAddress now that the key matches', () => {
+    const deliveryAddress = { city: 'Amsterdam', country: 'NL' };
+    const { stateData, invalidFields } = validateStateData({
+      paymentMethod: { type: 'scheme' },
+      deliveryAddress,
+    });
+
+    expect(stateData.deliveryAddress).toEqual(deliveryAddress);
+    expect(invalidFields).toHaveLength(0);
+  });
+
+  it('keeps the whitelisted fields', () => {
+    const { stateData, invalidFields } = validateStateData({
+      paymentMethod: { type: 'scheme' },
+      billingAddress: { city: 'Amsterdam' },
+      shopperEmail: 'shopper@example.com',
+      browserInfo: { userAgent: 'jest' },
+    });
+
+    expect(Object.keys(stateData)).toEqual([
+      'paymentMethod',
+      'billingAddress',
+      'shopperEmail',
+      'browserInfo',
+    ]);
+    expect(invalidFields).toHaveLength(0);
+  });
+});

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/__tests__/adyenHelper.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/__tests__/adyenHelper.test.js
@@ -202,20 +202,20 @@ describe('executeCall', () => {
   it('sends the sanitized request body', () => {
     adyenHelper.executeCall(constants.SERVICE.PAYMENT, {
       reference: '00001202',
-      shopperIP: 'i'.repeat(80),
+      shopperIP: 'i'.repeat(300),
       shopperEmail: '  shopper@example.com  ',
     });
 
-    expect(getSentBody().shopperIP).toBe('i'.repeat(50));
+    expect(getSentBody().shopperIP).toBe('i'.repeat(256));
     expect(getSentBody().shopperEmail).toBe('shopper@example.com');
   });
 
   it('does not mutate the request object it was given', () => {
-    const requestObject = { shopperIP: 'i'.repeat(80) };
+    const requestObject = { shopperIP: 'i'.repeat(300) };
 
     adyenHelper.executeCall(constants.SERVICE.PAYMENT, requestObject);
 
-    expect(requestObject.shopperIP).toBe('i'.repeat(80));
+    expect(requestObject.shopperIP).toBe('i'.repeat(300));
   });
 
   it('sanitizes once and re-sends the identical body on every retry', () => {
@@ -223,7 +223,7 @@ describe('executeCall', () => {
 
     expect(() =>
       adyenHelper.executeCall(constants.SERVICE.PAYMENT, {
-        shopperIP: 'i'.repeat(80),
+        shopperIP: 'i'.repeat(300),
       }),
     ).toThrow();
 
@@ -268,25 +268,26 @@ describe('createAddressObjects', () => {
     expect(paymentRequest.billingAddress.stateOrProvince).toBe('ZH');
   });
 
-  it('omits stateOrProvince entirely when the address has no stateCode', () => {
+  it('falls back to N/A when the address has no stateCode', () => {
     const paymentRequest = createAddressObjects(
       buildOrder(null, undefined),
       'scheme',
       {},
     );
 
-    expect('stateOrProvince' in paymentRequest.deliveryAddress).toBe(false);
-    expect('stateOrProvince' in paymentRequest.billingAddress).toBe(false);
+    expect(paymentRequest.deliveryAddress.stateOrProvince).toBe('N/A');
+    expect(paymentRequest.billingAddress.stateOrProvince).toBe('N/A');
   });
 
-  it('never falls back to the N/A literal for stateOrProvince', () => {
+  it('falls back to N/A when the stateCode is an empty string', () => {
     const paymentRequest = createAddressObjects(
       buildOrder('', ''),
       'scheme',
       {},
     );
 
-    expect(JSON.stringify(paymentRequest)).not.toContain('stateOrProvince');
+    expect(paymentRequest.deliveryAddress.stateOrProvince).toBe('N/A');
+    expect(paymentRequest.billingAddress.stateOrProvince).toBe('N/A');
   });
 
   it('keeps the N/A fallbacks for the other address fields', () => {

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/__tests__/checkoutRequestSanitizer.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/__tests__/checkoutRequestSanitizer.test.js
@@ -1,0 +1,387 @@
+const {
+  sanitizeRequest,
+  V72_FIELD_LIMITS,
+} = require('../checkoutRequestSanitizer');
+const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
+
+const validRequest = () => ({
+  merchantAccount: 'mocked_merchant_account',
+  reference: '00001202',
+  returnUrl:
+    'https://example.com/on/demandware.store/Sites-Adyen-Site/en_US/Adyen-ShowConfirmation?merchantReference=00001202',
+  shopperEmail: 'shopper@example.com',
+  shopperIP: '127.0.0.1',
+  shopperName: { firstName: 'Jane', lastName: 'Doe', gender: 'UNKNOWN' },
+  telephoneNumber: '+31612345678',
+  socialSecurityNumber: '12345678901',
+  dateOfBirth: '1990-01-31',
+  entityType: 'NaturalPerson',
+  captureDelayHours: 24,
+  metadata: { orderNo: '00001202' },
+  billingAddress: {
+    city: 'Amsterdam',
+    country: 'NL',
+    postalCode: '1011DJ',
+    stateOrProvince: 'NH',
+    street: 'Simon Carmiggeltstraat',
+  },
+  deliveryAddress: {
+    city: 'Amsterdam',
+    country: 'NL',
+    postalCode: '1011DJ',
+    stateOrProvince: 'NH',
+    street: 'Simon Carmiggeltstraat',
+  },
+  amount: { currency: 'EUR', value: 1000 },
+});
+
+describe('sanitizeRequest', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('leaves a fully valid payload unchanged', () => {
+    const request = validRequest();
+    expect(sanitizeRequest(request)).toEqual(request);
+    expect(AdyenLogs.info_log).not.toHaveBeenCalled();
+    expect(AdyenLogs.error_log).not.toHaveBeenCalled();
+  });
+
+  it('never mutates the caller object', () => {
+    const request = validRequest();
+    request.shopperIP = 'x'.repeat(80);
+    const snapshot = JSON.stringify(request);
+
+    sanitizeRequest(request);
+
+    expect(JSON.stringify(request)).toBe(snapshot);
+  });
+
+  it('leaves fields the v72 table does not cover byte-identical', () => {
+    const request = {
+      ...validRequest(),
+      paymentMethod: {
+        type: 'scheme',
+        encryptedCardNumber: 'adyenjs_0_1_25$aBcDeF==',
+        holderName: 'A'.repeat(200),
+      },
+      riskData: { clientData: 'x'.repeat(300) },
+      lineItems: [
+        { id: 'x'.repeat(50), amountExcludingTax: 1000, taxAmount: 210 },
+      ],
+      additionalData: {
+        'openinvoicedata.merchantData': 'y'.repeat(400),
+      },
+      enhancedSchemeData: {
+        levelTwoThree: {
+          customerReferenceNumber: 'cust-1',
+          totalTaxAmount: 210,
+          itemDetailLines: [
+            {
+              unitPrice: 500,
+              totalAmount: 1000,
+              quantity: 2,
+              unitOfMeasure: 'EAC',
+            },
+          ],
+        },
+      },
+    };
+
+    const sanitized = sanitizeRequest(request);
+
+    expect(JSON.stringify(sanitized.paymentMethod)).toBe(
+      JSON.stringify(request.paymentMethod),
+    );
+    expect(JSON.stringify(sanitized.riskData)).toBe(
+      JSON.stringify(request.riskData),
+    );
+    expect(JSON.stringify(sanitized.lineItems)).toBe(
+      JSON.stringify(request.lineItems),
+    );
+    expect(JSON.stringify(sanitized.additionalData)).toBe(
+      JSON.stringify(request.additionalData),
+    );
+    expect(JSON.stringify(sanitized.enhancedSchemeData)).toBe(
+      JSON.stringify(request.enhancedSchemeData),
+    );
+  });
+
+  describe('truncation', () => {
+    it('truncates the over-long length-capped fields', () => {
+      const request = {
+        ...validRequest(),
+        shopperIP: 'i'.repeat(80),
+        shopperName: { firstName: 'f'.repeat(120), lastName: 'l'.repeat(120) },
+        telephoneNumber: 't'.repeat(70),
+        socialSecurityNumber: 's'.repeat(60),
+        billingAddress: { postalCode: 'p'.repeat(20) },
+        deliveryAddress: { postalCode: 'p'.repeat(20) },
+      };
+
+      const sanitized = sanitizeRequest(request);
+
+      expect(sanitized.shopperIP).toBe('i'.repeat(V72_FIELD_LIMITS.SHOPPER_IP));
+      expect(sanitized.shopperName.firstName).toBe(
+        'f'.repeat(V72_FIELD_LIMITS.SHOPPER_NAME),
+      );
+      expect(sanitized.shopperName.lastName).toBe(
+        'l'.repeat(V72_FIELD_LIMITS.SHOPPER_NAME),
+      );
+      expect(sanitized.telephoneNumber).toBe(
+        't'.repeat(V72_FIELD_LIMITS.TELEPHONE_NUMBER),
+      );
+      expect(sanitized.socialSecurityNumber).toBe(
+        's'.repeat(V72_FIELD_LIMITS.SOCIAL_SECURITY_NUMBER),
+      );
+      expect(sanitized.billingAddress.postalCode).toBe(
+        'p'.repeat(V72_FIELD_LIMITS.POSTAL_CODE),
+      );
+      expect(sanitized.deliveryAddress.postalCode).toBe(
+        'p'.repeat(V72_FIELD_LIMITS.POSTAL_CODE),
+      );
+      expect(AdyenLogs.info_log).toHaveBeenCalledTimes(7);
+    });
+
+    it('does not split a surrogate pair when cutting', () => {
+      const sanitized = sanitizeRequest({
+        telephoneNumber: `${'t'.repeat(63)}\u{1F600}`,
+      });
+
+      expect(sanitized.telephoneNumber).toBe('t'.repeat(63));
+    });
+
+    it('never logs the value of a PII field', () => {
+      sanitizeRequest({ telephoneNumber: '+31612345678901234567890'.repeat(4) });
+
+      const loggedMessages = AdyenLogs.info_log.mock.calls.join(' ');
+      expect(loggedMessages).toContain('telephoneNumber');
+      expect(loggedMessages).not.toContain('31612345678');
+    });
+
+    it('sends an over-long reference unmodified because webhooks match on it', () => {
+      const reference = 'r'.repeat(100);
+
+      expect(sanitizeRequest({ reference }).reference).toBe(reference);
+      expect(AdyenLogs.error_log).toHaveBeenCalled();
+    });
+
+    it('truncates metadata keys and values', () => {
+      const sanitized = sanitizeRequest({
+        metadata: { ['k'.repeat(30)]: 'v'.repeat(100), short: 'value' },
+      });
+
+      expect(sanitized.metadata).toEqual({
+        ['k'.repeat(V72_FIELD_LIMITS.METADATA_KEY)]: 'v'.repeat(
+          V72_FIELD_LIMITS.METADATA_VALUE,
+        ),
+        short: 'value',
+      });
+    });
+
+    it('leaves a non-string metadata value untouched', () => {
+      const metadata = { count: 5, flag: true, nothing: null };
+
+      expect(sanitizeRequest({ metadata }).metadata).toEqual(metadata);
+      expect(AdyenLogs.info_log).not.toHaveBeenCalled();
+    });
+
+    it('drops a metadata entry whose key collides once truncated', () => {
+      const sanitized = sanitizeRequest({
+        metadata: {
+          [`${'k'.repeat(20)}first`]: 'kept',
+          [`${'k'.repeat(20)}second`]: 'dropped',
+        },
+      });
+
+      expect(sanitized.metadata).toEqual({ ['k'.repeat(20)]: 'kept' });
+      expect(AdyenLogs.error_log).toHaveBeenCalled();
+    });
+
+    it('emits a __proto__ metadata key as a plain entry', () => {
+      const sanitized = sanitizeRequest({
+        metadata: JSON.parse('{"__proto__":"polluted","orderNo":"00001202"}'),
+      });
+
+      expect(JSON.stringify(sanitized.metadata)).toContain(
+        '"__proto__":"polluted"',
+      );
+      expect({}.polluted).toBeUndefined();
+    });
+  });
+
+  describe('reformatting', () => {
+    it('encodes unsafe characters in returnUrl without breaking its structure', () => {
+      const sanitized = sanitizeRequest({
+        returnUrl: 'https://example.com/confirm?ref=order 1&token=a',
+      });
+
+      expect(sanitized.returnUrl).toBe(
+        'https://example.com/confirm?ref=order%201&token=a',
+      );
+    });
+
+    it('does not re-encode an already encoded returnUrl', () => {
+      const returnUrl = 'https://example.com/confirm?ref=order%201&token=a%2Bb';
+
+      expect(sanitizeRequest({ returnUrl }).returnUrl).toBe(returnUrl);
+      expect(AdyenLogs.info_log).not.toHaveBeenCalled();
+    });
+
+    it('logs and leaves an over-long returnUrl unmodified', () => {
+      const returnUrl = `https://example.com/confirm?ref=${'r'.repeat(1024)}`;
+
+      expect(sanitizeRequest({ returnUrl }).returnUrl).toBe(returnUrl);
+      expect(AdyenLogs.error_log).toHaveBeenCalled();
+    });
+
+    it('reformats a parseable dateOfBirth to YYYY-MM-DD', () => {
+      expect(
+        sanitizeRequest({ dateOfBirth: '1990-01-31T00:00:00.000Z' })
+          .dateOfBirth,
+      ).toBe('1990-01-31');
+    });
+
+    it('reformats a dateOfBirth without shifting the day across timezones', () => {
+      expect(sanitizeRequest({ dateOfBirth: '1990-1-3' }).dateOfBirth).toBe(
+        '1990-01-03',
+      );
+      expect(
+        sanitizeRequest({ dateOfBirth: '1990-01-31T23:30:00.000Z' })
+          .dateOfBirth,
+      ).toBe('1990-01-31');
+    });
+
+    it('uppercases a lowercase delivery state code', () => {
+      expect(
+        sanitizeRequest({ deliveryAddress: { stateOrProvince: 'ny' } })
+          .deliveryAddress.stateOrProvince,
+      ).toBe('NY');
+    });
+  });
+
+  describe('dropping', () => {
+    it.each([
+      ['no at sign', 'shopperexample.com'],
+      ['empty local part', '@example.com'],
+      ['empty domain', 'shopper@'],
+      ['a space', 'shop per@example.com'],
+      ['a leading dot in the domain', 'shopper@.example.com'],
+      ['an unquoted quote in the local part', 'sho"pper@example.com'],
+      ['over 256 characters', `${'a'.repeat(250)}@example.com`],
+    ])('drops a shopperEmail with %s', (_description, shopperEmail) => {
+      expect(sanitizeRequest({ shopperEmail }).shopperEmail).toBeUndefined();
+      expect(AdyenLogs.error_log).toHaveBeenCalled();
+    });
+
+    it.each([
+      ['a quoted local part containing an at sign', '"a@b"@example.com'],
+      ['multiple at signs outside a quoted part', 'a@b@example.com'],
+    ])('keeps a shopperEmail with %s', (_description, shopperEmail) => {
+      expect(sanitizeRequest({ shopperEmail }).shopperEmail).toBe(shopperEmail);
+    });
+
+    it('trims a padded shopperEmail instead of dropping it', () => {
+      expect(
+        sanitizeRequest({ shopperEmail: '  shopper@example.com ' })
+          .shopperEmail,
+      ).toBe('shopper@example.com');
+      expect(AdyenLogs.error_log).not.toHaveBeenCalled();
+    });
+
+    it('drops an unparseable dateOfBirth', () => {
+      expect(
+        sanitizeRequest({ dateOfBirth: 'not-a-date' }).dateOfBirth,
+      ).toBeUndefined();
+      expect(AdyenLogs.error_log).toHaveBeenCalled();
+    });
+
+    it('drops an entityType outside the allowed values', () => {
+      expect(
+        sanitizeRequest({ entityType: 'Partnership' }).entityType,
+      ).toBeUndefined();
+      expect(AdyenLogs.error_log).toHaveBeenCalled();
+    });
+
+    it('drops a delivery stateOrProvince that is not an alpha-2 code', () => {
+      expect(
+        sanitizeRequest({ deliveryAddress: { stateOrProvince: 'Queensland' } })
+          .deliveryAddress.stateOrProvince,
+      ).toBeUndefined();
+      expect(AdyenLogs.error_log).toHaveBeenCalled();
+    });
+  });
+
+  describe('billing versus delivery stateOrProvince', () => {
+    it('drops an over-long code on both rather than truncating it', () => {
+      const sanitized = sanitizeRequest({
+        billingAddress: { stateOrProvince: 'Queensland' },
+        deliveryAddress: { stateOrProvince: 'Queensland' },
+      });
+
+      expect(sanitized.billingAddress.stateOrProvince).toBeUndefined();
+      expect(sanitized.deliveryAddress.stateOrProvince).toBeUndefined();
+    });
+
+    it('keeps a three-character billing code that the delivery rule rejects', () => {
+      const sanitized = sanitizeRequest({
+        billingAddress: { stateOrProvince: 'SAO' },
+        deliveryAddress: { stateOrProvince: 'SAO' },
+      });
+
+      expect(sanitized.billingAddress.stateOrProvince).toBe('SAO');
+      expect(sanitized.deliveryAddress.stateOrProvince).toBeUndefined();
+    });
+  });
+
+  describe('clamping', () => {
+    it('clamps captureDelayHours to the maximum', () => {
+      expect(sanitizeRequest({ captureDelayHours: 1000 }).captureDelayHours).toBe(
+        672,
+      );
+    });
+
+    it('leaves captureDelayHours within the maximum alone', () => {
+      expect(sanitizeRequest({ captureDelayHours: 672 }).captureDelayHours).toBe(
+        672,
+      );
+    });
+  });
+
+  describe('absent and non-string values', () => {
+    it('handles a request without any validated field', () => {
+      const request = { merchantAccount: 'mocked_merchant_account' };
+
+      expect(sanitizeRequest(request)).toEqual(request);
+    });
+
+    it('leaves null and non-string values untouched', () => {
+      const request = {
+        reference: null,
+        returnUrl: null,
+        shopperEmail: null,
+        shopperIP: 12345,
+        telephoneNumber: 31612345678,
+        socialSecurityNumber: null,
+        dateOfBirth: null,
+        entityType: null,
+        captureDelayHours: 'many',
+        shopperName: null,
+        billingAddress: null,
+        deliveryAddress: { stateOrProvince: null },
+        metadata: null,
+      };
+
+      expect(sanitizeRequest(request)).toEqual(request);
+      expect(AdyenLogs.error_log).not.toHaveBeenCalled();
+    });
+
+    it('returns the original request when it cannot be copied', () => {
+      const request = { reference: '00001202' };
+      request.self = request;
+
+      expect(sanitizeRequest(request)).toBe(request);
+      expect(AdyenLogs.error_log).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/__tests__/checkoutRequestSanitizer.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/__tests__/checkoutRequestSanitizer.test.js
@@ -49,7 +49,7 @@ describe('sanitizeRequest', () => {
 
   it('never mutates the caller object', () => {
     const request = validRequest();
-    request.shopperIP = 'x'.repeat(80);
+    request.shopperIP = 'x'.repeat(300);
     const snapshot = JSON.stringify(request);
 
     sanitizeRequest(request);
@@ -111,7 +111,7 @@ describe('sanitizeRequest', () => {
     it('truncates the over-long length-capped fields', () => {
       const request = {
         ...validRequest(),
-        shopperIP: 'i'.repeat(80),
+        shopperIP: 'i'.repeat(300),
         shopperName: { firstName: 'f'.repeat(120), lastName: 'l'.repeat(120) },
         telephoneNumber: 't'.repeat(70),
         socialSecurityNumber: 's'.repeat(60),
@@ -152,7 +152,9 @@ describe('sanitizeRequest', () => {
     });
 
     it('never logs the value of a PII field', () => {
-      sanitizeRequest({ telephoneNumber: '+31612345678901234567890'.repeat(4) });
+      sanitizeRequest({
+        telephoneNumber: '+31612345678901234567890'.repeat(4),
+      });
 
       const loggedMessages = AdyenLogs.info_log.mock.calls.join(' ');
       expect(loggedMessages).toContain('telephoneNumber');
@@ -302,49 +304,60 @@ describe('sanitizeRequest', () => {
       ).toBeUndefined();
       expect(AdyenLogs.error_log).toHaveBeenCalled();
     });
+  });
 
-    it('drops a delivery stateOrProvince that is not an alpha-2 code', () => {
+  describe('stateOrProvince', () => {
+    it('logs but never drops a delivery code that is not alpha-2, because the field is required', () => {
       expect(
         sanitizeRequest({ deliveryAddress: { stateOrProvince: 'Queensland' } })
           .deliveryAddress.stateOrProvince,
-      ).toBeUndefined();
+      ).toBe('Queensland');
       expect(AdyenLogs.error_log).toHaveBeenCalled();
     });
-  });
 
-  describe('billing versus delivery stateOrProvince', () => {
-    it('drops an over-long code on both rather than truncating it', () => {
+    it('logs but never drops an over-long billing code', () => {
+      expect(
+        sanitizeRequest({
+          billingAddress: { stateOrProvince: 'Noord-Holland' },
+        }).billingAddress.stateOrProvince,
+      ).toBe('Noord-Holland');
+      expect(AdyenLogs.error_log).toHaveBeenCalled();
+    });
+
+    it('keeps a ten-character billing code that the delivery rule flags', () => {
       const sanitized = sanitizeRequest({
         billingAddress: { stateOrProvince: 'Queensland' },
         deliveryAddress: { stateOrProvince: 'Queensland' },
       });
 
-      expect(sanitized.billingAddress.stateOrProvince).toBeUndefined();
-      expect(sanitized.deliveryAddress.stateOrProvince).toBeUndefined();
+      expect(sanitized.billingAddress.stateOrProvince).toBe('Queensland');
+      expect(sanitized.deliveryAddress.stateOrProvince).toBe('Queensland');
+      expect(AdyenLogs.error_log).toHaveBeenCalledTimes(1);
     });
 
-    it('keeps a three-character billing code that the delivery rule rejects', () => {
+    it('leaves the N/A placeholder of a stateless country alone without logging', () => {
       const sanitized = sanitizeRequest({
-        billingAddress: { stateOrProvince: 'SAO' },
-        deliveryAddress: { stateOrProvince: 'SAO' },
+        billingAddress: { stateOrProvince: 'N/A' },
+        deliveryAddress: { stateOrProvince: 'N/A' },
       });
 
-      expect(sanitized.billingAddress.stateOrProvince).toBe('SAO');
-      expect(sanitized.deliveryAddress.stateOrProvince).toBeUndefined();
+      expect(sanitized.billingAddress.stateOrProvince).toBe('N/A');
+      expect(sanitized.deliveryAddress.stateOrProvince).toBe('N/A');
+      expect(AdyenLogs.error_log).not.toHaveBeenCalled();
     });
   });
 
   describe('clamping', () => {
     it('clamps captureDelayHours to the maximum', () => {
-      expect(sanitizeRequest({ captureDelayHours: 1000 }).captureDelayHours).toBe(
-        672,
-      );
+      expect(
+        sanitizeRequest({ captureDelayHours: 1000 }).captureDelayHours,
+      ).toBe(672);
     });
 
     it('leaves captureDelayHours within the maximum alone', () => {
-      expect(sanitizeRequest({ captureDelayHours: 672 }).captureDelayHours).toBe(
-        672,
-      );
+      expect(
+        sanitizeRequest({ captureDelayHours: 672 }).captureDelayHours,
+      ).toBe(672);
     });
   });
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
@@ -37,6 +37,9 @@ const collections = require('*/cartridge/scripts/util/collections');
 const constants = require('*/cartridge/adyen/config/constants');
 const AdyenConfigs = require('*/cartridge/adyen/utils/adyenConfigs');
 const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
+const {
+  sanitizeRequest,
+} = require('*/cartridge/adyen/utils/checkoutRequestSanitizer');
 const { AdyenError } = require('*/cartridge/adyen/logs/adyenError');
 const COHelpers = require('*/cartridge/scripts/checkout/checkoutHelpers');
 
@@ -473,9 +476,9 @@ const adyenHelperObj = {
         : 'ZZ',
       houseNumberOrName: shippingHouseNumberOrName,
       postalCode: shippingAddress.postalCode ? shippingAddress.postalCode : '',
-      stateOrProvince: shippingAddress.stateCode
-        ? shippingAddress.stateCode
-        : 'N/A',
+      ...(shippingAddress.stateCode && {
+        stateOrProvince: shippingAddress.stateCode,
+      }),
       street: shippingStreet,
     };
 
@@ -503,9 +506,9 @@ const adyenHelperObj = {
         : 'ZZ',
       houseNumberOrName: billingHouseNumberOrName,
       postalCode: billingAddress.postalCode ? billingAddress.postalCode : '',
-      stateOrProvince: billingAddress.stateCode
-        ? billingAddress.stateCode
-        : 'N/A',
+      ...(billingAddress.stateCode && {
+        stateOrProvince: billingAddress.stateCode,
+      }),
       street: billingStreet,
     };
 
@@ -842,7 +845,7 @@ const adyenHelperObj = {
     const validFields = [
       'paymentMethod',
       'billingAddress',
-      ' deliveryAddress',
+      'deliveryAddress',
       'riskData',
       'shopperName',
       'dateOfBirth',
@@ -853,7 +856,6 @@ const adyenHelperObj = {
       'browserInfo',
       'installments',
       'storePaymentMethod',
-      'conversionId',
     ];
     const invalidFields = [];
     const filteredStateData = {};
@@ -973,6 +975,8 @@ const adyenHelperObj = {
     service.addHeader('X-API-KEY', apiKey);
     service.addHeader('Idempotency-Key', uuid);
 
+    const requestBody = JSON.stringify(sanitizeRequest(requestObject));
+
     let callResult;
     // retry the call until we reach max retries OR the callresult is OK
     for (
@@ -980,7 +984,7 @@ const adyenHelperObj = {
       nrRetries < maxRetries && !callResult?.isOk();
       nrRetries++
     ) {
-      callResult = service.call(JSON.stringify(requestObject));
+      callResult = service.call(requestBody);
     }
 
     if (!callResult.isOk()) {

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenHelper.js
@@ -476,9 +476,11 @@ const adyenHelperObj = {
         : 'ZZ',
       houseNumberOrName: shippingHouseNumberOrName,
       postalCode: shippingAddress.postalCode ? shippingAddress.postalCode : '',
-      ...(shippingAddress.stateCode && {
-        stateOrProvince: shippingAddress.stateCode,
-      }),
+      // Required by the Adyen address model, so countries without a state still
+      // need a placeholder.
+      stateOrProvince: shippingAddress.stateCode
+        ? shippingAddress.stateCode
+        : 'N/A',
       street: shippingStreet,
     };
 
@@ -506,9 +508,9 @@ const adyenHelperObj = {
         : 'ZZ',
       houseNumberOrName: billingHouseNumberOrName,
       postalCode: billingAddress.postalCode ? billingAddress.postalCode : '',
-      ...(billingAddress.stateCode && {
-        stateOrProvince: billingAddress.stateCode,
-      }),
+      stateOrProvince: billingAddress.stateCode
+        ? billingAddress.stateCode
+        : 'N/A',
       street: billingStreet,
     };
 

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/checkoutRequestSanitizer.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/checkoutRequestSanitizer.js
@@ -27,12 +27,12 @@ const V72_FIELD_LIMITS = {
   REFERENCE: 80,
   RETURN_URL: 1024,
   SHOPPER_EMAIL: 256,
-  SHOPPER_IP: 50,
+  SHOPPER_IP: 256,
   SHOPPER_NAME: 100,
   TELEPHONE_NUMBER: 64,
   SOCIAL_SECURITY_NUMBER: 50,
   POSTAL_CODE: 10,
-  BILLING_STATE_OR_PROVINCE: 3,
+  BILLING_STATE_OR_PROVINCE: 10,
   CAPTURE_DELAY_HOURS: 672,
   METADATA_KEY: 20,
   METADATA_VALUE: 80,
@@ -42,6 +42,7 @@ const ENTITY_TYPES = ['NaturalPerson', 'CompanyName'];
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 const ISO_DATE_PREFIX = /^(\d{4}-\d{2}-\d{2})/;
 const ALPHA_2 = /^[A-Za-z]{2}$/;
+const STATE_OR_PROVINCE_PLACEHOLDER = 'N/A';
 const QUOTED_LOCAL_PART = /^"(?:[^"\\]|\\.)*"$/;
 const PERCENT_ESCAPE = /(%[0-9A-Fa-f]{2})/;
 const HIGH_SURROGATE = /[\uD800-\uDBFF]$/;
@@ -187,6 +188,17 @@ function applyDateOfBirth(container, key, path) {
   AdyenLogs.info_log(`Checkout v72: reformatted ${path} to YYYY-MM-DD`);
 }
 
+function logUnmodifiedStateOrProvince(path, value, requirement) {
+  // Neither dropped nor truncated: stateOrProvince is a required address field,
+  // so deleting it turns a format rejection into a misleading "not provided"
+  // rejection, and truncating turns "Queensland" into the valid-looking but
+  // wrong "QU", which produces a silent AVS partial match.
+  AdyenLogs.error_log(
+    `Checkout v72: ${path} is sent unmodified`,
+    `${requirement} (length ${value.length})`,
+  );
+}
+
 function applyBillingStateOrProvince(container, key, path) {
   const value = container[key];
   if (
@@ -195,31 +207,25 @@ function applyBillingStateOrProvince(container, key, path) {
   ) {
     return;
   }
-  // Dropped rather than truncated for the same reason as the delivery address:
-  // a wrong-but-well-formed state code produces a silent AVS partial match,
-  // which is worse for the merchant than no state code at all.
-  delete container[key];
-  AdyenLogs.error_log(
-    `Checkout v72: dropped ${path}, over ${V72_FIELD_LIMITS.BILLING_STATE_OR_PROVINCE} characters (length ${value.length})`,
+  logUnmodifiedStateOrProvince(
+    path,
+    value,
+    `over ${V72_FIELD_LIMITS.BILLING_STATE_OR_PROVINCE} characters`,
   );
 }
 
 function applyDeliveryStateOrProvince(container, key, path) {
   const value = container[key];
-  if (typeof value !== 'string') {
+  // The placeholder is what the address builders send for countries that have
+  // no state or province, where the field is required but has no valid code.
+  if (typeof value !== 'string' || value === STATE_OR_PROVINCE_PLACEHOLDER) {
     return;
   }
-  // The caller is assumed to supply an ISO 3166-1 alpha-2 code. Anything else is
-  // dropped rather than truncated, because truncating turns "Queensland" into the
-  // valid-looking but wrong "QU".
-  if (!ALPHA_2.test(value)) {
-    delete container[key];
-    AdyenLogs.error_log(
-      `Checkout v72: dropped ${path}, not an ISO 3166-1 alpha-2 code (length ${value.length})`,
-    );
+  if (ALPHA_2.test(value)) {
+    container[key] = value.toUpperCase();
     return;
   }
-  container[key] = value.toUpperCase();
+  logUnmodifiedStateOrProvince(path, value, 'not an ISO 3166-1 alpha-2 code');
 }
 
 function applyEntityType(container, key, path) {

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/checkoutRequestSanitizer.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/checkoutRequestSanitizer.js
@@ -1,0 +1,363 @@
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ * Adyen Salesforce Commerce Cloud
+ * Copyright (c) 2026 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Formats and validates the request attributes that Checkout API v72 validates
+ * server-side, so that merchant data breaching a v72 rule degrades gracefully
+ * instead of failing the payment.
+ * https://docs.adyen.com/online-payments/upgrade-your-integration/upgrade-to-checkout-api-v72
+ */
+const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
+
+const V72_FIELD_LIMITS = {
+  REFERENCE: 80,
+  RETURN_URL: 1024,
+  SHOPPER_EMAIL: 256,
+  SHOPPER_IP: 50,
+  SHOPPER_NAME: 100,
+  TELEPHONE_NUMBER: 64,
+  SOCIAL_SECURITY_NUMBER: 50,
+  POSTAL_CODE: 10,
+  BILLING_STATE_OR_PROVINCE: 3,
+  CAPTURE_DELAY_HOURS: 672,
+  METADATA_KEY: 20,
+  METADATA_VALUE: 80,
+};
+
+const ENTITY_TYPES = ['NaturalPerson', 'CompanyName'];
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+const ISO_DATE_PREFIX = /^(\d{4}-\d{2}-\d{2})/;
+const ALPHA_2 = /^[A-Za-z]{2}$/;
+const QUOTED_LOCAL_PART = /^"(?:[^"\\]|\\.)*"$/;
+const PERCENT_ESCAPE = /(%[0-9A-Fa-f]{2})/;
+const HIGH_SURROGATE = /[\uD800-\uDBFF]$/;
+
+function emailLocalPart(email) {
+  return email.substring(0, email.lastIndexOf('@'));
+}
+
+function emailDomain(email) {
+  return email.substring(email.lastIndexOf('@') + 1);
+}
+
+const EMAIL_REJECTIONS = [
+  (email) => email.length > V72_FIELD_LIMITS.SHOPPER_EMAIL,
+  (email) => email.indexOf(' ') > -1,
+  (email) => email.lastIndexOf('@') < 1,
+  (email) => email.lastIndexOf('@') === email.length - 1,
+  (email) => emailDomain(email).charAt(0) === '.',
+  (email) =>
+    emailLocalPart(email).indexOf('"') > -1 &&
+    !QUOTED_LOCAL_PART.test(emailLocalPart(email)),
+];
+
+function isValidShopperEmail(email) {
+  return !EMAIL_REJECTIONS.some((isRejected) => isRejected(email));
+}
+
+function toIsoDate(value) {
+  const isoPrefix = ISO_DATE_PREFIX.exec(value);
+  if (isoPrefix) {
+    return isoPrefix[1];
+  }
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) {
+    return null;
+  }
+  // Local accessors on purpose: Date.parse reads a non-ISO value as local
+  // midnight, so reading it back in UTC would shift the date by a day.
+  const date = new Date(timestamp);
+  const month = `0${date.getMonth() + 1}`.slice(-2);
+  const day = `0${date.getDate()}`.slice(-2);
+  return `${date.getFullYear()}-${month}-${day}`;
+}
+
+function cut(value, maxLength) {
+  // Drops a trailing high surrogate so the cut never splits a surrogate pair
+  // into an unpaired code unit.
+  return value.substring(0, maxLength).replace(HIGH_SURROGATE, '');
+}
+
+function truncate(container, key, maxLength, path) {
+  const value = container[key];
+  if (typeof value !== 'string' || value.length <= maxLength) {
+    return;
+  }
+  container[key] = cut(value, maxLength);
+  AdyenLogs.info_log(
+    `Checkout v72: truncated ${path} from ${value.length} to ${maxLength} characters`,
+  );
+}
+
+function truncateRule(maxLength) {
+  return (container, key, path) => truncate(container, key, maxLength, path);
+}
+
+function applyReference(container, key, path) {
+  const value = container[key];
+  if (typeof value !== 'string' || value.length <= V72_FIELD_LIMITS.REFERENCE) {
+    return;
+  }
+  // Sent unmodified on purpose: this is the order number that webhooks are
+  // matched against, so a truncated value would orphan the notification.
+  AdyenLogs.error_log(
+    `Checkout v72: ${path} is sent unmodified`,
+    `length ${value.length} exceeds the ${V72_FIELD_LIMITS.REFERENCE} character limit`,
+  );
+}
+
+function encodeOnce(value) {
+  // Encoding around the existing percent-escapes keeps this idempotent; a plain
+  // encodeURI would turn an already encoded '%20' into '%2520'.
+  return value
+    .split(PERCENT_ESCAPE)
+    .map((part, index) => (index % 2 ? part : encodeURI(part)))
+    .join('');
+}
+
+function applyReturnUrl(container, key, path) {
+  const value = container[key];
+  if (typeof value !== 'string') {
+    return;
+  }
+  const encoded = encodeOnce(value);
+  if (encoded !== value) {
+    container[key] = encoded;
+    AdyenLogs.info_log(`Checkout v72: encoded unsafe characters in ${path}`);
+  }
+  if (encoded.length > V72_FIELD_LIMITS.RETURN_URL) {
+    // Truncating would break the redirect back to the storefront.
+    AdyenLogs.error_log(
+      `Checkout v72: ${path} is sent unmodified`,
+      `length ${encoded.length} exceeds the ${V72_FIELD_LIMITS.RETURN_URL} character limit`,
+    );
+  }
+}
+
+function applyShopperEmail(container, key, path) {
+  const value = container[key];
+  if (typeof value !== 'string') {
+    return;
+  }
+  // Trimmed before validating so that a padded address is repaired rather than
+  // dropped: v72 rejects spaces, and losing the email weakens fraud scoring and
+  // hard-fails the payment methods that require it.
+  const trimmed = value.trim();
+  if (isValidShopperEmail(trimmed)) {
+    if (trimmed !== value) {
+      container[key] = trimmed;
+      AdyenLogs.info_log(`Checkout v72: trimmed whitespace around ${path}`);
+    }
+    return;
+  }
+  delete container[key];
+  AdyenLogs.error_log(
+    `Checkout v72: dropped ${path}, invalid format or over ${V72_FIELD_LIMITS.SHOPPER_EMAIL} characters (length ${value.length})`,
+  );
+}
+
+function applyDateOfBirth(container, key, path) {
+  const value = container[key];
+  if (typeof value !== 'string' || ISO_DATE.test(value)) {
+    return;
+  }
+  const isoDate = toIsoDate(value);
+  if (!isoDate) {
+    delete container[key];
+    AdyenLogs.error_log(
+      `Checkout v72: dropped ${path}, not parseable as a date (length ${value.length})`,
+    );
+    return;
+  }
+  container[key] = isoDate;
+  AdyenLogs.info_log(`Checkout v72: reformatted ${path} to YYYY-MM-DD`);
+}
+
+function applyBillingStateOrProvince(container, key, path) {
+  const value = container[key];
+  if (
+    typeof value !== 'string' ||
+    value.length <= V72_FIELD_LIMITS.BILLING_STATE_OR_PROVINCE
+  ) {
+    return;
+  }
+  // Dropped rather than truncated for the same reason as the delivery address:
+  // a wrong-but-well-formed state code produces a silent AVS partial match,
+  // which is worse for the merchant than no state code at all.
+  delete container[key];
+  AdyenLogs.error_log(
+    `Checkout v72: dropped ${path}, over ${V72_FIELD_LIMITS.BILLING_STATE_OR_PROVINCE} characters (length ${value.length})`,
+  );
+}
+
+function applyDeliveryStateOrProvince(container, key, path) {
+  const value = container[key];
+  if (typeof value !== 'string') {
+    return;
+  }
+  // The caller is assumed to supply an ISO 3166-1 alpha-2 code. Anything else is
+  // dropped rather than truncated, because truncating turns "Queensland" into the
+  // valid-looking but wrong "QU".
+  if (!ALPHA_2.test(value)) {
+    delete container[key];
+    AdyenLogs.error_log(
+      `Checkout v72: dropped ${path}, not an ISO 3166-1 alpha-2 code (length ${value.length})`,
+    );
+    return;
+  }
+  container[key] = value.toUpperCase();
+}
+
+function applyEntityType(container, key, path) {
+  const value = container[key];
+  if (typeof value !== 'string' || ENTITY_TYPES.indexOf(value) > -1) {
+    return;
+  }
+  delete container[key];
+  AdyenLogs.error_log(
+    `Checkout v72: dropped ${path}, expected one of ${ENTITY_TYPES.join(', ')}`,
+  );
+}
+
+function applyCaptureDelayHours(container, key, path) {
+  const value = container[key];
+  if (
+    typeof value !== 'number' ||
+    value <= V72_FIELD_LIMITS.CAPTURE_DELAY_HOURS
+  ) {
+    return;
+  }
+  container[key] = V72_FIELD_LIMITS.CAPTURE_DELAY_HOURS;
+  AdyenLogs.info_log(
+    `Checkout v72: clamped ${path} to ${V72_FIELD_LIMITS.CAPTURE_DELAY_HOURS}`,
+  );
+}
+
+function truncateMetadataEntry(target, metadata, metadataKey, path) {
+  const truncatedKey = cut(metadataKey, V72_FIELD_LIMITS.METADATA_KEY);
+  const value = metadata[metadataKey];
+  if (Object.prototype.hasOwnProperty.call(target, truncatedKey)) {
+    AdyenLogs.error_log(
+      `Checkout v72: dropped ${path} entry, its key collides with another entry once truncated to ${V72_FIELD_LIMITS.METADATA_KEY} characters`,
+    );
+    return true;
+  }
+  target[truncatedKey] =
+    typeof value === 'string'
+      ? cut(value, V72_FIELD_LIMITS.METADATA_VALUE)
+      : value;
+  return truncatedKey !== metadataKey || target[truncatedKey] !== value;
+}
+
+function applyMetadata(container, key, path) {
+  const metadata = container[key];
+  if (!metadata || typeof metadata !== 'object') {
+    return;
+  }
+  // Null-prototype accumulator so that a '__proto__' key is emitted as a plain
+  // entry instead of disappearing into the prototype setter.
+  const truncated = Object.create(null);
+  const coerced = Object.keys(metadata).filter((metadataKey) =>
+    truncateMetadataEntry(truncated, metadata, metadataKey, path),
+  );
+  container[key] = truncated;
+  if (coerced.length) {
+    AdyenLogs.info_log(
+      `Checkout v72: coerced ${coerced.length} ${path} entries to a ${V72_FIELD_LIMITS.METADATA_KEY} character key and a ${V72_FIELD_LIMITS.METADATA_VALUE} character value`,
+    );
+  }
+}
+
+const FIELD_RULES = [
+  { path: ['reference'], apply: applyReference },
+  { path: ['returnUrl'], apply: applyReturnUrl },
+  { path: ['shopperEmail'], apply: applyShopperEmail },
+  { path: ['shopperIP'], apply: truncateRule(V72_FIELD_LIMITS.SHOPPER_IP) },
+  {
+    path: ['shopperName', 'firstName'],
+    apply: truncateRule(V72_FIELD_LIMITS.SHOPPER_NAME),
+  },
+  {
+    path: ['shopperName', 'lastName'],
+    apply: truncateRule(V72_FIELD_LIMITS.SHOPPER_NAME),
+  },
+  {
+    path: ['telephoneNumber'],
+    apply: truncateRule(V72_FIELD_LIMITS.TELEPHONE_NUMBER),
+  },
+  {
+    path: ['socialSecurityNumber'],
+    apply: truncateRule(V72_FIELD_LIMITS.SOCIAL_SECURITY_NUMBER),
+  },
+  { path: ['dateOfBirth'], apply: applyDateOfBirth },
+  {
+    path: ['billingAddress', 'postalCode'],
+    apply: truncateRule(V72_FIELD_LIMITS.POSTAL_CODE),
+  },
+  {
+    path: ['deliveryAddress', 'postalCode'],
+    apply: truncateRule(V72_FIELD_LIMITS.POSTAL_CODE),
+  },
+  {
+    path: ['billingAddress', 'stateOrProvince'],
+    apply: applyBillingStateOrProvince,
+  },
+  {
+    path: ['deliveryAddress', 'stateOrProvince'],
+    apply: applyDeliveryStateOrProvince,
+  },
+  { path: ['entityType'], apply: applyEntityType },
+  { path: ['captureDelayHours'], apply: applyCaptureDelayHours },
+  { path: ['metadata'], apply: applyMetadata },
+];
+
+function resolveContainer(request, path) {
+  let container = request;
+  for (let i = 0; i < path.length - 1; i++) {
+    container = container[path[i]];
+    if (!container || typeof container !== 'object') {
+      return null;
+    }
+  }
+  return container;
+}
+
+function applyRule(request, rule) {
+  const container = resolveContainer(request, rule.path);
+  if (container) {
+    rule.apply(container, rule.path[rule.path.length - 1], rule.path.join('.'));
+  }
+}
+
+function sanitizeRequest(requestObject) {
+  try {
+    const sanitized = JSON.parse(JSON.stringify(requestObject));
+    FIELD_RULES.forEach((rule) => applyRule(sanitized, rule));
+    return sanitized;
+  } catch (e) {
+    AdyenLogs.error_log(
+      'Checkout v72: could not sanitize the request, sending it unmodified',
+      e,
+    );
+    return requestObject;
+  }
+}
+
+module.exports = {
+  V72_FIELD_LIMITS,
+  sanitizeRequest,
+};


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Upgrade to v72 api
- What existing problem does this pull request solve?
Use latest checkout api version

## Tested scenarios
Description of tested scenarios:
- Cards (level 2/3 data, tokenization, click to pay)
- PayPal (end of checkout / express)
- GooglePay (end of checkout / express)
- iDEAL
- Klarna
- Giftcards

**Fixed issue**:  SFI-1613
