### PR TITLE
[SFI-1719]: render payment methods in response order

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/__tests__/renderPaymentMethod.test.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/__tests__/renderPaymentMethod.test.js
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-const { renderPaymentMethod } = require('../renderPaymentMethod');
+const { renderPaymentMethod, renderCheckout } = require('../renderPaymentMethod');
 const store = require('../../../../../../config/store');
 
 let mount;
@@ -98,5 +98,97 @@ describe('Render Payment Method', () => {
         document.querySelector('button[value="submit-payment"]').disabled,
     ).toBeTruthy();
     expect(store.selectedMethod).toBe('paypal');
+  });
+});
+
+describe('Render Checkout', () => {
+  // Apple Pay and Google Pay are the only components with an asynchronous
+  // isAvailable, so they are the ones that used to be pushed to the bottom
+  const SLOW_METHODS = ['applepay', 'googlepay'];
+
+  const paymentMethodsResponse = {
+    locale: 'en_US',
+    imagePath: '/mocked_path/',
+    adyenDescriptions: {},
+    adyenPaymentMethodTitles: { en_US: {} },
+    AdyenPaymentMethods: {
+      storedPaymentMethods: [],
+      paymentMethods: [
+        { type: 'cashapp', name: 'Cash App Pay' },
+        { type: 'paypal', name: 'PayPal' },
+        { type: 'applepay', name: 'Apple Pay' },
+        { type: 'giftcard', brand: 'genericgiftcard', name: 'Generic GiftCard' },
+        { type: 'giftcard', brand: 'givex', name: 'Givex' },
+        { type: 'googlepay', name: 'Google Pay' },
+        { type: 'scheme', name: 'Cards' },
+        { type: 'klarna_account', name: 'Pay over time with Klarna.' },
+        { type: 'affirm', name: 'Affirm' },
+      ],
+    },
+  };
+
+  const getRenderedOrder = () =>
+    Array.from(
+      document.querySelectorAll('#paymentMethodsList input[name="brandCode"]'),
+    ).map((input) => input.value);
+
+  const mockCreateComponent = (availability = {}) =>
+    jest.fn((type) => {
+      const node = { mount: jest.fn() };
+      if (SLOW_METHODS.includes(type)) {
+        node.isAvailable = () =>
+          new Promise((resolve) => {
+            setTimeout(() => resolve(availability[type] !== false), 10);
+          });
+      }
+      return node;
+    });
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <ul id="paymentMethodsList"></ul>
+    `;
+    store.componentsObj = {};
+    store.paymentMethodsConfiguration = {};
+    store.checkout = {};
+  });
+
+  it('should render the payment methods in the order of the response', async () => {
+    window.AdyenWeb = { createComponent: mockCreateComponent() };
+
+    await renderCheckout(paymentMethodsResponse);
+
+    expect(getRenderedOrder()).toEqual([
+      'cashapp',
+      'paypal',
+      'applepay',
+      'googlepay',
+      'scheme',
+      'klarna_account',
+      'affirm',
+    ]);
+  });
+
+  it('should not leave a hidden list item for an unavailable payment method', async () => {
+    window.AdyenWeb = {
+      createComponent: mockCreateComponent({ applepay: false }),
+    };
+
+    await renderCheckout(paymentMethodsResponse);
+
+    expect(getRenderedOrder()).toEqual([
+      'cashapp',
+      'paypal',
+      'googlepay',
+      'scheme',
+      'klarna_account',
+      'affirm',
+    ]);
+    expect(
+      Array.from(document.querySelectorAll('#paymentMethodsList li')).filter(
+        (li) => li.style.display === 'none',
+      ),
+    ).toHaveLength(0);
+    expect(store.componentsObj.applepay).toBeUndefined();
   });
 });

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/renderPaymentMethod.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/checkout/renderPaymentMethod.js
@@ -170,6 +170,7 @@ function mountComponentIfAvailable(paymentMethodID, container, li) {
 
   if (isAvailable !== false) {
     componentObj?.node?.mount(container);
+    li.removeAttribute('style');
     return true;
   }
   li.remove();
@@ -205,6 +206,7 @@ async function renderPaymentMethod(
   paymentMethodTitle = null,
 ) {
   let canRender;
+  let li;
   try {
     const paymentMethodsUI = document.querySelector('#paymentMethodsList');
     const paymentMethodID = getPaymentMethodID(isStored, paymentMethod);
@@ -228,14 +230,19 @@ async function renderPaymentMethod(
 
     const imagePath = getImagePath(options);
     const liContents = getListContents({ ...options, imagePath });
-    const li = createListItem(paymentMethodID, liContents);
+    li = createListItem(paymentMethodID, liContents);
 
-    await handlePayment(options);
     configureContainer(options);
-
     li.append(container);
 
+    // The list item takes its place in the DOM before the first await, so the
+    // list follows the order of the payment methods response instead of the
+    // order in which the components resolve. It stays hidden until the
+    // availability check is done, to avoid showing a method that gets removed.
+    li.style.display = 'none';
     paymentMethodsUI.append(li);
+
+    await handlePayment(options);
 
     mountComponentIfAvailable(paymentMethodID, container, li);
 
@@ -248,6 +255,7 @@ async function renderPaymentMethod(
 
     canRender = true;
   } catch (err) {
+    li?.remove();
     canRender = false;
   }
   return canRender;


### PR DESCRIPTION


<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
The list item was appended to #paymentMethodsList after awaiting handlePayment
- What existing problem does this pull request solve?
Render the payment methods as in CA

## Tested scenarios
Description of tested scenarios:
- Rendering payment methods

**Fixed issue**:  SFI-1719
