### PR TITLE
[SFI-1695] Fix GooglePay Express button not rendering in minicart

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/templates/default/adyen/adyenExpressMetadata.isml
+++ b/src/cartridges/app_adyen_SFRA/cartridge/templates/default/adyen/adyenExpressMetadata.isml
@@ -36,6 +36,8 @@
    window.isGooglePayExpressEnabled = "${AdyenConfigs.isGooglePayExpressEnabled()}";
    window.isGooglePayExpressOnPdpEnabled = "${AdyenConfigs.isGooglePayExpressOnPdpEnabled()}";
    window.isGooglePayExpressOnShippingPageEnabled = "${AdyenConfigs.isGooglePayExpressOnShippingPageEnabled()}";
+   window.merchantAccount = "${AdyenConfigs.getAdyenMerchantAccount()}";
+   window.googleMerchantID = "${AdyenConfigs.getGoogleMerchantID()}";
 
    window.basketAmount = "${AdyenHelper.getBasketAmount()}".replace(/&quot;/g, '\"');
    window.makeExpressPaymentsCall = "${URLUtils.https('Adyen-MakeExpressPaymentsCall')}";


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
- What existing problem does this pull request solve?

`adyenExpressMetadata.isml` was missing the `window.merchantAccount` and `window.googleMerchantID` variables. `googlePayConfig.js` reads these two window variables to build the GooglePay `gatewayMerchantId`/`merchantId` configuration. `adyenComponentForm.isml` (the checkout billing page) already sets them, but `adyenExpressMetadata.isml` — which is included on the minicart, PDP, and shipping pages — did not, so the GooglePay Express button silently failed to initialise on those pages.

This PR adds the two missing window variables to `adyenExpressMetadata.isml`, sourced from `AdyenConfigs`, mirroring what `adyenComponentForm.isml` already does.

## Tested scenarios
Description of tested scenarios:
- Verified `adyenExpressMetadata.isml` now sets `window.merchantAccount` and `window.googleMerchantID` identically to `adyenComponentForm.isml`.
- Ran `isml-linter` on the changed template; no new lint issues introduced (pre-existing warnings unrelated to this change).
- Ran the existing Jest suite (`npm test`), including the GooglePay express tests (`googlePayExpress.test.js`) and the checkout `begin.test.js` middleware tests — all 440 tests pass.

**Fixed issue**: #1510