### PR TITLE
[SFI-1721]: calculate minor units server-side for express product price

### DIFF
--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/express/product/__tests__/expressPayments.test.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/express/product/__tests__/expressPayments.test.js
@@ -1,0 +1,125 @@
+/**
+ * @jest-environment ./jest/customJsdomEnvironment.js
+ */
+
+const mockCalculateProductPrice = jest.fn();
+const mockApplePay = jest.fn();
+const mockPaypal = jest.fn();
+
+jest.mock('../../../commons/index', () => ({
+  getExpressPaymentMethods: jest.fn(),
+  calculateProductPrice: mockCalculateProductPrice,
+}));
+
+jest.mock('../../../commons/httpClient', () => ({
+  httpClient: jest.fn(),
+}));
+
+jest.mock('../../paymentMethods', () => ({
+  ApplePay: mockApplePay,
+  GooglePay: jest.fn(),
+  Paypal: mockPaypal,
+}));
+
+jest.mock('../../../../../../../config/constants', () => ({
+  APPLE_PAY: 'applepay',
+  GOOGLE_PAY: 'googlepay',
+  PAY_WITH_GOOGLE: 'paywithgoogle',
+  PAYPAL: 'paypal',
+}));
+
+const expressPayments = require('../expressPayments');
+
+describe('PDP Express Payments', () => {
+  const paymentMethodsResponse = {
+    AdyenPaymentMethods: {
+      paymentMethods: [
+        { type: 'applepay', configuration: {} },
+        { type: 'paypal', configuration: {} },
+      ],
+    },
+    applicationInfo: {},
+    adyenTranslations: {},
+    amount: { currency: 'BHD' },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    $('body').off();
+    document.body.innerHTML = `
+      <input id="selected-express-product" data-pid="test-product-id" />
+      <input name="Quantity" value="1" />
+    `;
+
+    mockApplePay.mockImplementation(() => ({
+      getComponent: jest.fn().mockResolvedValue({ mount: jest.fn() }),
+    }));
+    mockPaypal.mockImplementation(() => ({
+      getComponent: jest.fn().mockResolvedValue({ mount: jest.fn() }),
+    }));
+  });
+
+  afterEach(() => {
+    $('body').off();
+  });
+
+  async function renderPaymentButtons() {
+    expressPayments.renderApplePayButton();
+    expressPayments.renderPaypalButton();
+
+    $('body').trigger('product:renderapplepayButton', {
+      paymentMethodsResponse,
+      button: document.createElement('div'),
+    });
+    $('body').trigger('product:renderpaypalButton', {
+      paymentMethodsResponse,
+      button: document.createElement('div'),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  it('uses the server-provided minor-unit value for Apple Pay and PayPal', async () => {
+    mockCalculateProductPrice.mockResolvedValue({
+      success: true,
+      totalAmount: {
+        value: 10.99,
+        minorUnitValue: 10990,
+        currencyCode: 'BHD',
+      },
+    });
+
+    await renderPaymentButtons();
+
+    expect(mockApplePay).toHaveBeenCalledWith({}, {}, {}, true, {
+      value: 10990,
+      currency: 'BHD',
+    });
+    expect(mockPaypal).toHaveBeenCalledWith({}, {}, {}, true, {
+      value: 10990,
+      currency: 'BHD',
+    });
+  });
+
+  it('keeps the initial amount at zero when the minor-unit value is invalid', async () => {
+    mockCalculateProductPrice.mockResolvedValue({
+      success: true,
+      totalAmount: {
+        value: 10.99,
+        minorUnitValue: 10990.5,
+        currencyCode: 'BHD',
+      },
+    });
+
+    await renderPaymentButtons();
+
+    expect(mockApplePay).toHaveBeenCalledWith({}, {}, {}, true, {
+      value: 0,
+      currency: 'BHD',
+    });
+    expect(mockPaypal).toHaveBeenCalledWith({}, {}, {}, true, {
+      value: 0,
+      currency: 'BHD',
+    });
+  });
+});

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/express/product/__tests__/expressPayments.test.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/express/product/__tests__/expressPayments.test.js
@@ -122,4 +122,19 @@ describe('PDP Express Payments', () => {
       currency: 'BHD',
     });
   });
+
+  it('keeps the initial amount at zero when the price response is null', async () => {
+    mockCalculateProductPrice.mockResolvedValue(null);
+
+    await renderPaymentButtons();
+
+    expect(mockApplePay).toHaveBeenCalledWith({}, {}, {}, true, {
+      value: 0,
+      currency: 'BHD',
+    });
+    expect(mockPaypal).toHaveBeenCalledWith({}, {}, {}, true, {
+      value: 0,
+      currency: 'BHD',
+    });
+  });
 });

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/express/product/expressPayments.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/express/product/expressPayments.js
@@ -84,10 +84,15 @@ function getPaymentMethodConfig(adyenPaymentMethods, paymentMethodType) {
 async function getProductPrice(productId, quantity = 1) {
   const response = await calculateProductPrice(productId, quantity);
 
-  if (response.success) {
+  const { totalAmount } = response;
+  if (
+    response.success &&
+    Number.isSafeInteger(totalAmount?.minorUnitValue) &&
+    totalAmount.minorUnitValue >= 0
+  ) {
     return {
-      value: Math.round(response.totalAmount.value * 100), // Convert to minor units (cents)
-      currency: response.totalAmount.currencyCode,
+      value: totalAmount.minorUnitValue,
+      currency: totalAmount.currencyCode,
     };
   }
   return null;

--- a/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/express/product/expressPayments.js
+++ b/src/cartridges/app_adyen_SFRA/cartridge/client/default/js/adyen/express/product/expressPayments.js
@@ -84,9 +84,9 @@ function getPaymentMethodConfig(adyenPaymentMethods, paymentMethodType) {
 async function getProductPrice(productId, quantity = 1) {
   const response = await calculateProductPrice(productId, quantity);
 
-  const { totalAmount } = response;
+  const totalAmount = response?.totalAmount;
   if (
-    response.success &&
+    response?.success &&
     Number.isSafeInteger(totalAmount?.minorUnitValue) &&
     totalAmount.minorUnitValue >= 0
   ) {

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/__tests__/calculatePrice.test.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/__tests__/calculatePrice.test.js
@@ -2,6 +2,7 @@
 const ProductMgr = require('dw/catalog/ProductMgr');
 const priceHelper = require('*/cartridge/scripts/helpers/pricing');
 const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
+const AdyenHelper = require('*/cartridge/adyen/utils/adyenHelper');
 
 const calculatePrice = require('../calculatePrice');
 
@@ -45,11 +46,13 @@ describe('calculatePrice', () => {
         { getValue: () => 5 },
         { getValue: () => 10 },
       ],
-      getQuantities: jest.fn().mockReturnValue([
-        { getValue: () => 1 },
-        { getValue: () => 5 },
-        { getValue: () => 10 },
-      ]),
+      getQuantities: jest
+        .fn()
+        .mockReturnValue([
+          { getValue: () => 1 },
+          { getValue: () => 5 },
+          { getValue: () => 10 },
+        ]),
       getPrice: jest.fn().mockReturnValue(mockPrice),
     };
 
@@ -69,6 +72,9 @@ describe('calculatePrice', () => {
     };
     ProductMgr.getProduct = jest.fn().mockReturnValue(mockProduct);
     priceHelper.getPromotionPrice = jest.fn().mockReturnValue(null);
+    AdyenHelper.getCurrencyValueForApi.mockImplementation((amount) => ({
+      value: Math.round(amount.value * 100),
+    }));
   });
 
   describe('validateProduct', () => {
@@ -83,7 +89,7 @@ describe('calculatePrice', () => {
     });
 
     it('should return error when product is not found', () => {
-      ProductMgr.getProduct.mockReturnValue(null);   
+      ProductMgr.getProduct.mockReturnValue(null);
       calculatePrice(req, res, next);
       expect(res.json).toHaveBeenCalledWith({
         success: false,
@@ -101,6 +107,7 @@ describe('calculatePrice', () => {
         success: true,
         totalAmount: {
           value: 21.98,
+          minorUnitValue: 2198,
           currencyCode: 'USD',
         },
       });
@@ -120,6 +127,7 @@ describe('calculatePrice', () => {
         success: true,
         totalAmount: {
           value: 21.98,
+          minorUnitValue: 2198,
           currencyCode: 'USD',
         },
       });
@@ -148,6 +156,7 @@ describe('calculatePrice', () => {
         success: true,
         totalAmount: {
           value: 21.98,
+          minorUnitValue: 2198,
           currencyCode: 'USD',
         },
       });
@@ -172,11 +181,14 @@ describe('calculatePrice', () => {
       ]);
       mockPriceTable.getPrice.mockReturnValue(tierPrice);
       calculatePrice(req, res, next);
-      expect(mockPriceTable.getPrice).toHaveBeenCalledWith(expectedQuantityTier);
+      expect(mockPriceTable.getPrice).toHaveBeenCalledWith(
+        expectedQuantityTier,
+      );
       expect(res.json).toHaveBeenCalledWith({
         success: true,
         totalAmount: {
           value: 62.93,
+          minorUnitValue: 6293,
           currencyCode: 'USD',
         },
       });
@@ -191,10 +203,41 @@ describe('calculatePrice', () => {
         success: true,
         totalAmount: {
           value: 21.98,
+          minorUnitValue: 2198,
           currencyCode: 'USD',
         },
       });
     });
+  });
+
+  describe('minor-unit price response', () => {
+    it.each([
+      ['EUR', 10.99, 1099],
+      ['JPY', 1000, 1000],
+      ['BHD', 10.999, 10999],
+    ])(
+      'returns the correct minor-unit value for %s',
+      (currencyCode, value, minorUnitValue) => {
+        mockPrice.multiply.mockReturnValue({
+          value,
+          currencyCode,
+        });
+        AdyenHelper.getCurrencyValueForApi.mockReturnValue({
+          value: minorUnitValue,
+        });
+
+        calculatePrice(req, res, next);
+
+        expect(res.json).toHaveBeenCalledWith({
+          success: true,
+          totalAmount: {
+            value,
+            minorUnitValue,
+            currencyCode,
+          },
+        });
+      },
+    );
   });
 
   describe('getFinalUnitPrice', () => {
@@ -214,6 +257,7 @@ describe('calculatePrice', () => {
         success: true,
         totalAmount: {
           value: 15.98,
+          minorUnitValue: 1598,
           currencyCode: 'USD',
         },
       });
@@ -231,6 +275,7 @@ describe('calculatePrice', () => {
         success: true,
         totalAmount: {
           value: 21.98,
+          minorUnitValue: 2198,
           currencyCode: 'USD',
         },
       });
@@ -297,6 +342,7 @@ describe('calculatePrice', () => {
         success: true,
         totalAmount: {
           value: 21.98,
+          minorUnitValue: 2198,
           currencyCode: 'USD',
         },
       });

--- a/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/calculatePrice.js
+++ b/src/cartridges/int_adyen_SFRA/cartridge/adyen/scripts/expressPayments/calculatePrice.js
@@ -2,6 +2,7 @@ const ProductMgr = require('dw/catalog/ProductMgr');
 const Resource = require('dw/web/Resource');
 const priceHelper = require('*/cartridge/scripts/helpers/pricing');
 const AdyenLogs = require('*/cartridge/adyen/logs/adyenCustomLogs');
+const AdyenHelper = require('*/cartridge/adyen/utils/adyenHelper');
 const setErrorType = require('*/cartridge/adyen/logs/setErrorType');
 const { AdyenError } = require('*/cartridge/adyen/logs/adyenError');
 
@@ -113,11 +114,13 @@ function getFinalUnitPrice(product, basePrice) {
 function sendPriceResponse(res, next, product, price, qty) {
   const unitPrice = getFinalUnitPrice(product, price);
   const totalAmount = unitPrice.multiply(qty);
+  const minorUnitValue = AdyenHelper.getCurrencyValueForApi(totalAmount).value;
 
   res.json({
     success: true,
     totalAmount: {
       value: totalAmount.value,
+      minorUnitValue,
       currencyCode: totalAmount.currencyCode,
     },
   });


### PR DESCRIPTION
## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Fix calculate price middleware for JPY
- What existing problem does this pull request solve?
Properly handle apple pay payments

## Tested scenarios
Description of tested scenarios:
- Apple Pay

**Fixed issue**:  SFI-1721
