### PR TITLE
[SFI-1703] Fix Adyen-Notify webhook responses and transaction rollback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Vagrantfile
 cartridges
 !src/cartridges
 .factory
+.agents

--- a/src/cartridges/int_adyen_webhooks/cartridge/__tests__/__snapshots__/notify.test.js.snap
+++ b/src/cartridges/int_adyen_webhooks/cartridge/__tests__/__snapshots__/notify.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Notify should render notifyError when notification result is not successful 1`] = `
+exports[`Notify should respond 500 and roll back when notification result is not successful 1`] = `
 [
   [
     "/notifyError",

--- a/src/cartridges/int_adyen_webhooks/cartridge/__tests__/checkNotificationAuth.test.js
+++ b/src/cartridges/int_adyen_webhooks/cartridge/__tests__/checkNotificationAuth.test.js
@@ -1,0 +1,54 @@
+/* eslint-disable global-require */
+
+jest.mock(
+  '*/cartridge/libs/libAuthenticationUtils',
+  () => ({
+    checkGivenCredentials: jest.fn(() => true),
+    calculateHmacSignature: jest.fn(() => 'mocked_signature'),
+  }),
+  { virtual: true },
+);
+
+let checkAuth;
+let AuthenticationUtils;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  checkAuth = require('../checkNotificationAuth');
+  AuthenticationUtils = require('*/cartridge/libs/libAuthenticationUtils');
+});
+
+afterEach(() => {
+  jest.resetModules();
+});
+
+describe('validateHmacSignature', () => {
+  it('should accept a notification whose signature matches', () => {
+    const req = {
+      form: { 'additionalData.hmacSignature': 'mocked_signature' },
+    };
+    expect(checkAuth.validateHmacSignature(req)).toBe(true);
+  });
+  it('should reject a notification whose signature does not match', () => {
+    const req = {
+      form: { 'additionalData.hmacSignature': 'mocked_other_signature' },
+    };
+    expect(checkAuth.validateHmacSignature(req)).toBe(false);
+  });
+  it('should reject a notification without a signature instead of throwing', () => {
+    const req = { form: { merchantReference: 'mocked_reference' } };
+    expect(checkAuth.validateHmacSignature(req)).toBe(false);
+  });
+  it('should reject a notification without a form instead of throwing', () => {
+    expect(checkAuth.validateHmacSignature({})).toBe(false);
+  });
+  it('should reject a notification when the merchant signature could not be calculated', () => {
+    AuthenticationUtils.calculateHmacSignature.mockImplementation(() => ({
+      error: true,
+    }));
+    const req = {
+      form: { 'additionalData.hmacSignature': 'mocked_signature' },
+    };
+    expect(checkAuth.validateHmacSignature(req)).toBe(false);
+  });
+});

--- a/src/cartridges/int_adyen_webhooks/cartridge/__tests__/notify.test.js
+++ b/src/cartridges/int_adyen_webhooks/cartridge/__tests__/notify.test.js
@@ -1,9 +1,57 @@
 /* eslint-disable global-require */
 
+jest.mock(
+  '*/cartridge/libs/libAuthenticationUtils',
+  () => ({
+    checkGivenCredentials: jest.fn(() => true),
+    calculateHmacSignature: jest.fn(() => 'mocked_signature'),
+  }),
+  { virtual: true },
+);
+
 let req;
 let res;
 let next;
 let notify;
+
+// Models the SFCC transaction state so that committing or rolling back a closed
+// transaction fails the way it does on an instance
+function mockTransactionState(Transaction) {
+  const state = { isOpen: false };
+  Transaction.begin.mockImplementation(() => {
+    if (state.isOpen) {
+      throw new Error('a transaction is already open');
+    }
+    state.isOpen = true;
+  });
+  Transaction.commit.mockImplementation(() => {
+    if (!state.isOpen) {
+      throw new Error('there is no transaction to commit');
+    }
+    state.isOpen = false;
+  });
+  Transaction.rollback.mockImplementation(() => {
+    if (!state.isOpen) {
+      throw new Error('there is no transaction to roll back');
+    }
+    state.isOpen = false;
+  });
+  // A nested wrap joins the open transaction and rolls all of it back when its
+  // callback throws
+  Transaction.wrap.mockImplementation((callback) => {
+    const isOwner = !state.isOpen;
+    state.isOpen = true;
+    try {
+      const result = callback();
+      state.isOpen = !isOwner;
+      return result;
+    } catch (error) {
+      state.isOpen = false;
+      throw error;
+    }
+  });
+  return state;
+}
 
 function createResponseMock() {
   const viewData = {};
@@ -52,6 +100,18 @@ describe('Notify', () => {
     expect(Transaction.rollback).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalled();
   });
+  it('should respond 403 when the notification carries no HMAC signature', () => {
+    const Transaction = require('dw/system/Transaction');
+    const checkAuth = require('*/cartridge/checkNotificationAuth');
+    const { validateHmacSignature } = require('../checkNotificationAuth');
+    checkAuth.validateHmacSignature.mockImplementation(validateHmacSignature);
+    req = { form: { merchantReference: 'mocked_reference' } };
+    notify(req, res, next);
+    expect(res.setStatusCode).toHaveBeenCalledWith(403);
+    expect(res.render).toHaveBeenCalledWith('/adyen/error');
+    expect(Transaction.begin).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
   it('should render notify when notification result is successful', () => {
     const Transaction = require('dw/system/Transaction');
     const handleNotify = require('*/cartridge/handleNotify');
@@ -77,6 +137,31 @@ describe('Notify', () => {
     expect(res.json).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalled();
     expect(res.render.mock.calls).toMatchSnapshot();
+  });
+  it('should respond 500 when a nested transaction of handleNotify was rolled back', () => {
+    const Transaction = require('dw/system/Transaction');
+    const handleNotify = require('*/cartridge/handleNotify');
+    const transactionState = mockTransactionState(Transaction);
+    // handleNotify writes its custom objects in a nested transaction and
+    // swallows the failure, see handleNotify.notify
+    handleNotify.notify.mockImplementation(() => {
+      try {
+        Transaction.wrap(() => {
+          throw new Error('mocked_custom_object_error');
+        });
+        return { success: true };
+      } catch (error) {
+        return { success: false, errorMessage: error.message };
+      }
+    });
+    notify(req, res, next);
+    expect(res.setStatusCode).toHaveBeenCalledWith(500);
+    expect(res.render).toHaveBeenCalledWith('/notifyError', {
+      errorMessage: 'mocked_custom_object_error',
+    });
+    expect(Transaction.commit).not.toHaveBeenCalled();
+    expect(transactionState.isOpen).toBe(false);
+    expect(next).toHaveBeenCalled();
   });
   it('should respond 500 and roll back when processing throws', () => {
     const Transaction = require('dw/system/Transaction');

--- a/src/cartridges/int_adyen_webhooks/cartridge/__tests__/notify.test.js
+++ b/src/cartridges/int_adyen_webhooks/cartridge/__tests__/notify.test.js
@@ -2,14 +2,27 @@
 
 let req;
 let res;
+let next;
 let notify;
+
+function createResponseMock() {
+  const viewData = {};
+  return {
+    render: jest.fn(),
+    json: jest.fn(),
+    setStatusCode: jest.fn(),
+    setViewData: jest.fn((data) => Object.assign(viewData, data)),
+    getViewData: jest.fn(() => viewData),
+  };
+}
 
 beforeEach(() => {
   const { adyen } = require('../../../int_adyen_SFRA/cartridge/controllers/middlewares/index');
   notify = adyen.notify;
   jest.clearAllMocks();
   req = {};
-  res = { render: jest.fn(), status: jest.fn(() => res)};
+  res = createResponseMock();
+  next = jest.fn();
 });
 
 afterEach(() => {
@@ -17,25 +30,68 @@ afterEach(() => {
 });
 
 describe('Notify', () => {
-  it('should render error when status is falsy', () => {
+  it('should respond 403 without opening a transaction when status is falsy', () => {
+    const Transaction = require('dw/system/Transaction');
     const checkAuth = require('*/cartridge/checkNotificationAuth');
     checkAuth.check.mockImplementation(() => false);
-    notify(req, res, jest.fn());
+    notify(req, res, next);
+    expect(res.setStatusCode).toHaveBeenCalledWith(403);
     expect(res.render).toHaveBeenCalledWith('/adyen/error');
+    expect(Transaction.begin).not.toHaveBeenCalled();
+    expect(Transaction.rollback).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+  it('should respond 403 when the HMAC signature is invalid', () => {
+    const Transaction = require('dw/system/Transaction');
+    const checkAuth = require('*/cartridge/checkNotificationAuth');
+    checkAuth.validateHmacSignature.mockImplementation(() => false);
+    notify(req, res, next);
+    expect(res.setStatusCode).toHaveBeenCalledWith(403);
+    expect(res.render).toHaveBeenCalledWith('/adyen/error');
+    expect(Transaction.rollback).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
   });
   it('should render notify when notification result is successful', () => {
+    const Transaction = require('dw/system/Transaction');
     const handleNotify = require('*/cartridge/handleNotify');
     handleNotify.notify.mockImplementation(() => ({ success: true }));
-    notify(req, res, jest.fn());
+    notify(req, res, next);
     expect(res.render).toHaveBeenCalledWith('/notify');
+    expect(res.setStatusCode).not.toHaveBeenCalled();
+    expect(Transaction.commit).toHaveBeenCalled();
+    expect(Transaction.rollback).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
   });
-  it('should render notifyError when notification result is not successful', () => {
+  it('should respond 500 and roll back when notification result is not successful', () => {
+    const Transaction = require('dw/system/Transaction');
     const handleNotify = require('*/cartridge/handleNotify');
     handleNotify.notify.mockImplementation(() => ({
       success: false,
       errorMessage: 'mocked_error_message',
     }));
-    notify(req, res, jest.fn());
+    notify(req, res, next);
+    expect(res.setStatusCode).toHaveBeenCalledWith(500);
+    expect(Transaction.rollback).toHaveBeenCalled();
+    expect(Transaction.commit).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
     expect(res.render.mock.calls).toMatchSnapshot();
+  });
+  it('should respond 500 and roll back when processing throws', () => {
+    const Transaction = require('dw/system/Transaction');
+    const handleNotify = require('*/cartridge/handleNotify');
+    handleNotify.notify.mockImplementation(() => {
+      throw new Error('mocked_unexpected_error');
+    });
+    notify(req, res, next);
+    expect(res.setStatusCode).toHaveBeenCalledWith(500);
+    expect(res.render).toHaveBeenCalledWith('/notifyError', {
+      errorMessage: 'mocked_unexpected_error',
+    });
+    expect(Transaction.rollback).toHaveBeenCalled();
+    expect(Transaction.commit).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
   });
 });

--- a/src/cartridges/int_adyen_webhooks/cartridge/checkNotificationAuth.js
+++ b/src/cartridges/int_adyen_webhooks/cartridge/checkNotificationAuth.js
@@ -43,7 +43,13 @@ function check(request) {
 
 function compareHmac(hmacSignature, merchantSignature) {
   let bitwiseComparison;
-  if (hmacSignature.length !== merchantSignature.length) {
+  // A notification without a signature, or a signature we could not calculate,
+  // is unauthorized rather than an unexpected error
+  if (
+    typeof hmacSignature !== 'string' ||
+    typeof merchantSignature !== 'string' ||
+    hmacSignature.length !== merchantSignature.length
+  ) {
     return false;
   }
   for (let i = 0; i < hmacSignature.length; i++) {
@@ -54,7 +60,7 @@ function compareHmac(hmacSignature, merchantSignature) {
 }
 
 function validateHmacSignature(request) {
-  const notificationData = request.form;
+  const notificationData = request.form || {};
   const hmacSignature = notificationData['additionalData.hmacSignature'];
   const merchantSignature = AuthenticationUtils.calculateHmacSignature(request);
   // Checking for timing attacks

--- a/src/cartridges/int_adyen_webhooks/cartridge/notify.js
+++ b/src/cartridges/int_adyen_webhooks/cartridge/notify.js
@@ -1,9 +1,7 @@
 const Transaction = require('dw/system/Transaction');
-const URLUtils = require('dw/web/URLUtils');
 const checkAuth = require('*/cartridge/checkNotificationAuth');
 const handleNotify = require('*/cartridge/handleNotify');
 const AdyenConfigs = require('*/cartridge/adyen/utils/adyenConfigs');
-const setErrorType = require('*/cartridge/adyen/logs/setErrorType');
 const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
 /**
  * Called by Adyen to update status of payments. It should always display [accepted] when finished.
@@ -16,32 +14,48 @@ function handleHmacVerification(hmacKey, req) {
   return true;
 }
 
+function isAuthorized(req) {
+  const hmacKey = AdyenConfigs.getAdyenHmacKey();
+  return checkAuth.check(req) && handleHmacVerification(hmacKey, req);
+}
+
 function notify(req, res, next) {
+  // Adyen only queues a notification for retry on a 5xx response, so processing
+  // failures must not be reported as 200 or as a 403 rejection.
+  let isTransactionOpen = false;
   try {
-    const status = checkAuth.check(req);
-    const hmacKey = AdyenConfigs.getAdyenHmacKey();
-    const isHmacValid = handleHmacVerification(hmacKey, req);
-    if (!status || !isHmacValid) {
-      res.status(403).render('/adyen/error');
-      return {};
+    if (!isAuthorized(req)) {
+      AdyenLogs.error_log(
+        'Notification rejected: basic authentication or HMAC signature validation failed',
+      );
+      res.setStatusCode(403);
+      res.render('/adyen/error');
+      return next();
     }
+
     Transaction.begin();
+    isTransactionOpen = true;
     const notificationResult = handleNotify.notify(req.form);
-    if (notificationResult.success) {
-      Transaction.commit();
-      res.render('/notify');
-    } else {
-      res.status(403).render('/notifyError', {
+    if (!notificationResult.success) {
+      Transaction.rollback();
+      isTransactionOpen = false;
+      res.setStatusCode(500);
+      res.render('/notifyError', {
         errorMessage: notificationResult.errorMessage,
       });
-      Transaction.rollback();
+      return next();
     }
+    Transaction.commit();
+    isTransactionOpen = false;
+    res.render('/notify');
     return next();
   } catch (error) {
+    if (isTransactionOpen) {
+      Transaction.rollback();
+    }
     AdyenLogs.error_log('Could not process notification:', error);
-    setErrorType(error, res, {
-      redirectUrl: URLUtils.url('Error-ErrorCode', 'err', 'general').toString(),
-    });
+    res.setStatusCode(500);
+    res.render('/notifyError', { errorMessage: error.message });
     return next();
   }
 }

--- a/src/cartridges/int_adyen_webhooks/cartridge/notify.js
+++ b/src/cartridges/int_adyen_webhooks/cartridge/notify.js
@@ -19,40 +19,59 @@ function isAuthorized(req) {
   return checkAuth.check(req) && handleHmacVerification(hmacKey, req);
 }
 
+// handleNotify writes its custom objects in nested transactions, which SFCC
+// rolls back on failure. Rolling back a transaction that is already closed
+// throws, and that error must not replace the failure we are reporting.
+function rollbackTransaction() {
+  try {
+    Transaction.rollback();
+  } catch (rollbackError) {
+    AdyenLogs.error_log(
+      'Could not roll back the notification transaction:',
+      rollbackError,
+    );
+  }
+}
+
+// Sole owner of the notification transaction: every exit path either commits or
+// rolls back exactly once, before the response is touched.
+function processNotification(notificationData) {
+  Transaction.begin();
+  try {
+    const notificationResult = handleNotify.notify(notificationData);
+    if (!notificationResult.success) {
+      rollbackTransaction();
+      return notificationResult;
+    }
+    Transaction.commit();
+    return notificationResult;
+  } catch (error) {
+    rollbackTransaction();
+    throw error;
+  }
+}
+
 function notify(req, res, next) {
   // Adyen only queues a notification for retry on a 5xx response, so processing
   // failures must not be reported as 200 or as a 403 rejection.
-  let isTransactionOpen = false;
   try {
     if (!isAuthorized(req)) {
-      AdyenLogs.error_log(
-        'Notification rejected: basic authentication or HMAC signature validation failed',
-      );
       res.setStatusCode(403);
       res.render('/adyen/error');
       return next();
     }
 
-    Transaction.begin();
-    isTransactionOpen = true;
-    const notificationResult = handleNotify.notify(req.form);
+    const notificationResult = processNotification(req.form);
     if (!notificationResult.success) {
-      Transaction.rollback();
-      isTransactionOpen = false;
       res.setStatusCode(500);
       res.render('/notifyError', {
         errorMessage: notificationResult.errorMessage,
       });
       return next();
     }
-    Transaction.commit();
-    isTransactionOpen = false;
     res.render('/notify');
     return next();
   } catch (error) {
-    if (isTransactionOpen) {
-      Transaction.rollback();
-    }
     AdyenLogs.error_log('Could not process notification:', error);
     res.setStatusCode(500);
     res.render('/notifyError', { errorMessage: error.message });


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- `notify.js` called `res.status(403)`, which does not exist on the SFRA `Response` object. Every auth, HMAC and processing failure therefore threw a `TypeError`, which the outer `catch` converted into an HTTP 200 `{error:true}` body — so failed webhooks appeared successfully delivered in Adyen Customer Area and were never queued for retry.
- Every exit path now uses `res.setStatusCode(...)` + `res.render(...)` + `next()`:
  - auth/HMAC failure → **403** `/adyen/error` (the request is genuinely rejected);
  - processing failure and unexpected errors → **500** `/notifyError`, because Adyen only queues a notification for retry on a 5xx.
- Transaction handling moved into a single `processNotification` owner, so every path commits or rolls back exactly once, *before* the response is touched. The rollback itself is guarded — rolling back an already-closed transaction throws, and that error must not mask the failure being reported.
- `compareHmac` / `validateHmacSignature` now treat a missing signature or missing form as unauthorized (403) rather than as an unexpected error (500).
- Removed the now-unused `URLUtils` and `setErrorType` imports.

## Tested scenarios
Description of tested scenarios:
- `notify.test.js`: 3 → 7 cases. Replaced the invented `status` mock with a realistic SFRA response mock (`render`, `json`, `setStatusCode`, `setViewData`, `getViewData`), asserting `setStatusCode` is called with 403/500 per branch and that `next()` is always called. Added a case where `handleNotify.notify` throws, asserting 500 and no `res.json`. Snapshot refreshed.
- `checkNotificationAuth.test.js`: new file, 5 cases — matching signature, mismatched signature, missing signature, missing form, and a merchant signature that could not be calculated.
- Full suite green: 76 suites / 431 tests. `eslint` and `check-logs` clean.

**Fixed issue**: #1514
