### PR TITLE
[SFI-1720] resolve internal requires through the cartridge path

### DIFF
--- a/jest/globals.js
+++ b/jest/globals.js
@@ -14,6 +14,10 @@ global.dw = {
   },
 };
 
+// SFCC pipeline exit codes, provided by the platform at runtime
+global.PIPELET_NEXT = 2;
+global.PIPELET_ERROR = 1;
+
 global.empty = (value) =>
   value === null ||
   value === undefined ||

--- a/jest/sfccPathSetup.js
+++ b/jest/sfccPathSetup.js
@@ -600,6 +600,13 @@ jest.mock(
 );
 
 jest.mock(
+  '*/cartridge/utils/customObjectHelper',
+  () =>
+    require('../src/cartridges/int_adyen_webhooks/cartridge/utils/customObjectHelper'),
+  { virtual: true },
+);
+
+jest.mock(
   '*/cartridge/eventHandlers/AUTHORISATION',
   () =>
     require('../src/cartridges/int_adyen_webhooks/cartridge/eventHandlers/AUTHORISATION'),

--- a/src/cartridges/int_adyen_webhooks/cartridge/__tests__/handleCustomObject.test.js
+++ b/src/cartridges/int_adyen_webhooks/cartridge/__tests__/handleCustomObject.test.js
@@ -1,0 +1,199 @@
+jest.mock('dw/order/OrderMgr', () => ({
+  getOrder: jest.fn(),
+}));
+
+// Event handlers are resolved through the cartridge path, so each one is mocked
+// under the path handleCustomObject builds at runtime
+jest.mock(
+  '*/cartridge/eventHandlers/CAPTURE',
+  () => ({
+    handle: jest.fn(),
+  }),
+  { virtual: true },
+);
+
+jest.mock(
+  '*/cartridge/eventHandlers/PENDING',
+  () => ({
+    handle: jest.fn(() => ({ pending: true })),
+  }),
+  { virtual: true },
+);
+
+const OrderMgr = require('dw/order/OrderMgr');
+const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
+const captureHandler = require('*/cartridge/eventHandlers/CAPTURE');
+const pendingHandler = require('*/cartridge/eventHandlers/PENDING');
+const { handle, execute } = require('../handleCustomObject');
+
+const TEN_MINUTES = 10 * 60 * 1000;
+
+function mockOrder(overrides = {}) {
+  return {
+    orderNo: '00001234',
+    creationDate: new Date(Date.now() - TEN_MINUTES),
+    custom: { Adyen_pspReference: '' },
+    addNote: jest.fn(),
+    getTotalGrossPrice: jest.fn(() => ({ value: 100 })),
+    ...overrides,
+  };
+}
+
+function mockCustomObj(custom = {}) {
+  return {
+    custom: {
+      orderId: '00001234-20240101',
+      eventCode: 'CAPTURE',
+      pspReference: 'mocked_pspReference',
+      version: '1',
+      ...custom,
+    },
+  };
+}
+
+describe('handleCustomObject', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    captureHandler.handle.mockImplementation(() => undefined);
+    pendingHandler.handle.mockImplementation(() => ({ pending: true }));
+  });
+
+  it('resolves the handler through the cartridge path and finalizes the order', () => {
+    const order = mockOrder();
+    const customObj = mockCustomObj();
+    OrderMgr.getOrder.mockReturnValue(order);
+
+    const result = handle(customObj);
+
+    expect(OrderMgr.getOrder).toHaveBeenCalledWith('00001234');
+    expect(captureHandler.handle).toHaveBeenCalledWith({
+      order,
+      customObj,
+      result,
+      totalAmount: 1000,
+    });
+    expect(order.custom.Adyen_pspReference).toBe('mocked_pspReference');
+    expect(order.addNote).toHaveBeenCalledWith(
+      'Adyen Payment Notification',
+      expect.stringContaining('eventCode : CAPTURE'),
+    );
+    expect(customObj.custom.processedStatus).toBe('SUCCESS');
+    expect(customObj.custom.updateStatus).toBe('SUCCESS');
+    expect(result.status).toBe(PIPELET_NEXT);
+    expect(result.Pending).toBe(false);
+  });
+
+  it('keeps an existing PSP reference on the order', () => {
+    const order = mockOrder({ custom: { Adyen_pspReference: 'existing_psp' } });
+    OrderMgr.getOrder.mockReturnValue(order);
+
+    handle(mockCustomObj());
+
+    expect(order.custom.Adyen_pspReference).toBe('existing_psp');
+  });
+
+  it('propagates the pending status returned by the PENDING handler', () => {
+    OrderMgr.getOrder.mockReturnValue(mockOrder());
+
+    const result = handle(mockCustomObj({ eventCode: 'PENDING' }));
+
+    expect(pendingHandler.handle).toHaveBeenCalled();
+    expect(result.Pending).toBe(true);
+    expect(result.status).toBe(PIPELET_NEXT);
+  });
+
+  it('logs an unhandled status and does not finalize when no handler module exists', () => {
+    const order = mockOrder();
+    const customObj = mockCustomObj({ eventCode: 'NOT_A_REAL_EVENT_CODE' });
+    OrderMgr.getOrder.mockReturnValue(order);
+
+    const result = handle(customObj);
+
+    expect(AdyenLogs.info_log).toHaveBeenCalledWith(
+      'No handler module found for event code: NOT_A_REAL_EVENT_CODE',
+    );
+    expect(AdyenLogs.info_log).toHaveBeenCalledWith(
+      'Order 00001234 received unhandled status NOT_A_REAL_EVENT_CODE',
+    );
+    expect(order.addNote).not.toHaveBeenCalled();
+    expect(customObj.custom.processedStatus).toBeUndefined();
+    expect(result.status).toBe(PIPELET_NEXT);
+    expect(result.Pending).toBe(false);
+  });
+
+  it('reports a throwing handler as an error instead of a missing module', () => {
+    const order = mockOrder();
+    const customObj = mockCustomObj();
+    const handlerError = new Error('mocked_handler_error');
+    captureHandler.handle.mockImplementation(() => {
+      throw handlerError;
+    });
+    OrderMgr.getOrder.mockReturnValue(order);
+
+    const result = handle(customObj);
+
+    expect(AdyenLogs.error_log).toHaveBeenCalledWith(
+      'Handler for event code CAPTURE failed for order 00001234',
+      handlerError,
+    );
+    expect(AdyenLogs.info_log).not.toHaveBeenCalledWith(
+      'No handler module found for event code: CAPTURE',
+    );
+    expect(order.addNote).not.toHaveBeenCalled();
+    expect(customObj.custom.updateStatus).toBeUndefined();
+    expect(result.status).toBe(PIPELET_NEXT);
+  });
+
+  it('skips a missing order for a $0.00 recurring payment authorisation', () => {
+    const customObj = mockCustomObj({
+      orderId: 'recurringPayment-00001234-20240101',
+    });
+    OrderMgr.getOrder.mockReturnValue(null);
+
+    const result = handle(customObj);
+
+    expect(result.SkipOrder).toBe(true);
+    expect(customObj.custom.processedStatus).toBe('SUCCESS');
+    expect(result.status).toBe(PIPELET_ERROR);
+    expect(AdyenLogs.error_log).not.toHaveBeenCalled();
+  });
+
+  it('logs an error for a missing order that is not a recurring payment', () => {
+    const customObj = mockCustomObj();
+    OrderMgr.getOrder.mockReturnValue(null);
+
+    const result = handle(customObj);
+
+    expect(AdyenLogs.error_log).toHaveBeenCalledWith(
+      'Notification for not existing order 00001234-20240101 received.',
+    );
+    expect(result.SkipOrder).toBe(false);
+    expect(customObj.custom.processedStatus).toBeUndefined();
+  });
+
+  it('skips an order that is still inside the notification delay window', () => {
+    const order = mockOrder({ creationDate: new Date() });
+    OrderMgr.getOrder.mockReturnValue(order);
+
+    const result = handle(mockCustomObj());
+
+    expect(result.SkipOrder).toBe(true);
+    expect(result.status).toBe(PIPELET_NEXT);
+    expect(captureHandler.handle).not.toHaveBeenCalled();
+  });
+
+  it('maps the handler result onto the job arguments and returns the status', () => {
+    const order = mockOrder();
+    OrderMgr.getOrder.mockReturnValue(order);
+    const args = { CustomObj: mockCustomObj({ eventCode: 'PENDING' }) };
+
+    const status = execute(args);
+
+    expect(status).toBe(PIPELET_NEXT);
+    expect(args.EventCode).toBe('PENDING');
+    expect(args.SubmitOrder).toBe(false);
+    expect(args.SkipOrder).toBe(false);
+    expect(args.Pending).toBe(true);
+    expect(args.Order).toBe(order);
+  });
+});

--- a/src/cartridges/int_adyen_webhooks/cartridge/__tests__/handleCustomObject.test.js
+++ b/src/cartridges/int_adyen_webhooks/cartridge/__tests__/handleCustomObject.test.js
@@ -20,6 +20,16 @@ jest.mock(
   { virtual: true },
 );
 
+// Stands in for a handler that fails while being loaded, for example a merchant
+// override with a syntax error
+jest.mock(
+  '*/cartridge/eventHandlers/BROKEN_ON_LOAD',
+  () => {
+    throw new Error('mocked_module_load_error');
+  },
+  { virtual: true },
+);
+
 const OrderMgr = require('dw/order/OrderMgr');
 const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
 const captureHandler = require('*/cartridge/eventHandlers/CAPTURE');
@@ -109,8 +119,13 @@ describe('handleCustomObject', () => {
 
     const result = handle(customObj);
 
-    expect(AdyenLogs.info_log).toHaveBeenCalledWith(
-      'No handler module found for event code: NOT_A_REAL_EVENT_CODE',
+    expect(AdyenLogs.error_log).toHaveBeenCalledWith(
+      'Could not load a handler module for event code NOT_A_REAL_EVENT_CODE',
+      expect.objectContaining({
+        message: expect.stringContaining(
+          '*/cartridge/eventHandlers/NOT_A_REAL_EVENT_CODE',
+        ),
+      }),
     );
     expect(AdyenLogs.info_log).toHaveBeenCalledWith(
       'Order 00001234 received unhandled status NOT_A_REAL_EVENT_CODE',
@@ -121,7 +136,23 @@ describe('handleCustomObject', () => {
     expect(result.Pending).toBe(false);
   });
 
-  it('reports a throwing handler as an error instead of a missing module', () => {
+  it('reports the underlying error when a handler module fails to load', () => {
+    const order = mockOrder();
+    const customObj = mockCustomObj({ eventCode: 'BROKEN_ON_LOAD' });
+    OrderMgr.getOrder.mockReturnValue(order);
+
+    const result = handle(customObj);
+
+    expect(AdyenLogs.error_log).toHaveBeenCalledWith(
+      'Could not load a handler module for event code BROKEN_ON_LOAD',
+      expect.objectContaining({ message: 'mocked_module_load_error' }),
+    );
+    expect(order.addNote).not.toHaveBeenCalled();
+    expect(customObj.custom.processedStatus).toBeUndefined();
+    expect(result.status).toBe(PIPELET_NEXT);
+  });
+
+  it('reports a throwing handler as a handler failure, not a load failure', () => {
     const order = mockOrder();
     const customObj = mockCustomObj();
     const handlerError = new Error('mocked_handler_error');
@@ -132,12 +163,10 @@ describe('handleCustomObject', () => {
 
     const result = handle(customObj);
 
+    expect(AdyenLogs.error_log).toHaveBeenCalledTimes(1);
     expect(AdyenLogs.error_log).toHaveBeenCalledWith(
       'Handler for event code CAPTURE failed for order 00001234',
       handlerError,
-    );
-    expect(AdyenLogs.info_log).not.toHaveBeenCalledWith(
-      'No handler module found for event code: CAPTURE',
     );
     expect(order.addNote).not.toHaveBeenCalled();
     expect(customObj.custom.updateStatus).toBeUndefined();

--- a/src/cartridges/int_adyen_webhooks/cartridge/handleCustomObject.js
+++ b/src/cartridges/int_adyen_webhooks/cartridge/handleCustomObject.js
@@ -2,7 +2,7 @@
 const OrderMgr = require('dw/order/OrderMgr');
 const adyenHelper = require('*/cartridge/adyen/utils/adyenHelper');
 const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
-const { createLogMessage } = require('./utils/customObjectHelper');
+const { createLogMessage } = require('*/cartridge/utils/customObjectHelper');
 
 /**
  * Extracts and processes the order ID from the custom object
@@ -96,6 +96,23 @@ function extractPendingStatus(handlerResult, eventCode) {
 }
 
 /**
+ * Resolves the event handler for an event code through the cartridge path, so
+ * that merchants can override a handler or add one for a new event code
+ * @param {string} eventCode - The event code to resolve a handler for
+ * @returns {Object|null} The handler module, or null when none is available
+ */
+function resolveEventHandler(eventCode) {
+  try {
+    // eslint-disable-next-line
+    return require(`*/cartridge/eventHandlers/${eventCode}`);
+  } catch (error) {
+    // An unsupported event code is indistinguishable from a missing module here
+    AdyenLogs.info_log(`No handler module found for event code: ${eventCode}`);
+    return null;
+  }
+}
+
+/**
  * Processes the event using the appropriate event handler
  * @param {Object} order - The order object
  * @param {Object} customObj - The custom object
@@ -104,13 +121,11 @@ function extractPendingStatus(handlerResult, eventCode) {
  * @returns {Object} An object containing isHandled status and pending status
  */
 function processEventHandler(order, customObj, result, totalAmount) {
-  // Handle all events using dedicated event handlers
-  try {
-    // eslint-disable-next-line
-    const handlerModule = require(
-      `./eventHandlers/${customObj.custom.eventCode}`,
-    );
-    if (handlerModule && typeof handlerModule.handle === 'function') {
+  const { eventCode } = customObj.custom;
+  const handlerModule = resolveEventHandler(eventCode);
+
+  if (handlerModule && typeof handlerModule.handle === 'function') {
+    try {
       const handlerResult = handlerModule.handle({
         order,
         customObj,
@@ -119,22 +134,19 @@ function processEventHandler(order, customObj, result, totalAmount) {
       });
       return {
         isHandled: true,
-        pending: extractPendingStatus(
-          handlerResult,
-          customObj.custom.eventCode,
-        ),
+        pending: extractPendingStatus(handlerResult, eventCode),
       };
+    } catch (error) {
+      AdyenLogs.error_log(
+        `Handler for event code ${eventCode} failed for order ${order.orderNo}`,
+        error,
+      );
     }
-  } catch (error) {
-    // Handler module doesn't exist for this event type
-    AdyenLogs.info_log(
-      `No handler module found for event code: ${customObj.custom.eventCode}`,
-    );
   }
 
   // Handle unhandled event types
   AdyenLogs.info_log(
-    `Order ${order.orderNo} received unhandled status ${customObj.custom.eventCode}`,
+    `Order ${order.orderNo} received unhandled status ${eventCode}`,
   );
   return { isHandled: false, pending: false };
 }

--- a/src/cartridges/int_adyen_webhooks/cartridge/handleCustomObject.js
+++ b/src/cartridges/int_adyen_webhooks/cartridge/handleCustomObject.js
@@ -106,8 +106,14 @@ function resolveEventHandler(eventCode) {
     // eslint-disable-next-line
     return require(`*/cartridge/eventHandlers/${eventCode}`);
   } catch (error) {
-    // An unsupported event code is indistinguishable from a missing module here
-    AdyenLogs.info_log(`No handler module found for event code: ${eventCode}`);
+    // A module that is absent and a module that fails to load both land here,
+    // and a load failure reports the offending file, so the two cannot be told
+    // apart by their message. The error is always logged rather than swallowed,
+    // so that a broken merchant override stays debuggable
+    AdyenLogs.error_log(
+      `Could not load a handler module for event code ${eventCode}`,
+      error,
+    );
     return null;
   }
 }

--- a/src/cartridges/int_adyen_webhooks/cartridge/handleNotify.js
+++ b/src/cartridges/int_adyen_webhooks/cartridge/handleNotify.js
@@ -32,7 +32,7 @@ const {
   createOrUpdateCustomObject,
   setCustomObjectStatus,
   createLogMessage,
-} = require('./utils/customObjectHelper');
+} = require('*/cartridge/utils/customObjectHelper');
 
 function notify(notificationData) {
   // Check the input parameters

--- a/src/cartridges/int_adyen_webhooks/cartridge/utils/customObjectHelper.js
+++ b/src/cartridges/int_adyen_webhooks/cartridge/utils/customObjectHelper.js
@@ -1,7 +1,7 @@
 const Transaction = require('dw/system/Transaction');
 const CustomObjectMgr = require('dw/object/CustomObjectMgr');
 const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
-const constants = require('./constants');
+const constants = require('*/cartridge/utils/constants');
 
 /**
  * Create or update a custom object with notification data in a transaction.

--- a/src/cartridges/int_adyen_webhooks/cartridge/utils/paymentUtils.js
+++ b/src/cartridges/int_adyen_webhooks/cartridge/utils/paymentUtils.js
@@ -1,7 +1,7 @@
 const PaymentMgr = require('dw/order/PaymentMgr');
 const Order = require('dw/order/Order');
 const COHelpers = require('*/cartridge/scripts/checkout/checkoutHelpers');
-const constants = require('./constants');
+const constants = require('*/cartridge/utils/constants');
 
 /**
  * Checks Adyen payment instruments and updates Adyen_log if found.


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
`int_adyen_webhooks` resolved its event handlers and helpers with relative requires
- What existing problem does this pull request solve?
Merchants could not override them from their own cartridge

## Tested scenarios
Description of tested scenarios:
- Payments + webhooks

**Fixed issue**: SFI-1720
https://github.com/Adyen/adyen-salesforce-commerce-cloud/issues/1522
