### PR TITLE
[SFI-1512] send confirmation email when order has no locale

### DIFF
--- a/jest/globals.js
+++ b/jest/globals.js
@@ -18,7 +18,10 @@ global.session = {
   },
 };
 
-global.request = { getLocale: jest.fn(() => 'nl_NL') };
+global.request = {
+  getLocale: jest.fn(() => 'nl_NL'),
+  setLocale: jest.fn(() => true),
+};
 
 global.customer = { profile: { customerNo: 'mocked_customerNo' } };
 

--- a/jest/sfccCartridgeMocks.js
+++ b/jest/sfccCartridgeMocks.js
@@ -393,6 +393,7 @@ jest.mock(
     getAdyenRecurringPaymentsEnabled: jest.fn(() => true),
     isAdyenAnalyticsEnabled: jest.fn(() => true),
     getAdyenLevel23CommodityCode: jest.fn(() => 'mocked_comodity_code'),
+    getAdyenDefaultLocale: jest.fn(() => 'en_US'),
   }),
   { virtual: true },
 );

--- a/jest/sfccPathSetup.js
+++ b/jest/sfccPathSetup.js
@@ -326,6 +326,13 @@ jest.mock(
 );
 
 jest.mock(
+  '*/cartridge/adyen/utils/localeHelper',
+  () =>
+    require('../src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/localeHelper'),
+  { virtual: true },
+);
+
+jest.mock(
   '*/cartridge/adyen/utils/dcapHelper',
   () =>
     require('../src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/dcapHelper'),

--- a/metadata/site_import/meta/system-objecttype-extensions.xml
+++ b/metadata/site_import/meta/system-objecttype-extensions.xml
@@ -654,6 +654,15 @@
                 <externally-managed-flag>false</externally-managed-flag>
                 <min-length>0</min-length>
             </attribute-definition>
+            <attribute-definition attribute-id="Adyen_DefaultLocale">
+                <display-name xml:lang="x-default">Default locale</display-name>
+                <description xml:lang="x-default">Fallback locale used for order confirmation emails and payment links when the shopper's order has no specific locale (for example en_US)</description>
+                <type>string</type>
+                <mandatory-flag>false</mandatory-flag>
+                <externally-managed-flag>false</externally-managed-flag>
+                <min-length>0</min-length>
+                <default-value>en_US</default-value>
+            </attribute-definition>
             <attribute-definition attribute-id="Adyen_ApplePay_DomainAssociation">
                 <display-name xml:lang="x-default">Apple Pay Domain Association</display-name>
                 <description xml:lang="x-default">Apple Pay Domain Association used for LIVE payments</description>
@@ -688,6 +697,7 @@
                 <attribute attribute-id="Adyen_GooglePayMerchantID"/>
                 <attribute attribute-id="AdyenRatePayID"/>
                 <attribute attribute-id="Adyen_IntegratorName"/>
+                <attribute attribute-id="Adyen_DefaultLocale"/>
                 <attribute attribute-id="Adyen_StoreId"/>
                 <attribute attribute-id="Adyen_SelectedStoreID"/>
                 <attribute attribute-id="AdyenOneClickEnabled"/>

--- a/src/cartridges/bm_adyen/cartridge/templates/default/adyenSettings/settingCards/optionalSettings.isml
+++ b/src/cartridges/bm_adyen/cartridge/templates/default/adyenSettings/settingCards/optionalSettings.isml
@@ -83,6 +83,13 @@
             </div>
          </div>
          <div class="form-group">
+            <label class="form-title mb-0" for="defaultLocale">Default locale</label>
+            <small id="defaultLocaleHelp" class="form-text mb-1">Used for order confirmation emails and payment links when the shopper's order has no specific locale, for example en_US.</small>
+            <div class="input-fields">
+               <input type="text" class="form-control" name="Adyen_DefaultLocale" id="defaultLocale" aria-describedby="defaultLocaleHelp" value="${AdyenConfigs.getAdyenDefaultLocale() || ''}">
+            </div>
+         </div>
+         <div class="form-group">
             <label class="form-title mb-0" for="systemIntegrator">System integrator</label>
             <small id="systemIntegratorHelp" class="form-text mb-1">Let us know the name of the company that built your integration with Adyen to get custom support.</small>
             <div class="input-fields">

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/config/constants.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/config/constants.js
@@ -161,6 +161,11 @@ module.exports = {
   },
   FRAUD_STATUS_AMBER: 'AMBER',
 
+  LOCALE: {
+    DEFAULT_ID: 'default',
+    FALLBACK_ID: 'en_US',
+  },
+
   MERCHANT_APPLICATION_NAME: 'adyen-salesforce-commerce-cloud',
   EXTERNAL_PLATFORM_NAME: 'SalesforceCommerceCloud',
   EXTERNAL_PLATFORM_VERSION: 'SFRA',

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/hooks/payment/__tests__/authorizeCSC.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/hooks/payment/__tests__/authorizeCSC.test.js
@@ -1,10 +1,11 @@
 const { authorize } = require('../authorizeCSC');
 const AdyenHelper = require('*/cartridge/adyen/utils/adyenHelper');
+const AdyenConfigs = require('*/cartridge/adyen/utils/adyenConfigs');
 
-const buildOrder = (stateCode) => ({
+const buildOrder = (stateCode, customerLocaleID = 'en_US') => ({
   orderNo: '00001202',
   custom: {},
-  customerLocaleID: 'en_US',
+  customerLocaleID,
   getCustomerNo: () => 'mocked_customerNo',
   getCustomerEmail: () => 'shopper@example.com',
   addNote: jest.fn(),
@@ -24,13 +25,16 @@ const buildOrderPaymentInstrument = () => ({
   }),
 });
 
-const getSentBillingAddress = () =>
-  AdyenHelper.executeCall.mock.calls[0][1].billingAddress;
+const getSentPaymentLinkRequest = () =>
+  AdyenHelper.executeCall.mock.calls[0][1];
+
+const getSentBillingAddress = () => getSentPaymentLinkRequest().billingAddress;
 
 describe('authorizeCSC payment link request', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     global.request.clientId = 'dw.csc';
+    AdyenConfigs.getAdyenDefaultLocale.mockReturnValue('nl_NL');
     AdyenHelper.executeCall.mockReturnValue({
       url: 'https://test.adyen.link/PL123',
     });
@@ -64,5 +68,17 @@ describe('authorizeCSC payment link request', () => {
 
     expect(getSentBillingAddress().city).toBe('N/A');
     expect(getSentBillingAddress().postalCode).toBe('N/A');
+  });
+
+  it('sends the locale of the order as shopperLocale', () => {
+    authorize(buildOrder('NH', 'fr_FR'), buildOrderPaymentInstrument());
+
+    expect(getSentPaymentLinkRequest().shopperLocale).toBe('fr-FR');
+  });
+
+  it('sends the configured default locale when the order has no specific locale', () => {
+    authorize(buildOrder('NH', 'default'), buildOrderPaymentInstrument());
+
+    expect(getSentPaymentLinkRequest().shopperLocale).toBe('nl-NL');
   });
 });

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/hooks/payment/authorizeCSC.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/hooks/payment/authorizeCSC.js
@@ -2,6 +2,7 @@ const Status = require('dw/system/Status');
 const AdyenConfigs = require('*/cartridge/adyen/utils/adyenConfigs');
 const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
 const AdyenHelper = require('*/cartridge/adyen/utils/adyenHelper');
+const localeHelper = require('*/cartridge/adyen/utils/localeHelper');
 const constants = require('*/cartridge/adyen/config/constants');
 
 const ADYEN_PBL_NOTE_KEY = 'Adyen Payment Link';
@@ -48,8 +49,7 @@ function buildPaymentLinkRequest(
     shopperInteraction: 'Ecommerce',
     shopperReference: order.getCustomerNo(),
     shopperEmail: order.getCustomerEmail(),
-    shopperLocale:
-      order.customerLocaleID === 'default' ? 'en-US' : order.customerLocaleID,
+    shopperLocale: localeHelper.getShopperLocale(order.customerLocaleID),
   };
 
   paymentLinkRequest.billingAddress = {

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/__tests__/localeHelper.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/__tests__/localeHelper.test.js
@@ -1,0 +1,92 @@
+/* eslint-disable global-require */
+jest.mock('dw/util/Locale', () => ({ getLocale: jest.fn() }), {
+  virtual: true,
+});
+
+const KNOWN_COUNTRIES = {
+  en_US: 'US',
+  nl_NL: 'NL',
+  fr_FR: 'FR',
+};
+
+let localeHelper;
+let Locale;
+let AdyenConfigs;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  localeHelper = require('../localeHelper');
+  Locale = require('dw/util/Locale');
+  AdyenConfigs = require('*/cartridge/adyen/utils/adyenConfigs');
+  Locale.getLocale.mockImplementation((localeId) =>
+    KNOWN_COUNTRIES[localeId] ? { country: KNOWN_COUNTRIES[localeId] } : null,
+  );
+  AdyenConfigs.getAdyenDefaultLocale.mockReturnValue('nl_NL');
+});
+
+afterEach(() => {
+  jest.resetModules();
+});
+
+describe('isUsableLocaleId', () => {
+  it('accepts a locale ID that resolves to a locale with a country', () => {
+    expect(localeHelper.isUsableLocaleId('fr_FR')).toBe(true);
+  });
+  it('rejects the default locale ID', () => {
+    expect(localeHelper.isUsableLocaleId('default')).toBe(false);
+  });
+  it('rejects a missing locale ID', () => {
+    expect(localeHelper.isUsableLocaleId('')).toBe(false);
+    expect(localeHelper.isUsableLocaleId(null)).toBe(false);
+    expect(localeHelper.isUsableLocaleId(undefined)).toBe(false);
+  });
+  it('rejects a locale ID that cannot be resolved', () => {
+    expect(localeHelper.isUsableLocaleId('mocked_locale')).toBe(false);
+  });
+  it('rejects a locale without a country', () => {
+    Locale.getLocale.mockReturnValue({ country: null });
+    expect(localeHelper.isUsableLocaleId('en')).toBe(false);
+  });
+});
+
+describe('resolveLocaleId', () => {
+  it('keeps a usable locale ID', () => {
+    expect(localeHelper.resolveLocaleId('fr_FR')).toBe('fr_FR');
+  });
+  it('falls back to the configured locale for the default locale ID', () => {
+    expect(localeHelper.resolveLocaleId('default')).toBe('nl_NL');
+  });
+  it('falls back to the configured locale for a missing locale ID', () => {
+    expect(localeHelper.resolveLocaleId('')).toBe('nl_NL');
+  });
+  it('falls back to the configured locale for an unresolvable locale ID', () => {
+    expect(localeHelper.resolveLocaleId('mocked_locale')).toBe('nl_NL');
+  });
+  it('falls back to en_US when the configured locale is not usable', () => {
+    AdyenConfigs.getAdyenDefaultLocale.mockReturnValue('mocked_locale');
+    expect(localeHelper.resolveLocaleId('default')).toBe('en_US');
+  });
+  it('falls back to en_US when no locale is configured', () => {
+    AdyenConfigs.getAdyenDefaultLocale.mockReturnValue(null);
+    expect(localeHelper.resolveLocaleId('default')).toBe('en_US');
+  });
+});
+
+describe('getFallbackLocaleId', () => {
+  it('returns the configured locale when it is usable', () => {
+    expect(localeHelper.getFallbackLocaleId()).toBe('nl_NL');
+  });
+  it('returns en_US when the configured locale is not usable', () => {
+    AdyenConfigs.getAdyenDefaultLocale.mockReturnValue('default');
+    expect(localeHelper.getFallbackLocaleId()).toBe('en_US');
+  });
+});
+
+describe('getShopperLocale', () => {
+  it('normalises the separator of the order locale for the Adyen API', () => {
+    expect(localeHelper.getShopperLocale('fr_FR')).toBe('fr-FR');
+  });
+  it('normalises the separator of the fallback locale', () => {
+    expect(localeHelper.getShopperLocale('default')).toBe('nl-NL');
+  });
+});

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenConfigs.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/adyenConfigs.js
@@ -67,6 +67,10 @@ const adyenConfigsObj = {
     return getCustomPreference('Adyen_IntegratorName');
   },
 
+  getAdyenDefaultLocale() {
+    return getCustomPreference('Adyen_DefaultLocale');
+  },
+
   getAdyenClientKey() {
     return getCustomPreference('Adyen_ClientKey');
   },

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/localeHelper.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/utils/localeHelper.js
@@ -1,0 +1,69 @@
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ * Adyen Salesforce Commerce Cloud
+ * Copyright (c) 2025 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ */
+const Locale = require('dw/util/Locale');
+// script includes
+const AdyenConfigs = require('*/cartridge/adyen/utils/adyenConfigs');
+const constants = require('*/cartridge/adyen/config/constants');
+
+const localeHelper = {
+  /**
+   * Checks whether a locale ID can be resolved to a locale with a country.
+   * Orders placed on a URL without a locale segment carry 'default', which
+   * cannot be resolved and breaks consumers such as SFRA's email helpers.
+   * @param {string} localeId - the locale ID to check, e.g. 'en_US'
+   * @returns {boolean} true when the locale ID is usable
+   */
+  isUsableLocaleId(localeId) {
+    if (!localeId || localeId === constants.LOCALE.DEFAULT_ID) {
+      return false;
+    }
+    const locale = Locale.getLocale(localeId);
+    return !!(locale && locale.country);
+  },
+
+  /**
+   * @returns {string} the configured fallback locale ID, or the built-in one
+   */
+  getFallbackLocaleId() {
+    const configuredLocaleId = AdyenConfigs.getAdyenDefaultLocale();
+    return this.isUsableLocaleId(configuredLocaleId)
+      ? configuredLocaleId
+      : constants.LOCALE.FALLBACK_ID;
+  },
+
+  /**
+   * @param {string} localeId - the locale ID of the order or basket
+   * @returns {string} the given locale ID when usable, the fallback otherwise
+   */
+  resolveLocaleId(localeId) {
+    return this.isUsableLocaleId(localeId)
+      ? localeId
+      : this.getFallbackLocaleId();
+  },
+
+  /**
+   * @param {string} localeId - the locale ID of the order or basket
+   * @returns {string} a resolved locale ID in the Adyen API format, e.g. 'en-US'
+   */
+  getShopperLocale(localeId) {
+    return this.resolveLocaleId(localeId).replace('_', '-');
+  },
+};
+
+module.exports = localeHelper;

--- a/src/cartridges/int_adyen_webhooks/cartridge/job/__tests__/notifications.test.js
+++ b/src/cartridges/int_adyen_webhooks/cartridge/job/__tests__/notifications.test.js
@@ -1,0 +1,157 @@
+/* eslint-disable global-require */
+jest.mock(
+  'dw/object/CustomObjectMgr',
+  () => ({ queryCustomObjects: jest.fn() }),
+  { virtual: true },
+);
+
+jest.mock('*/cartridge/handleCustomObject', () => ({ handle: jest.fn() }), {
+  virtual: true,
+});
+
+jest.mock('*/cartridge/deleteCustomObjects', () => ({ remove: jest.fn() }), {
+  virtual: true,
+});
+
+let notifications;
+let CustomObjectMgr;
+let objectsHandler;
+let COHelpers;
+let AdyenLogs;
+let AdyenConfigs;
+
+const buildOrder = (customerLocaleID) => ({
+  orderNo: 'mocked_orderNo',
+  status: { value: 'mocked_status' },
+  getCustomerLocaleID: () => customerLocaleID,
+});
+
+const mockSearchQuery = (customObjects) => {
+  let index = 0;
+  CustomObjectMgr.queryCustomObjects.mockReturnValue({
+    count: customObjects.length,
+    hasNext: () => index < customObjects.length,
+    next: () => {
+      const customObj = customObjects[index];
+      index += 1;
+      return customObj;
+    },
+    close: jest.fn(),
+  });
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.PIPELET_NEXT = 'mocked_next';
+  global.PIPELET_ERROR = 'mocked_error';
+  notifications = require('../notifications');
+  CustomObjectMgr = require('dw/object/CustomObjectMgr');
+  objectsHandler = require('*/cartridge/handleCustomObject');
+  COHelpers = require('*/cartridge/scripts/checkout/checkoutHelpers');
+  AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
+  AdyenConfigs = require('*/cartridge/adyen/utils/adyenConfigs');
+  COHelpers.sendConfirmationEmail.mockReset();
+  AdyenConfigs.getAdyenDefaultLocale.mockReturnValue('en_US');
+});
+
+afterEach(() => {
+  jest.resetModules();
+});
+
+describe('processNotifications', () => {
+  it('sends the confirmation email with the locale ID of the order', () => {
+    const order = buildOrder('nl_NL');
+    objectsHandler.handle.mockReturnValue({
+      status: 'mocked_ok',
+      SubmitOrder: true,
+      Order: order,
+    });
+    mockSearchQuery(['mocked_customObject']);
+
+    notifications.processNotifications();
+
+    expect(COHelpers.sendConfirmationEmail).toHaveBeenCalledWith(
+      order,
+      'nl_NL',
+    );
+  });
+
+  it('sends the confirmation email with the fallback locale ID when the order has no specific locale', () => {
+    AdyenConfigs.getAdyenDefaultLocale.mockReturnValue('nl_NL');
+    const order = buildOrder('default');
+    objectsHandler.handle.mockReturnValue({
+      status: 'mocked_ok',
+      SubmitOrder: true,
+      Order: order,
+    });
+    mockSearchQuery(['mocked_customObject']);
+
+    notifications.processNotifications();
+
+    expect(COHelpers.sendConfirmationEmail).toHaveBeenCalledWith(
+      order,
+      'nl_NL',
+    );
+  });
+
+  it('logs a failing confirmation email and keeps processing the other notifications', () => {
+    objectsHandler.handle.mockReturnValue({
+      status: 'mocked_ok',
+      SubmitOrder: true,
+      Order: buildOrder('nl_NL'),
+    });
+    COHelpers.sendConfirmationEmail.mockImplementationOnce(() => {
+      throw new Error('mocked_mail_error');
+    });
+    mockSearchQuery(['mocked_customObject_1', 'mocked_customObject_2']);
+
+    notifications.processNotifications();
+
+    expect(AdyenLogs.error_log).toHaveBeenCalledWith(
+      'Failed to send the confirmation email for order mocked_orderNo',
+      expect.any(Error),
+    );
+    expect(COHelpers.sendConfirmationEmail).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not send a confirmation email when the order was not submitted', () => {
+    objectsHandler.handle.mockReturnValue({
+      status: 'mocked_ok',
+      SubmitOrder: false,
+      Order: buildOrder('nl_NL'),
+    });
+    mockSearchQuery(['mocked_customObject']);
+
+    notifications.processNotifications();
+
+    expect(COHelpers.sendConfirmationEmail).not.toHaveBeenCalled();
+  });
+
+  it('does not send a confirmation email for a skipped order', () => {
+    objectsHandler.handle.mockReturnValue({
+      status: 'mocked_ok',
+      SubmitOrder: true,
+      SkipOrder: true,
+      Order: buildOrder('nl_NL'),
+    });
+    mockSearchQuery(['mocked_customObject']);
+
+    notifications.processNotifications();
+
+    expect(COHelpers.sendConfirmationEmail).not.toHaveBeenCalled();
+  });
+
+  it('does not send a confirmation email for a pending order', () => {
+    objectsHandler.handle.mockReturnValue({
+      status: 'mocked_ok',
+      SubmitOrder: true,
+      Pending: true,
+      Order: buildOrder('nl_NL'),
+    });
+    mockSearchQuery(['mocked_customObject']);
+
+    notifications.processNotifications();
+
+    expect(COHelpers.sendConfirmationEmail).not.toHaveBeenCalled();
+  });
+});

--- a/src/cartridges/int_adyen_webhooks/cartridge/job/__tests__/notifications.test.js
+++ b/src/cartridges/int_adyen_webhooks/cartridge/job/__tests__/notifications.test.js
@@ -94,6 +94,58 @@ describe('processNotifications', () => {
     );
   });
 
+  it('applies the locale of the order while sending the confirmation email and restores the job locale afterwards', () => {
+    global.request.getLocale.mockReturnValueOnce('en_US');
+    objectsHandler.handle.mockReturnValue({
+      status: 'mocked_ok',
+      SubmitOrder: true,
+      Order: buildOrder('nl_NL'),
+    });
+    mockSearchQuery(['mocked_customObject']);
+
+    notifications.processNotifications();
+
+    expect(global.request.setLocale.mock.calls).toEqual([['nl_NL'], ['en_US']]);
+  });
+
+  it('restores the job locale when sending the confirmation email fails', () => {
+    global.request.getLocale.mockReturnValueOnce('en_US');
+    objectsHandler.handle.mockReturnValue({
+      status: 'mocked_ok',
+      SubmitOrder: true,
+      Order: buildOrder('nl_NL'),
+    });
+    COHelpers.sendConfirmationEmail.mockImplementationOnce(() => {
+      throw new Error('mocked_mail_error');
+    });
+    mockSearchQuery(['mocked_customObject']);
+
+    notifications.processNotifications();
+
+    expect(global.request.setLocale).toHaveBeenLastCalledWith('en_US');
+  });
+
+  it('logs a warning when the locale of the order is not available on the site and still sends the confirmation email', () => {
+    global.request.setLocale.mockReturnValueOnce(false);
+    const order = buildOrder('nl_NL');
+    objectsHandler.handle.mockReturnValue({
+      status: 'mocked_ok',
+      SubmitOrder: true,
+      Order: order,
+    });
+    mockSearchQuery(['mocked_customObject']);
+
+    notifications.processNotifications();
+
+    expect(AdyenLogs.warning_log).toHaveBeenCalledWith(
+      'Locale nl_NL is not available for the confirmation email of order mocked_orderNo',
+    );
+    expect(COHelpers.sendConfirmationEmail).toHaveBeenCalledWith(
+      order,
+      'nl_NL',
+    );
+  });
+
   it('logs a failing confirmation email and keeps processing the other notifications', () => {
     objectsHandler.handle.mockReturnValue({
       status: 'mocked_ok',

--- a/src/cartridges/int_adyen_webhooks/cartridge/job/notifications.js
+++ b/src/cartridges/int_adyen_webhooks/cartridge/job/notifications.js
@@ -54,6 +54,33 @@ function handleFailedOrder(handlerResult, order) {
 }
 
 /**
+ * Sends the order confirmation email in the locale of the order
+ * @param {Object} order - The order object
+ */
+function sendOrderConfirmationEmail(order) {
+  const localeId = localeHelper.resolveLocaleId(order.getCustomerLocaleID());
+  const jobLocaleId = request.getLocale();
+  try {
+    // The email templates and resource bundles are resolved with the locale of
+    // the current request, which in a job is the site default.
+    if (!request.setLocale(localeId)) {
+      AdyenLogs.warning_log(
+        `Locale ${localeId} is not available for the confirmation email of order ${order.orderNo}`,
+      );
+    }
+    COHelpers.sendConfirmationEmail(order, localeId);
+  } catch (e) {
+    // A failing email should not stop the remaining notifications
+    AdyenLogs.error_log(
+      `Failed to send the confirmation email for order ${order.orderNo}`,
+      e,
+    );
+  } finally {
+    request.setLocale(jobLocaleId);
+  }
+}
+
+/**
  * Handles successful order processing
  * @param {Object} handlerResult - The result from the handler
  * @param {Object} order - The order object
@@ -64,20 +91,8 @@ function handleSuccessfulOrder(handlerResult, order) {
     return false;
   }
 
-  // Send confirmation email
   if (handlerResult.SubmitOrder) {
-    const customerLocaleId = localeHelper.resolveLocaleId(
-      order.getCustomerLocaleID(),
-    );
-    try {
-      COHelpers.sendConfirmationEmail(order, customerLocaleId);
-    } catch (e) {
-      // A failing email should not stop the remaining notifications
-      AdyenLogs.error_log(
-        `Failed to send the confirmation email for order ${order.orderNo}`,
-        e,
-      );
-    }
+    sendOrderConfirmationEmail(order);
   }
   return true;
 }

--- a/src/cartridges/int_adyen_webhooks/cartridge/job/notifications.js
+++ b/src/cartridges/int_adyen_webhooks/cartridge/job/notifications.js
@@ -23,10 +23,10 @@
 const OrderMgr = require('dw/order/OrderMgr');
 const Transaction = require('dw/system/Transaction');
 const CustomObjectMgr = require('dw/object/CustomObjectMgr');
-const Locale = require('dw/util/Locale');
 const COHelpers = require('*/cartridge/scripts/checkout/checkoutHelpers');
 // script includes
 const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
+const localeHelper = require('*/cartridge/adyen/utils/localeHelper');
 const deleteCustomObjects = require('*/cartridge/deleteCustomObjects');
 const objectsHandler = require('*/cartridge/handleCustomObject');
 
@@ -66,9 +66,18 @@ function handleSuccessfulOrder(handlerResult, order) {
 
   // Send confirmation email
   if (handlerResult.SubmitOrder) {
-    const customerLocaleId = order.getCustomerLocaleID();
-    const customerLocale = Locale.getLocale(customerLocaleId);
-    COHelpers.sendConfirmationEmail(order, customerLocale);
+    const customerLocaleId = localeHelper.resolveLocaleId(
+      order.getCustomerLocaleID(),
+    );
+    try {
+      COHelpers.sendConfirmationEmail(order, customerLocaleId);
+    } catch (e) {
+      // A failing email should not stop the remaining notifications
+      AdyenLogs.error_log(
+        `Failed to send the confirmation email for order ${order.orderNo}`,
+        e,
+      );
+    }
   }
   return true;
 }


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Orders placed on a URL without a locale segment carry the locale ID 'default', which cannot be resolved.
- What existing problem does this pull request solve?
The notifications job passed the unresolvable locale into SFRA's sendConfirmationEmail,

## Tested scenarios
Description of tested scenarios:
- Use default locale to send confirmation emails

**Fixed issue**:  SFI-1512
